### PR TITLE
Replace IP address check for VM provision

### DIFF
--- a/experiment/modules/nsg_for_hana/nsg.tf
+++ b/experiment/modules/nsg_for_hana/nsg.tf
@@ -1,5 +1,5 @@
 data "http" "local_ip" {
-  url = "http://v4.ifconfig.co"
+  url = "http://api.ipify.org"
 }
 
 # Create Network Security Group and rule


### PR DESCRIPTION
ifconfig.co (IP address check service) discontinued IPv4 lookups via subdomain as of 7/25/18.
Therefore, switched to new provider (ipify.org) which allows direct IPv4 lookups.