### PR TITLE
Separate disk creation and attachment from VM creation

### DIFF
--- a/experiment/main.tf
+++ b/experiment/main.tf
@@ -13,7 +13,7 @@ resource "azurerm_resource_group" "hana-resource-group" {
 
 # TODO(pabowers): switch to use the Terraform registry version when release for nsg support becomes available
 module "vnet" {
-  source  = "github.com/Azure/terraform-azurerm-vnet"
+  source = "github.com/Azure/terraform-azurerm-vnet"
 
   address_space       = "10.0.0.0/21"
   location            = "${var.az_region}"
@@ -59,4 +59,8 @@ module "single_node_hana" {
   pw_os_sidadm        = "${var.pw_os_sidadm}"
   pw_db_system        = "${var.pw_db_system}"
   hana_subnet_id      = "${module.vnet.vnet_subnets[0]}"
+}
+
+output "ip" {
+  value = "${module.single_node_hana.ip}"
 }

--- a/experiment/modules/single_node_hana/single-node-hana.tf
+++ b/experiment/modules/single_node_hana/single-node-hana.tf
@@ -58,21 +58,6 @@ resource "azurerm_storage_account" "mystorageaccount" {
   }
 }
 
-/*
-module "attached_disk" "disk" {
-  source = "../disk_create"
-  #count                = "${length(var.storage_disk_sizes_gb)}"
-  disk_name                 = "db${var.db_num}-disk${0}"
-  az_region            = "${var.az_region}"
-  storage_account_type = "Premium_LRS"
-  resource_group_name  = "${var.az_resource_group}"
-  create_option        = "Empty"
-  disk_size_gb         = "${var.storage_disk_sizes_gb[0]}"
-  virtual_machine_id = "${azurerm_virtual_machine.db.id}"
-  lun                = "${0}"
-  caching            = "ReadWrite"
-}
-*/
 resource "azurerm_managed_disk" "disk" {
   count                = "${length(var.storage_disk_sizes_gb)}"
   name                 = "db${var.db_num}-disk${count.index}"

--- a/experiment/modules/single_node_hana/single-node-hana.tf
+++ b/experiment/modules/single_node_hana/single-node-hana.tf
@@ -58,13 +58,47 @@ resource "azurerm_storage_account" "mystorageaccount" {
   }
 }
 
+/*
+module "attached_disk" "disk" {
+  source = "../disk_create"
+  #count                = "${length(var.storage_disk_sizes_gb)}"
+  disk_name                 = "db${var.db_num}-disk${0}"
+  az_region            = "${var.az_region}"
+  storage_account_type = "Premium_LRS"
+  resource_group_name  = "${var.az_resource_group}"
+  create_option        = "Empty"
+  disk_size_gb         = "${var.storage_disk_sizes_gb[0]}"
+  virtual_machine_id = "${azurerm_virtual_machine.db.id}"
+  lun                = "${0}"
+  caching            = "ReadWrite"
+}
+*/
+resource "azurerm_managed_disk" "disk" {
+  count                = "${length(var.storage_disk_sizes_gb)}"
+  name                 = "db${var.db_num}-disk${count.index}"
+  location             = "${var.az_region}"
+  storage_account_type = "Premium_LRS"
+  resource_group_name  = "${var.az_resource_group}"
+  disk_size_gb         = "${var.storage_disk_sizes_gb[count.index]}"
+  create_option        = "Empty"
+}
+
+resource "azurerm_virtual_machine_data_disk_attachment" "disk" {
+  count              = "${length(var.storage_disk_sizes_gb)}"
+  virtual_machine_id = "${azurerm_virtual_machine.db.id}"
+  managed_disk_id    = "${element(azurerm_managed_disk.disk.*.id, count.index)}"
+  lun                = "${count.index}"
+  caching            = "ReadWrite"
+}
+
 # Create virtual machine
 resource "azurerm_virtual_machine" "db" {
-  name                  = "${var.sap_sid}-db${var.db_num}"
-  location              = "${var.az_region}"
-  resource_group_name   = "${var.az_resource_group}"
-  network_interface_ids = ["${azurerm_network_interface.hdb-nic.id}"]
-  vm_size               = "${var.vm_size}"
+  name                          = "${var.sap_sid}-db${var.db_num}"
+  location                      = "${var.az_region}"
+  resource_group_name           = "${var.az_resource_group}"
+  network_interface_ids         = ["${azurerm_network_interface.hdb-nic.id}"]
+  vm_size                       = "${var.vm_size}"
+  delete_os_disk_on_termination = "true"
 
   storage_os_disk {
     name              = "myOsDisk"
@@ -78,30 +112,6 @@ resource "azurerm_virtual_machine" "db" {
     offer     = "SLES-SAP"
     sku       = "12-SP3"
     version   = "latest"
-  }
-
-  storage_data_disk {
-    name              = "hana-data-disk"
-    managed_disk_type = "Premium_LRS"
-    create_option     = "Empty"
-    disk_size_gb      = "${local.disksize_hana_data_gb}"
-    lun               = 0
-  }
-
-  storage_data_disk {
-    name              = "hana-log-disk"
-    managed_disk_type = "Premium_LRS"
-    create_option     = "Empty"
-    disk_size_gb      = "${local.disksize_hana_log_gb}"
-    lun               = 1
-  }
-
-  storage_data_disk {
-    name              = "hana-shared-disk"
-    managed_disk_type = "Premium_LRS"
-    create_option     = "Empty"
-    disk_size_gb      = "${local.disksize_hana_shared_gb}"
-    lun               = 2
   }
 
   os_profile {
@@ -123,6 +133,14 @@ resource "azurerm_virtual_machine" "db" {
 
     storage_uri = "${azurerm_storage_account.mystorageaccount.primary_blob_endpoint}"
   }
+
+  tags {
+    environment = "Terraform SAP HANA single node deployment"
+  }
+}
+
+resource null_resource "mount-disks-and-configure-hana" {
+  depends_on = ["azurerm_virtual_machine.db"]
 
   connection {
     user        = "${var.vm_user}"

--- a/experiment/modules/single_node_hana/variables.tf
+++ b/experiment/modules/single_node_hana/variables.tf
@@ -71,6 +71,11 @@ variable "hana_subnet_id" {
   description = "The hana specific subnet that this node needs to be on"
 }
 
+variable "storage_disk_sizes_gb" {
+  description = "List disk sizes in GB for all disks this VM will need"
+  default     = [512, 512, 512]
+}
+
 locals {
   vm_fqdn                 = "${azurerm_public_ip.hdb-pip.fqdn}"
   vm_name                 = "${var.sap_sid}-db${var.db_num}"

--- a/experiment/modules/single_node_hana/variables.tf
+++ b/experiment/modules/single_node_hana/variables.tf
@@ -79,7 +79,4 @@ variable "storage_disk_sizes_gb" {
 locals {
   vm_fqdn                 = "${azurerm_public_ip.hdb-pip.fqdn}"
   vm_name                 = "${var.sap_sid}-db${var.db_num}"
-  disksize_hana_data_gb   = 512
-  disksize_hana_log_gb    = 512
-  disksize_hana_shared_gb = 512
 }


### PR DESCRIPTION
The disk creation and attachment has been moved out of the vm creation in Terraform to allow the user to specify setting the sizes of several disks at the same time for one VM. This allows the user to use one disk for data, log, and shared, or as many as they want for each.