### PR TITLE
Fixing master's build

### DIFF
--- a/experiment/modules/single_node_hana/single-node-hana.tf
+++ b/experiment/modules/single_node_hana/single-node-hana.tf
@@ -125,28 +125,18 @@ resource "azurerm_virtual_machine" "db" {
 }
 
 resource null_resource "mount-disks-and-configure-hana" {
-  depends_on = ["azurerm_virtual_machine.db"]
+  depends_on = ["azurerm_virtual_machine.db", "azurerm_virtual_machine_data_disk_attachment.disk"]
 
   connection {
     user        = "${var.vm_user}"
     private_key = "${file("${var.sshkey_path_private}")}"
-    timeout     = "20m"
+    timeout     = "5m"
     host        = "${local.vm_fqdn}"
   }
 
   provisioner "file" {
     source      = "${path.module}/provision_hardware.sh"
     destination = "/tmp/provision_hardware.sh"
-  }
-
-  provisioner "file" {
-    source      = "${path.module}/sid_config_template.txt"
-    destination = "/tmp/sid_config_template.txt"
-  }
-
-  provisioner "file" {
-    source      = "${path.module}/sid_passwords_template.txt"
-    destination = "/tmp/sid_passwords_template.txt"
   }
 
   provisioner "file" {
@@ -163,9 +153,5 @@ resource null_resource "mount-disks-and-configure-hana" {
 
   provisioner "local-exec" {
     command = "ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -u ${var.vm_user} --private-key '${var.sshkey_path_private}' -i '${local.vm_fqdn},' ansible/playbook.yml"
-  }
-
-  tags {
-    environment = "Terraform SAP HANA single node deployment"
   }
 }

--- a/experiment/modules/single_node_hana/variables.tf
+++ b/experiment/modules/single_node_hana/variables.tf
@@ -77,6 +77,6 @@ variable "storage_disk_sizes_gb" {
 }
 
 locals {
-  vm_fqdn                 = "${azurerm_public_ip.hdb-pip.fqdn}"
-  vm_name                 = "${var.sap_sid}-db${var.db_num}"
+  vm_fqdn = "${azurerm_public_ip.hdb-pip.fqdn}"
+  vm_name = "${var.sap_sid}-db${var.db_num}"
 }


### PR DESCRIPTION
@Azure/azure-sap-hana Files were removed in a previous commit, but were still referenced in the single-node-hana.tf, which caused errors in the build.  Terraform format had not been run on master, so I'm also cleaning up the formatting there.  I was having lots of errors waiting for ssh to connect with the cleanup tool and I would rather the ssh connection fails in 5 minutes than waiting 20 minutes to tell me about the nsg error.  Another realization was that null type resources cannot have tags, so that was also removed.