### PR TITLE
Pass parameters for HANA db install directly from Terraform

### DIFF
--- a/experiment/modules/single_node_hana/single-node-hana.tf
+++ b/experiment/modules/single_node_hana/single-node-hana.tf
@@ -152,6 +152,6 @@ resource null_resource "mount-disks-and-configure-hana" {
   }
 
   provisioner "local-exec" {
-    command = "ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -u ${var.vm_user} --private-key '${var.sshkey_path_private}' -i '${local.vm_fqdn},' ansible/playbook.yml"
+    command = "ANSIBLE_HOST_KEY_CHECKING=\"False\" ansible-playbook -u ${var.vm_user} --private-key '${var.sshkey_path_private}' --extra-vars='{\"url_sapcar\": \"${var.url_sap_sapcar}\", \"url_hdbserver\": \"${var.url_sap_hdbserver}\", \"sap_sid\": \"${var.sap_sid}\", \"sap_instance_num\": \"${var.sap_instancenum}\", \"sap_hostname\": \"${local.vm_name}\", \"pwd_os_sapadm\": \"${var.pw_os_sapadm}\", \"pwd_os_sidadm\": \"${var.pw_os_sidadm}\", \"pwd_db_system\": \"${var.pw_db_system}\" }' -i '${local.vm_fqdn},' ansible/playbook.yml"
   }
 }


### PR DESCRIPTION
Before this, each time you wanted to install HANA on a landscape, you would need to put the configs in `ansible/roles/saphana-install/defaults/main.yml`.  This change means that the user will only need to pass in variables in their local `terraform.tfvars` file instead of in several places. @Azure/azure-sap-hana 