### PR TITLE
use PV1 as a prefix for disk name

### DIFF
--- a/experiment/modules/single_node_hana/single-node-hana.tf
+++ b/experiment/modules/single_node_hana/single-node-hana.tf
@@ -86,7 +86,7 @@ resource "azurerm_virtual_machine" "db" {
   delete_os_disk_on_termination = "true"
 
   storage_os_disk {
-    name              = "myOsDisk"
+    name              = "${var.sap_sid}-OsDisk"
     caching           = "ReadWrite"
     create_option     = "FromImage"
     managed_disk_type = "Premium_LRS"


### PR DESCRIPTION
Small pull request to keep the resource names consistent. I noticed this name as I was manually deleting the resources on portal. Terraform destroy was not working, so I had to manually delete the resources (painful!). 