### PR TITLE
Fixed application of the instance number to hdb install and corrected mountpoints

### DIFF
--- a/experiment/ansible/playbook.yml
+++ b/experiment/ansible/playbook.yml
@@ -4,23 +4,23 @@
 
   vars:
     disks:
-      /dev/disk/azure/scsi1/lun0 : vg_hana_data_PV1
-      /dev/disk/azure/scsi1/lun1 : vg_hana_log_PV1
-      /dev/disk/azure/scsi1/lun2 : vg_hana_shared_PV1
+      /dev/disk/azure/scsi1/lun0 : vg_hana_data_{{ sap_sid }}
+      /dev/disk/azure/scsi1/lun1 : vg_hana_log_{{ sap_sid }}
+      /dev/disk/azure/scsi1/lun2 : vg_hana_shared_{{ sap_sid }}
 
     logvols:
       hana_shared:
         size: 100%FREE
-        vol: vg_hana_shared_PV1
-        mountpoint: /hana/shared/PV1
+        vol: vg_hana_shared_{{ sap_sid }}
+        mountpoint: /hana/shared/{{ sap_sid }}
       hana_data:
         size: 100%FREE
-        vol: vg_hana_data_PV1
-        mountpoint: /hana/data/PV1
+        vol: vg_hana_data_{{ sap_sid }}
+        mountpoint: /hana/data/{{ sap_sid }}
       hana_logs:
         size: 100%FREE
-        vol: vg_hana_log_PV1
-        mountpoint: /hana/log/PV1
+        vol: vg_hana_log_{{ sap_sid }}
+        mountpoint: /hana/log/{{ sap_sid }}
   roles:
     - disk-setup
     - saphana-install

--- a/experiment/modules/single_node_hana/single-node-hana.tf
+++ b/experiment/modules/single_node_hana/single-node-hana.tf
@@ -135,6 +135,6 @@ resource null_resource "mount-disks-and-configure-hana" {
   }
 
   provisioner "local-exec" {
-    command = "ANSIBLE_HOST_KEY_CHECKING=\"False\" ansible-playbook -u ${var.vm_user} --private-key '${var.sshkey_path_private}' --extra-vars='{\"url_sapcar\": \"${var.url_sap_sapcar}\", \"url_hdbserver\": \"${var.url_sap_hdbserver}\", \"sap_sid\": \"${var.sap_sid}\", \"sap_instance_num\": \"${var.sap_instancenum}\", \"sap_hostname\": \"${local.vm_name}\", \"pwd_os_sapadm\": \"${var.pw_os_sapadm}\", \"pwd_os_sidadm\": \"${var.pw_os_sidadm}\", \"pwd_db_system\": \"${var.pw_db_system}\" }' -i '${local.vm_fqdn},' ansible/playbook.yml"
+    command = "ANSIBLE_HOST_KEY_CHECKING=\"False\" ansible-playbook -u ${var.vm_user} --private-key '${var.sshkey_path_private}' --extra-vars='{\"url_sapcar\": \"${var.url_sap_sapcar}\", \"url_hdbserver\": \"${var.url_sap_hdbserver}\", \"sap_sid\": \"${var.sap_sid}\", \"sap_instancenum\": \"${var.sap_instancenum}\", \"sap_hostname\": \"${local.vm_name}\", \"pwd_os_sapadm\": \"${var.pw_os_sapadm}\", \"pwd_os_sidadm\": \"${var.pw_os_sidadm}\", \"pwd_db_system\": \"${var.pw_db_system}\" }' -i '${local.vm_fqdn},' ansible/playbook.yml"
   }
 }


### PR DESCRIPTION
Fixing an oversight that always mounts to PV1 directories instead of specifying by the `sap_sid`.  Addressed the issues in #19 and #20.