### PR TITLE
Changing the hana shared mountpoint

### DIFF
--- a/experiment/ansible/playbook.yml
+++ b/experiment/ansible/playbook.yml
@@ -6,13 +6,13 @@
     disks:
       /dev/disk/azure/scsi1/lun0 : vg_hana_data_{{ sap_sid }}
       /dev/disk/azure/scsi1/lun1 : vg_hana_log_{{ sap_sid }}
-      /dev/disk/azure/scsi1/lun2 : vg_hana_shared_{{ sap_sid }}
+      /dev/disk/azure/scsi1/lun2 : vg_hana_shared
 
     logvols:
       hana_shared:
         size: 100%FREE
-        vol: vg_hana_shared_{{ sap_sid }}
-        mountpoint: /hana/shared/{{ sap_sid }}
+        vol: vg_hana_shared
+        mountpoint: /hana/shared
       hana_data:
         size: 100%FREE
         vol: vg_hana_data_{{ sap_sid }}


### PR DESCRIPTION
Changing the shared mountpoint to /hana/shared instead of /hana/shared/sid will speed up the installation process because the downloads will be on their own dedicated Premium Azure storage instead of on the local machine. @Azure/azure-sap-hana 