### PR TITLE
Use flag to choose between Hana 1.0 and 2.0

### DIFF
--- a/experiment/ansible/roles/saphana-install/defaults/main.yml
+++ b/experiment/ansible/roles/saphana-install/defaults/main.yml
@@ -12,3 +12,4 @@ sap_hostname:
 pwd_os_sapadm: 
 pwd_os_sidadm: 
 pwd_db_system: 
+use_hana2:

--- a/experiment/ansible/roles/saphana-install/tasks/main.yml
+++ b/experiment/ansible/roles/saphana-install/tasks/main.yml
@@ -6,7 +6,7 @@
 
 - name: deploy hdblcm install template
   template:
-    src: hdbserver_install.j2
+    src: "{{ 'hdbserver_hana2.j2' if use_hana2 else 'hdbserver_install.j2'}}"
     dest: /hana/shared/install/hdbserver_{{ sap_sid }}_install.cfg
 
 - name: deploy hdblcm password file

--- a/experiment/ansible/roles/saphana-install/templates/hdbserver_hana2.j2
+++ b/experiment/ansible/roles/saphana-install/templates/hdbserver_hana2.j2
@@ -1,0 +1,108 @@
+[Server]
+
+# Enable usage of persistent memory ( Default: n )
+use_pmem=n
+
+# Enable the installation or upgrade of the SAP Host Agent ( Default: y )
+install_hostagent=y
+
+# Database Isolation ( Default: low; Valid values: low | high )
+db_isolation=low
+
+# Create initial tenant database ( Default: y )
+create_initial_tenant=y
+
+# Non-standard Shared File System
+checkmnt=
+
+# Installation Path ( Default: /hana/shared )
+sapmnt=/hana/shared
+
+# Local Host Name ( Default: sh2-db0 )
+hostname={{ sap_hostname }}
+
+# Install SSH Key ( Default: y )
+install_ssh_key=y
+
+# Root User Name ( Default: root )
+root_user=root
+
+# Root User Password
+root_password=
+
+# SAP Host Agent User (sapadm) Password
+sapadm_password=
+
+# Directory containing a storage configuration
+storage_cfg=
+
+# Internal Network Address
+internal_network=
+
+# SAP HANA System ID
+sid={{ sap_sid|upper }}
+
+# Instance Number
+number={{ sap_instancenum }}
+
+# Local Host Worker Group ( Default: default )
+workergroup=default
+
+# System Usage ( Default: custom; Valid values: production | test | development | custom )
+system_usage=custom
+
+# Location of Data Volumes ( Default: /hana/data/${sid} )
+datapath=/hana/data/${sid}
+
+# Location of Log Volumes ( Default: /hana/log/${sid} )
+logpath=/hana/log/${sid}
+
+# Location of Persistent Memory Volumes ( Default: /hana/pmem/${sid} )
+pmempath=/hana/pmem/${sid}
+
+# Directory containing custom configurations
+custom_cfg=
+
+# Restrict maximum memory allocation?
+restrict_max_mem=
+
+# Maximum Memory Allocation in MB
+max_mem=
+
+# Certificate Host Names
+certificates_hostmap=
+
+# Master Password
+master_password=
+
+# System Administrator Password
+password=
+
+# System Administrator Home Directory ( Default: /usr/sap/${sid}/home )
+home=/usr/sap/${sid}/home
+
+# System Administrator Login Shell ( Default: /bin/sh )
+shell=/bin/sh
+
+# System Administrator User ID
+userid=
+
+# ID of User Group (sapsys)
+groupid=
+
+# Database User (SYSTEM) Password
+system_user_password=
+
+# Restart system after machine reboot? ( Default: n )
+autostart=n
+
+# Enable HANA repository ( Default: y )
+repository=y
+
+# Inter Service Communication Mode ( Valid values: standard | ssl )
+isc_mode=
+
+[Action]
+
+# Action ( Default: exit; Valid values: install | update | extract_components )
+action=install

--- a/experiment/main.tf
+++ b/experiment/main.tf
@@ -37,6 +37,7 @@ module "nsg" {
   az_region           = "${var.az_region}"
   sap_instancenum     = "${var.sap_instancenum}"
   sap_sid             = "${var.sap_sid}"
+  useHana2            = "${var.useHana2}"
 }
 
 module "single_node_hana" {
@@ -59,6 +60,7 @@ module "single_node_hana" {
   pw_os_sidadm        = "${var.pw_os_sidadm}"
   pw_db_system        = "${var.pw_db_system}"
   hana_subnet_id      = "${module.vnet.vnet_subnets[0]}"
+  useHana2            = "${var.useHana2}"
 }
 
 output "ip" {

--- a/experiment/modules/nsg_for_hana/nsg.tf
+++ b/experiment/modules/nsg_for_hana/nsg.tf
@@ -44,31 +44,68 @@ resource "azurerm_network_security_group" "sap-nsg" {
     destination_address_prefix = "*"
   }
 
-  security_rule {
-    name                       = "HTTP"
-    priority                   = 1030
-    direction                  = "Inbound"
-    access                     = "Allow"
-    protocol                   = "Tcp"
-    source_port_range          = "*"
-    destination_port_range     = "80${var.sap_instancenum}"
-    source_address_prefix      = "*"
-    destination_address_prefix = "*"
-  }
-
-  security_rule {
-    name                       = "HTTPS"
-    priority                   = 1040
-    direction                  = "Inbound"
-    access                     = "Allow"
-    protocol                   = "Tcp"
-    source_port_range          = "*"
-    destination_port_range     = "43${var.sap_instancenum}"
-    source_address_prefix      = "*"
-    destination_address_prefix = "*"
-  }
-
   tags {
     environment = "Terraform SAP HANA single node deployment nsg"
   }
+}
+
+resource "azurerm_network_security_rule" "hana1-http" {
+  count                       = "${!var.useHana2 ? 1 : 0}"
+  name                        = "HTTP"
+  priority                    = 1030
+  direction                   = "Inbound"
+  access                      = "Allow"
+  protocol                    = "Tcp"
+  source_port_range           = "*"
+  destination_port_range      = "80${var.sap_instancenum}"
+  source_address_prefix       = "*"
+  destination_address_prefix  = "*"
+  resource_group_name         = "${var.resource_group_name}"
+  network_security_group_name = "${azurerm_network_security_group.sap-nsg.name}"
+}
+
+resource "azurerm_network_security_rule" "hana1-https" {
+  count                       = "${!var.useHana2 ? 1 : 0}"
+  name                        = "HTTPS"
+  priority                    = 1040
+  direction                   = "Inbound"
+  access                      = "Allow"
+  protocol                    = "Tcp"
+  source_port_range           = "*"
+  destination_port_range      = "43${var.sap_instancenum}"
+  source_address_prefix       = "*"
+  destination_address_prefix  = "*"
+  resource_group_name         = "${var.resource_group_name}"
+  network_security_group_name = "${azurerm_network_security_group.sap-nsg.name}"
+}
+
+# Specify that those are for HANA 2 and XSA only
+resource "azurerm_network_security_rule" "hana2-xsa-http" {
+  count                       = "${var.useHana2 ? 1 : 0}"
+  name                        = "XSA-HTTP"
+  priority                    = 1030
+  direction                   = "Inbound"
+  access                      = "Allow"
+  protocol                    = "Tcp"
+  source_port_range           = "*"
+  destination_port_range      = "4000-4999"
+  source_address_prefix       = "*"
+  destination_address_prefix  = "*"
+  resource_group_name         = "${var.resource_group_name}"
+  network_security_group_name = "${azurerm_network_security_group.sap-nsg.name}"
+}
+
+resource "azurerm_network_security_rule" "hana2-xsa" {
+  count                       = "${var.useHana2 ? 1 : 0}"
+  name                        = "XSA"
+  priority                    = 1040
+  direction                   = "Inbound"
+  access                      = "Allow"
+  protocol                    = "Tcp"
+  source_port_range           = "*"
+  destination_port_range      = "50000-59999"
+  source_address_prefix       = "*"
+  destination_address_prefix  = "*"
+  resource_group_name         = "${var.resource_group_name}"
+  network_security_group_name = "${azurerm_network_security_group.sap-nsg.name}"
 }

--- a/experiment/modules/nsg_for_hana/variables.tf
+++ b/experiment/modules/nsg_for_hana/variables.tf
@@ -1,13 +1,18 @@
-variable "sap_sid" {
-  default = "PV1"
-}
+variable "az_region" {}
 
 variable "resource_group_name" {
   description = "Name of the Azure resource group that this NSG belongs to"
 }
 
-variable "az_region" {}
-
 variable "sap_instancenum" {
   description = "The sap instance number which is in range 00-99"
+}
+
+variable "sap_sid" {
+  default = "PV1"
+}
+
+variable "useHana2" {
+  description = "If this is set to true, then, ports specifically for HANA 2.0 will be opened."
+  default     = false
 }

--- a/experiment/modules/single_node_hana/single-node-hana.tf
+++ b/experiment/modules/single_node_hana/single-node-hana.tf
@@ -135,6 +135,6 @@ resource null_resource "mount-disks-and-configure-hana" {
   }
 
   provisioner "local-exec" {
-    command = "ANSIBLE_HOST_KEY_CHECKING=\"False\" ansible-playbook -u ${var.vm_user} --private-key '${var.sshkey_path_private}' --extra-vars='{\"url_sapcar\": \"${var.url_sap_sapcar}\", \"url_hdbserver\": \"${var.url_sap_hdbserver}\", \"sap_sid\": \"${var.sap_sid}\", \"sap_instancenum\": \"${var.sap_instancenum}\", \"sap_hostname\": \"${local.vm_name}\", \"pwd_os_sapadm\": \"${var.pw_os_sapadm}\", \"pwd_os_sidadm\": \"${var.pw_os_sidadm}\", \"pwd_db_system\": \"${var.pw_db_system}\" }' -i '${local.vm_fqdn},' ansible/playbook.yml"
+    command = "ANSIBLE_HOST_KEY_CHECKING=\"False\" ansible-playbook -u ${var.vm_user} --private-key '${var.sshkey_path_private}' --extra-vars='{\"url_sapcar\": \"${var.url_sap_sapcar}\", \"url_hdbserver\": \"${var.url_sap_hdbserver}\", \"sap_sid\": \"${var.sap_sid}\", \"sap_instancenum\": \"${var.sap_instancenum}\", \"sap_hostname\": \"${local.vm_name}\", \"pwd_os_sapadm\": \"${var.pw_os_sapadm}\", \"pwd_os_sidadm\": \"${var.pw_os_sidadm}\", \"pwd_db_system\": \"${var.pw_db_system}\", \"use_hana2\": \"${var.useHana2}\" }' -i '${local.vm_fqdn},' ansible/playbook.yml"
   }
 }

--- a/experiment/modules/single_node_hana/variables.tf
+++ b/experiment/modules/single_node_hana/variables.tf
@@ -76,6 +76,11 @@ variable "storage_disk_sizes_gb" {
   default     = [512, 512, 512]
 }
 
+variable "useHana2" {
+  description = "If this is set to true, then, ports specifically for HANA 2.0 will be opened."
+  default     = false
+}
+
 locals {
   vm_fqdn = "${azurerm_public_ip.hdb-pip.fqdn}"
   vm_name = "${var.sap_sid}-db${var.db_num}"

--- a/experiment/variables.tf
+++ b/experiment/variables.tf
@@ -62,3 +62,8 @@ variable "pw_os_sidadm" {
 variable "pw_db_system" {
   description = "Password for the database user SYSTEM"
 }
+
+variable "useHana2" {
+  description = "A boolean that will choose between HANA 1.0 and 2.0"
+  default     = false
+}


### PR DESCRIPTION
This allows the user to pick between installing HANA 1.0 or 2.0 with a simple flag.  The user will also need to supply the correct bits for HANA 2 if they use this option.   HANA 2.0 is needed for SHINE, which is a helpful tool for demos.