### PR TITLE
Fixing a problem where domain name already exists when another resour…

### DIFF
--- a/experiment/modules/generic_nic_and_pip/main.tf
+++ b/experiment/modules/generic_nic_and_pip/main.tf
@@ -4,7 +4,7 @@ resource "azurerm_public_ip" "pip" {
   location                     = "${var.az_region}"
   resource_group_name          = "${var.az_resource_group}"
   public_ip_address_allocation = "${var.public_ip_allocation_type}"
-  domain_name_label            = "${lower(var.name)}"
+  domain_name_label            = "${lower(var.name)}-${var.az_resource_group}"
 
   idle_timeout_in_minutes = 30
 


### PR DESCRIPTION
…ce group is created.
Fix for master: domain names aren't unique when several instances are created in the same region.  I'm updating so that the domain name will depend on the resource group name as well, which will make the fqdn more unique.