### PR TITLE
Flag to enable installation of XSA and SHINE

### DIFF
--- a/experiment/ansible/roles/shine-install/default/main.yml
+++ b/experiment/ansible/roles/shine-install/default/main.yml
@@ -7,3 +7,6 @@ pwd_db_shine:
 
 # e-mail address for SHINE user (not needed)
 email_shine: shinedemo@microsoft.com
+
+# Flag to determine whether SHINE needs to be installed or not
+install_xsa_shine:

--- a/experiment/ansible/single_node_playbook.yml
+++ b/experiment/ansible/single_node_playbook.yml
@@ -4,10 +4,10 @@
   roles:
     - disk-setup
     - saphana-install
-    - xsa-install
+    - { role: xsa-install, when: install_xsa_shine == true }
 
 - hosts: db0
   become: true
   become_user: "{{ sap_sid|lower }}adm"
   roles:
-    - shine-install
+    - { role: shine-install, when: install_xsa_shine == true }

--- a/experiment/modules/playbook-execution/main.tf
+++ b/experiment/modules/playbook-execution/main.tf
@@ -26,7 +26,8 @@ resource null_resource "mount-disks-and-configure-hana" {
      \"pwd_db_xsaadmin\": \"${var.pwd_db_xsaadmin}\", \
      \"pwd_db_tenant\": \"${var.pwd_db_tenant}\", \
      \"pwd_db_shine\": \"${var.pwd_db_shine}\", \
-     \"email_shine\": \"${var.email_shine}\" }" \
+     \"email_shine\": \"${var.email_shine}\", \
+     \"install_xsa_shine\": ${var.install_xsa_shine} }" \
      -i '../../ansible/azure_rm.py' ${var.ansible_playbook_path}
      EOT
 

--- a/experiment/modules/playbook-execution/variables.tf
+++ b/experiment/modules/playbook-execution/variables.tf
@@ -118,3 +118,8 @@ variable "email_shine" {
   description = "e-mail address for SHINE user"
   default     = ""
 }
+
+variable "install_xsa_shine" {
+  description = "Flag to determine whether to install SHINE on the host VM"
+  default     = false
+}

--- a/experiment/modules/single_node_hana/single-node-hana.tf
+++ b/experiment/modules/single_node_hana/single-node-hana.tf
@@ -53,4 +53,5 @@ module "configure_vm" {
   pwd_db_tenant       = "${var.pwd_db_tenant}"
   pwd_db_shine        = "${var.pwd_db_shine}"
   email_shine         = "${var.email_shine}"
+  install_xsa_shine   = "${var.install_xsa_shine}"
 }

--- a/experiment/modules/single_node_hana/variables.tf
+++ b/experiment/modules/single_node_hana/variables.tf
@@ -117,3 +117,7 @@ variable "pwd_db_shine" {
 variable "email_shine" {
   description = "e-mail address for SHINE user"
 }
+
+variable "install_xsa_shine" {
+  description = "Flag that determines whether to install SHINE on the host"
+}


### PR DESCRIPTION
User can choose to install XSA and SHINE on HANA VM using the flag "install_xsa_shine". The variable can be defined in a tfvars file. It is a Boolean flag meaning it accepts 'true' or 'false'. The default value is 'false'. 