### PR TITLE
HANA Cockpit for single node instances

### DIFF
--- a/experiment/ansible/roles/cockpit-download/defaults/main.yml
+++ b/experiment/ansible/roles/cockpit-download/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+# URL for HANA Cockpit
+url_cockpit: "https://tnieksap.blob.core.windows.net/shine/SAPHANACOCKPIT07_11-70002299.SAR?sp=r&st=2018-09-16T20:34:48Z&se=2020-01-01T08:00:00Z&spr=https&sv=2017-11-09&sig=Ttv5ue8y8NihbRaDL7WT93gZQML6SupspBK1BY4jz8Y%3D&sr=b"

--- a/experiment/ansible/roles/cockpit-download/defaults/main.yml
+++ b/experiment/ansible/roles/cockpit-download/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
 # URL for HANA Cockpit
-url_cockpit: "https://tnieksap.blob.core.windows.net/shine/SAPHANACOCKPIT07_11-70002299.SAR?sp=r&st=2018-09-16T20:34:48Z&se=2020-01-01T08:00:00Z&spr=https&sv=2017-11-09&sig=Ttv5ue8y8NihbRaDL7WT93gZQML6SupspBK1BY4jz8Y%3D&sr=b"
+url_cockpit:

--- a/experiment/ansible/roles/cockpit-download/tasks/main.yml
+++ b/experiment/ansible/roles/cockpit-download/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+# This role installs XSA on top of an existing HANA 2.0 instance
+- name: Download HANA Cockpit
+  get_url:
+    url: "{{ url_cockpit }}"
+    dest: /hana/shared/install/SAPHANACOCKPIT07_11-70002299.SAR
+  
+- name: Extract HANA Cockpit
+  command: ./SAPCAR_LINUX.EXE -manifest SIGNATURE.SMF -xvf SAPHANACOCKPIT07_11-70002299.SAR -R SAP_HANA_COCKPIT
+  args:
+    chdir: /hana/shared/install
+    creates: /hana/shared/install/SAP_HANA_COCKPIT

--- a/experiment/ansible/roles/cockpit-install/tasks/main.yml
+++ b/experiment/ansible/roles/cockpit-install/tasks/main.yml
@@ -1,0 +1,51 @@
+---
+# This role installs XSA on top of an existing HANA 2.0 instance
+- name: Log into XSA
+  shell: |
+    . ~/.bashrc
+    xs login --skip-ssl-validation -a https://{{ ansible_fqdn }}:3{{ sap_instancenum }}30/ -s SAP -u XSA_ADMIN  -p {{ pwd_db_xsaadmin }}
+  args:
+    executable: /bin/bash
+
+# - name: Install HRTT
+#   shell: |
+#     . ~/.bashrc
+#     xs install /hana/shared/install/SAP_HANA_COCKPIT/XSAC_HRTT_20/sap-xsac-hrtt-2.6.62.zip
+#   args:
+#     executable: /bin/bash
+#     chdir: "/usr/sap/{{ sap_sid|upper }}/HDB{{ sap_instancenum }}"
+
+- name: Install XSA Cockpit
+  shell: |
+    . ~/.bashrc
+    xs install /hana/shared/install/SAP_HANA_COCKPIT/XSA_COCKPIT/cockpit-web-xsa-assembly-1.1.7.zip
+  args:
+    executable: /bin/bash
+    chdir: "/usr/sap/{{ sap_sid|upper }}/HDB{{ sap_instancenum }}"
+
+- name: Install HANA Cockpit
+  shell: |
+    . ~/.bashrc
+    xs install /hana/shared/install/SAP_HANA_COCKPIT/COCKPIT2_APP/sap-xsac-cockpit-2.7.11.zip
+  args:
+    executable: /bin/bash
+    chdir: "/usr/sap/{{ sap_sid|upper }}/HDB{{ sap_instancenum }}"
+
+- name: Get Cockpit URL
+  shell: |
+    . ~/.bashrc
+    xs app cockpit-web-app --urls
+  register: cockpit_url
+  args:
+    executable: /bin/bash
+
+- name: Get Cockpit Admin URL
+  shell: |
+    . ~/.bashrc
+    xs app cockpit-admin-web-app --urls
+  register: cockpit_admin_url
+  args:
+    executable: /bin/bash
+
+- debug:
+    msg: "Cockpit URL = {{ cockpit_url }}\nCockpit Admin URL = {{ cockpit_admin_url }}"

--- a/experiment/ansible/roles/datagen/default/main.yml
+++ b/experiment/ansible/roles/datagen/default/main.yml
@@ -1,0 +1,3 @@
+---
+# Number of loops
+num_crossjoin_loops: 3

--- a/experiment/ansible/roles/datagen/tasks/main.yml
+++ b/experiment/ansible/roles/datagen/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+- name: Deploy prepare SQL for SHINE
+  template:
+    src: crossjoin.sql.j2
+    dest: /usr/sap/{{ sap_sid|upper }}/HDB{{ sap_instancenum }}/crossjoin.sql
+
+- name: Execute SQL to generate data
+  shell: |
+    . ~/.bashrc
+    hdbsql -d SYSTEMDB -u SYSTEM -p {{ pwd_db_system }} -i {{ sap_instancenum }} -I /usr/sap/{{ sap_sid|upper }}/HDB{{ sap_instancenum }}/crossjoin.sql
+  args:
+    executable: /bin/bash

--- a/experiment/ansible/roles/datagen/templates/crossjoin.sql.j2
+++ b/experiment/ansible/roles/datagen/templates/crossjoin.sql.j2
@@ -1,0 +1,8 @@
+drop table test;
+create column table test (a int, b int) PARTITION BY HASH ("A") PARTITIONS 100;
+
+do begin R10 = (select 0 as XNUM from SYS.DUMMY union all select 1 as XNUM from SYS.DUMMY union all select 2 as XNUM from SYS.DUMMY union all select 3 as XNUM from SYS.DUMMY union all select 4 as XNUM from SYS.DUMMY union all select 5 as XNUM from SYS.DUMMY union all select 6 as XNUM from SYS.DUMMY union all select 7 as XNUM from SYS.DUMMY union all select 8 as XNUM from SYS.DUMMY union all select 9 as XNUM from SYS.DUMMY); R10000000 = (select row_number() over () as XNUM from :R10 as R1 cross join :R10 as R2 cross join :R10 as R3 cross join :R10 as R4 cross join :R10 as R5 cross join :R10 as R6 cross join :R10 as R7); XA = (select A.XNUM as A, 100 as B from :R10000000 A ); insert into TEST (A, B) select A, B from :XA; end;
+
+commit;
+
+select count(*) from TEST;

--- a/experiment/ansible/single_node_playbook.yml
+++ b/experiment/ansible/single_node_playbook.yml
@@ -5,13 +5,12 @@
     - disk-setup
     - saphana-install
     - { role: xsa-install, when: install_xsa_shine == true }
-    - cockpit-download 
+    - { role: cockpit-download, when: install_xsa_shine == true }    
 
 - hosts: db0
   become: true
   become_user: "{{ sap_sid|lower }}adm"
   roles:
     - { role: shine-install, when: install_xsa_shine == true }
-    - cockpit-install
-    - shine-install
-      
+    - { role: cockpit-install, when: install_xsa_shine == true }    
+

--- a/experiment/ansible/single_node_playbook.yml
+++ b/experiment/ansible/single_node_playbook.yml
@@ -5,9 +5,13 @@
     - disk-setup
     - saphana-install
     - { role: xsa-install, when: install_xsa_shine == true }
+    - cockpit-download 
 
 - hosts: db0
   become: true
   become_user: "{{ sap_sid|lower }}adm"
   roles:
     - { role: shine-install, when: install_xsa_shine == true }
+    - cockpit-install
+    - shine-install
+      

--- a/experiment/modules/playbook-execution/main.tf
+++ b/experiment/modules/playbook-execution/main.tf
@@ -27,7 +27,8 @@ resource null_resource "mount-disks-and-configure-hana" {
      \"pwd_db_tenant\": \"${var.pwd_db_tenant}\", \
      \"pwd_db_shine\": \"${var.pwd_db_shine}\", \
      \"email_shine\": \"${var.email_shine}\", \
-     \"install_xsa_shine\": ${var.install_xsa_shine} }" \
+     \"install_xsa_shine\": ${var.install_xsa_shine}, \
+     \"url_cockpit\": \"${var.url_cockpit}\" }" \
      -i '../../ansible/azure_rm.py' ${var.ansible_playbook_path}
      EOT
 

--- a/experiment/modules/playbook-execution/variables.tf
+++ b/experiment/modules/playbook-execution/variables.tf
@@ -116,6 +116,11 @@ variable "pwd_db_shine" {
 
 variable "email_shine" {
   description = "e-mail address for SHINE user"
+  default     = "shinedemo@microsoft.com"
+}
+
+variable "url_cockpit" {
+  description = "URL for HANA Cockpit"
   default     = ""
 }
 

--- a/experiment/modules/single_node_hana/single-node-hana.tf
+++ b/experiment/modules/single_node_hana/single-node-hana.tf
@@ -56,4 +56,3 @@ module "configure_vm" {
   install_xsa_shine   = "${var.install_xsa_shine}"
   url_cockpit         = "${var.url_cockpit}"
 }
-

--- a/experiment/modules/single_node_hana/single-node-hana.tf
+++ b/experiment/modules/single_node_hana/single-node-hana.tf
@@ -54,4 +54,6 @@ module "configure_vm" {
   pwd_db_shine        = "${var.pwd_db_shine}"
   email_shine         = "${var.email_shine}"
   install_xsa_shine   = "${var.install_xsa_shine}"
+  url_cockpit         = "${var.url_cockpit}"
 }
+

--- a/experiment/modules/single_node_hana/variables.tf
+++ b/experiment/modules/single_node_hana/variables.tf
@@ -80,18 +80,22 @@ variable "useHana2" {
 
 variable "url_xsa_runtime" {
   description = "URL for XSA runtime"
+  default     = ""
 }
 
 variable "url_di_core" {
   description = "URL for DI Core"
+  default     = ""
 }
 
 variable "url_sapui5" {
   description = "URL for SAPUI5"
+  default     = ""
 }
 
 variable "url_portal_services" {
   description = "URL for Portal Services"
+  default     = ""
 }
 
 variable "url_xs_services" {
@@ -100,22 +104,32 @@ variable "url_xs_services" {
 
 variable "url_shine_xsa" {
   description = "URL for SHINE XSA"
+  default     = ""
 }
 
 variable "pwd_db_xsaadmin" {
   description = "Password for XSAADMIN user"
+  default     = ""
 }
 
 variable "pwd_db_tenant" {
   description = "Password for SYSTEM user (tenant DB)"
+  default     = ""
 }
 
 variable "pwd_db_shine" {
   description = "Password for SHINE user"
+  default     = ""
 }
 
 variable "email_shine" {
   description = "e-mail address for SHINE user"
+  default     = "shinedemo@microsoft.com"
+}
+
+variable "url_cockpit" {
+  description = "URL for HANA Cockpit"
+  default     = ""
 }
 
 variable "install_xsa_shine" {


### PR DESCRIPTION
This PR adds e2e download and install for the HANA Cockpit 2.0 component. Pre-requisite is a working HANA 2.0 with XSA install, and a valid download URL (set variable url_cockpit in terraform.tfvars).
Currently, the ansible role piggy-backs on the install_xsa_shine flag.

TODO:
- Separate install_xsa_shine into install_xsa, install_cockpit and install_shine
- Integrate into HA pair
- Allow for automated config of HANA Cockpit at first execution (requires SQL tracing)