### PR TITLE
Added a wait so the service principal will be created before the role…

### DIFF
--- a/deploy/vm/ansible/roles/stonith-device-creation/tasks/main.yml
+++ b/deploy/vm/ansible/roles/stonith-device-creation/tasks/main.yml
@@ -31,6 +31,10 @@
 - set_fact:
     Subscription_ID: "{{ json_subscription_info.id }}"
 
+- name: Sleep to let service principal be created before accessing
+  pause:
+    seconds: 30
+
 # TODO: Figure out custom role: "Role definition limit exceeded. No more role definitions can be created."
 
 - name: Assign custom role to the service principal


### PR DESCRIPTION
… is added.

There was a waiting issue where the service principal was not created before it was needed to assign the role.  Waiting 30 seconds fixes the problem