### PR TITLE
Fixing Master build that had a variable missing

### DIFF
--- a/deploy/vm/modules/ha_pair/variables.tf
+++ b/deploy/vm/modules/ha_pair/variables.tf
@@ -3,6 +3,8 @@ variable "ansible_playbook_path" {
   default     = "../../ansible/ha_pair_playbook.yml"
 }
 
+variable "az_region" {}
+
 variable "az_resource_group" {
   description = "Which Azure resource group to deploy the HANA setup into.  i.e. <myResourceGroup>"
 }


### PR DESCRIPTION
In an earlier attempt to organize and alphabetize variables, I accidentally got rid of a necessary az_region variable in the ``variables.tf`` file for the HA pair deployment.