### PR TITLE
If the setup is failing, fail instead of ending up in a limbo state

### DIFF
--- a/deploy/vm/ansible/ha_pair_playbook.yml
+++ b/deploy/vm/ansible/ha_pair_playbook.yml
@@ -25,6 +25,7 @@
 
 - hosts: db0,db1
   become: true
+  any_errors_fatal: true
   vars:
     db_num: "{{ ansible_hostname[-1] }}"
   roles:


### PR DESCRIPTION
At present, if the HA pair setup fails on one of the two databases, the playbook continues to run, but the installation may not end up being successful.  Failing when the error actually happens makes it much easier to track down the root cause.