### PR TITLE
Changed outputs to be more easily parsed

### DIFF
--- a/deploy/vm/modules/ha_pair/outputs.tf
+++ b/deploy/vm/modules/ha_pair/outputs.tf
@@ -1,15 +1,19 @@
 output "db0_ip" {
-  value = "Connect to db0 using ${var.vm_user}@${module.create_db0.fqdn}"
+  value = "${module.create_db0.fqdn}"
 }
 
 output "db1_ip" {
-  value = "Connect to db1 using ${var.vm_user}@${module.create_db1.fqdn}"
+  value = "${module.create_db1.fqdn}"
 }
 
-output "iscsi_ip" {
-  value = "Connect to iscsi using ${var.vm_user}@${module.nic_and_pip_setup_iscsi.fqdn}"
+output "db_vm_user" {
+  value = "${var.vm_user}"
 }
 
 output "windows_bastion_ip" {
   value = "${module.windows_bastion_host.ip}"
+}
+
+output "windows_bastion_user" {
+  value = "${var.bastion_username_windows}"
 }

--- a/deploy/vm/modules/single_node_hana/outputs.tf
+++ b/deploy/vm/modules/single_node_hana/outputs.tf
@@ -1,7 +1,15 @@
 output "db_ip" {
-  value = "Connect using ${var.vm_user}@${module.create_db.fqdn}"
+  value = "${module.create_db.fqdn}"
+}
+
+output "db_vm_user" {
+  value = "${var.vm_user}"
 }
 
 output "windows_bastion_ip" {
   value = "${module.windows_bastion_host.ip}"
+}
+
+output "windows_bastion_user" {
+  value = "${var.bastion_username_windows}"
 }


### PR DESCRIPTION
If you use `terraform output -json` after applying the terraform, you get the outputs in a much easier to read format.