### PR TITLE
FIX: domain name prefix should be an user input

### DIFF
--- a/deploy/vm/modules/create_hdb_node/main.tf
+++ b/deploy/vm/modules/create_hdb_node/main.tf
@@ -4,6 +4,7 @@ module "nic_and_pip_setup" {
 
   az_resource_group         = "${var.az_resource_group}"
   az_region                 = "${var.az_region}"
+  az_domain_name            = "${var.az_domain_name}"
   name                      = "${local.machine_name}"
   nsg_id                    = "${var.nsg_id}"
   subnet_id                 = "${var.hana_subnet_id}"

--- a/deploy/vm/modules/create_hdb_node/variables.tf
+++ b/deploy/vm/modules/create_hdb_node/variables.tf
@@ -3,6 +3,10 @@ variable "availability_set_id" {
   default     = ""                                                                 # Empty string denotes that this VM is not in an availability set.
 }
 
+variable "az_domain_name" {
+  description = "Prefix to be used in the domain name"
+}
+
 variable "az_region" {}
 
 variable "az_resource_group" {

--- a/deploy/vm/modules/generic_nic_and_pip/main.tf
+++ b/deploy/vm/modules/generic_nic_and_pip/main.tf
@@ -4,7 +4,7 @@ resource "azurerm_public_ip" "pip" {
   location                     = "${var.az_region}"
   resource_group_name          = "${var.az_resource_group}"
   public_ip_address_allocation = "${var.public_ip_allocation_type}"
-  domain_name_label            = "${lower(var.name)}-${var.az_resource_group}"
+  domain_name_label            = "${lower(var.name)}-${lower(var.az_domain_name)}"
 
   idle_timeout_in_minutes = 30
 

--- a/deploy/vm/modules/generic_nic_and_pip/variables.tf
+++ b/deploy/vm/modules/generic_nic_and_pip/variables.tf
@@ -5,7 +5,7 @@ variable "az_resource_group" {
 }
 
 variable "az_domain_name" {
- description = "Prefix to be used in the domain name"
+  description = "Prefix to be used in the domain name"
 }
 
 variable "backend_ip_pool_ids" {

--- a/deploy/vm/modules/generic_nic_and_pip/variables.tf
+++ b/deploy/vm/modules/generic_nic_and_pip/variables.tf
@@ -4,6 +4,10 @@ variable "az_resource_group" {
   description = "Which Azure resource group to deploy the HANA setup into.  i.e. <myResourceGroup>"
 }
 
+variable "az_domain_name" {
+ description = "Prefix to be used in the domain name"
+}
+
 variable "backend_ip_pool_ids" {
   type        = "list"
   description = "The ids that associate the load balancer's back end IP pool with this NIC."

--- a/deploy/vm/modules/ha_pair/main.tf
+++ b/deploy/vm/modules/ha_pair/main.tf
@@ -148,7 +148,7 @@ module "vm_and_disk_creation_iscsi" {
   az_resource_group     = "${module.common_setup.resource_group_name}"
   az_region             = "${module.common_setup.resource_group_location}"
   storage_disk_sizes_gb = [16]
-  machine_name          = "${module.common_setup.resource_group_name}-iscsi"
+  machine_name          = "${var.az_domain_name}-iscsi"
   vm_user               = "${var.vm_user}"
   vm_size               = "Standard_D2s_v3"
   nic_id                = "${module.nic_and_pip_setup_iscsi.nic_id}"

--- a/deploy/vm/modules/ha_pair/main.tf
+++ b/deploy/vm/modules/ha_pair/main.tf
@@ -94,6 +94,7 @@ module "create_hdb0" {
   availability_set_id       = "${azurerm_availability_set.ha-pair-availset.id}"
   az_resource_group         = "${module.common_setup.resource_group_name}"
   az_region                 = "${module.common_setup.resource_group_location}"
+  az_domain_name            = "${var.az_domain_name}"
   backend_ip_pool_ids       = ["${azurerm_lb_backend_address_pool.availability-back-pool.id}"]
   hdb_num                   = "0"
   hana_subnet_id            = "${module.common_setup.vnet_subnets[0]}"
@@ -113,6 +114,7 @@ module "create_hdb1" {
   availability_set_id       = "${azurerm_availability_set.ha-pair-availset.id}"
   az_resource_group         = "${module.common_setup.resource_group_name}"
   az_region                 = "${module.common_setup.resource_group_location}"
+  az_domain_name            = "${var.az_domain_name}"
   backend_ip_pool_ids       = ["${azurerm_lb_backend_address_pool.availability-back-pool.id}"]
   hdb_num                   = "1"
   hana_subnet_id            = "${module.common_setup.vnet_subnets[0]}"
@@ -131,6 +133,7 @@ module "nic_and_pip_setup_iscsi" {
 
   az_region                 = "${module.common_setup.resource_group_location}"
   az_resource_group         = "${module.common_setup.resource_group_name}"
+  az_domain_name            = "${var.az_domain_name}"
   name                      = "iscsi"
   nsg_id                    = "${module.common_setup.nsg_id}"
   private_ip_address        = "${var.private_ip_address_iscsi}"

--- a/deploy/vm/modules/ha_pair/variables.tf
+++ b/deploy/vm/modules/ha_pair/variables.tf
@@ -3,6 +3,10 @@ variable "ansible_playbook_path" {
   default     = "../../ansible/ha_pair_playbook.yml"
 }
 
+variable "az_domain_name" {
+  description = "Prefix to be used in the domain name"
+}
+
 variable "az_region" {}
 
 variable "az_resource_group" {

--- a/deploy/vm/modules/single_node_hana/single-node-hana.tf
+++ b/deploy/vm/modules/single_node_hana/single-node-hana.tf
@@ -19,6 +19,7 @@ module "create_hdb" {
   az_resource_group         = "${module.common_setup.resource_group_name}"
   az_region                 = "${var.az_region}"
   hdb_num                   = 0
+  az_domain_name            = "${var.az_domain_name}"
   hana_subnet_id            = "${module.common_setup.vnet_subnets[0]}"
   nsg_id                    = "${module.common_setup.nsg_id}"
   private_ip_address        = "${var.private_ip_address_hdb}"

--- a/deploy/vm/modules/single_node_hana/variables.tf
+++ b/deploy/vm/modules/single_node_hana/variables.tf
@@ -3,6 +3,10 @@ variable "ansible_playbook_path" {
   default     = "../../ansible/single_node_playbook.yml"
 }
 
+variable "az_domain_name" {
+  description = "Prefix to be used in the domain name"
+}
+
 variable "az_region" {}
 
 variable "az_resource_group" {


### PR DESCRIPTION
With this fix, the resource group name can be of any valid format now. With the current code, the terraform module complains if the resource group name has upper case or underscores. The reason of complain is that we are using this resource group name in the domain name of the VMs which can not have uppercase or underscores. The error that terraform returns is not very obvious, so after a little bit of digging, I found this issue. Also looks like az_domain_name was unused even though this is mentioned in the README