### PR TITLE
 create n+m HANA cluster for scale out

### DIFF
--- a/deploy/vm/ansible/create_n_m_hana_cluster.yml
+++ b/deploy/vm/ansible/create_n_m_hana_cluster.yml
@@ -1,8 +1,19 @@
 ---
-- name: "Create HANA cluster of {{ n }} VMs"
+- name: prepare configs
+  hosts: localhost
+  tasks:
+     - set_fact:
+          m_count: "1"
+       when: m < 0
+     - set_fact:
+          m_count: "{{ m }}"
+       when: m > 0
+
+- name: "Create HANA cluster of {{ n }} VMs and standby of {{ m }} VMs"
   hosts: localhost
   roles:
-     - { role: create-vm-cluster, vm_group: "hana_vm_group" }
+     - { role: create-hana-cluster, vm_group: "hana_vm_group" }
+     - { role: create-vm-cluster, vm_group: "standby_group", domain_name_prefix: "standby", vm_count: "{{ m_count }}", when: m > 0 }
 
 - hosts: localhost
   tasks:

--- a/deploy/vm/ansible/create_n_m_hana_cluster.yml
+++ b/deploy/vm/ansible/create_n_m_hana_cluster.yml
@@ -1,0 +1,32 @@
+---
+- name: "Create HANA cluster of {{ n }} VMs"
+  hosts: localhost
+  roles:
+     - { role: create-vm-cluster, vm_group: "hana_vm_group" }
+
+- hosts: localhost
+  tasks:
+     - debug:
+         msg: "Created HANA VM {{ item }}"
+       with_items: "{{ groups['hana_vm_group'] }}"
+
+- name: Managed disk for logs
+  hosts: localhost
+  tasks:
+     - name: create managed disks for logs
+       azure_rm_managed_disk:
+          name: "hana{{ item }}log"
+          resource_group: "{{ resource_group }}"
+          disk_size_gb: 256
+          storage_account_type: Premium_LRS
+          managed_by: "hanavm-{{ item }}"
+       with_sequence: start=1 end="{{ n }}"
+     - name: create managed disks for logs
+       azure_rm_managed_disk:
+          name: "hana{{ item }}data"
+          resource_group: "{{ resource_group }}"
+          disk_size_gb: 256
+          storage_account_type: Premium_LRS
+          managed_by: "hanavm-{{ item }}"
+       with_sequence: start=1 end="{{ n }}"
+

--- a/deploy/vm/ansible/create_n_m_hana_cluster.yml
+++ b/deploy/vm/ansible/create_n_m_hana_cluster.yml
@@ -2,24 +2,26 @@
 - name: prepare configs
   hosts: localhost
   tasks:
-     - set_fact:
+     - name: This is a hack to get the iteration functionality of Ansible working
+       set_fact:
           m_count: "1"
-       when: m < 0
+       when: m < 1
      - set_fact:
           m_count: "{{ m }}"
        when: m > 0
 
+# vm_group name can not have upper case or special characters since this is a part of the domain name prefix
 - name: "Create HANA cluster of {{ n }} VMs and standby of {{ m }} VMs"
   hosts: localhost
   roles:
-     - { role: create-hana-cluster, vm_group: "hana_vm_group" }
-     - { role: create-vm-cluster, vm_group: "standby_group", domain_name_prefix: "standby", vm_count: "{{ m_count }}", when: m > 0 }
+     - { role: create-hana-cluster, vm_group: "hana" }
+     - { role: create-vm-cluster, vm_group: "standby", vm_count: "{{ m_count }}", when: m > 0 }
 
 - hosts: localhost
   tasks:
      - debug:
          msg: "Created HANA VM {{ item }}"
-       with_items: "{{ groups['hana_vm_group'] }}"
+       with_items: "{{ groups['hana'] }}"
 
 - name: Managed disk for logs
   hosts: localhost

--- a/deploy/vm/ansible/roles/create-hana-cluster/defaults/main.yml
+++ b/deploy/vm/ansible/roles/create-hana-cluster/defaults/main.yml
@@ -5,5 +5,4 @@ allowed_source_ip_prefix:
 ssh_public_key_file:
 vm_user:
 vm_group: "hana"
-domain_name_prefix: "hana"
-vm_count:
+n:

--- a/deploy/vm/ansible/roles/create-hana-cluster/tasks/main.yml
+++ b/deploy/vm/ansible/roles/create-hana-cluster/tasks/main.yml
@@ -20,7 +20,7 @@
         resource_group: "{{ resource_group }}"
         allocation_method: Static
         name: "hanavm-pip{{ item }}"
-        domain_name: "hanavm-{{ item }}-{{ resource_group }}"
+        domain_name: "{{ az_domain_name }}-hana{{ item }}"
         sku: Standard
       register: ip_sample
       with_sequence: start=1 end="{{ n }}"
@@ -38,14 +38,6 @@
              priority: 1001
              direction: Inbound
              source_address_prefix: "{{ allowed_source_ip_prefix }}"
-    - name: create public ip for loadbalancer
-      azure_rm_publicipaddress:
-          resource_group: "{{ resource_group }}"
-          allocation_method: Static
-          name: "hanalb-pip{{ item }}"
-          domain_name: "hana-{{ item }}-{{ resource_group }}"
-          sku: Standard
-      register: ip_sample_lb
       with_sequence: start=1 end="{{ n }}"
     - name: set up the load balancers
       azure_rm_loadbalancer:
@@ -54,25 +46,22 @@
           sku: Standard
           frontend_ip_configurations:
               - name: "frontendipconf{{ item }}"
-                public_ip_address: "hanalb-pip{{ item }}"
+                private_ip_address: "10.0.1.9{{ item }}"
+                private_ip_allocation_method: Static
+                subnet: "{{ hana_cluster_subnet.state.id }}"
           backend_address_pools:
               - name: "backendaddrpool{{ item }}"
           probes:
               - name: "probe{{ item }}"
-                port: 80
-          inbound_nat_pools:
-              - name: "inboundnatpool{{ item }}"
-                frontend_ip_configuration_name: "frontendipconf{{ item }}"
                 protocol: Tcp
-                frontend_port_range_start: 80
-                frontend_port_range_end: 81
-                backend_port: 8080
+                port: 22
           load_balancing_rules:
               - name: "lbrbalancingrule{{ item }}"
+                protocol: All
                 frontend_ip_configuration: "frontendipconf{{ item }}"
                 backend_address_pool: "backendaddrpool{{ item }}"
-                frontend_port: 80
-                backend_port: 80
+                frontend_port: 0
+                backend_port: 0
                 probe: "probe{{ item }}"
       with_sequence: start=1 end="{{ n }}"
     - name: NIC for the VMs

--- a/deploy/vm/ansible/roles/create-hana-cluster/tasks/main.yml
+++ b/deploy/vm/ansible/roles/create-hana-cluster/tasks/main.yml
@@ -20,10 +20,10 @@
         resource_group: "{{ resource_group }}"
         allocation_method: Static
         name: "hanavm-pip{{ item }}"
-        domain_name: "{{ domain_name_prefix }}-{{ item }}-{{ resource_group }}"
+        domain_name: "hanavm-{{ item }}-{{ resource_group }}"
         sku: Standard
       register: ip_sample
-      with_sequence: start=1 end="{{ vm_count }}"
+      with_sequence: start=1 end="{{ n }}"
     - debug:
         msg: "hana vm :{{ ip_sample.results[0].state.dns_settings.fqdn }}"
     - name: Create Network Security Group that allows SSH
@@ -38,6 +38,43 @@
              priority: 1001
              direction: Inbound
              source_address_prefix: "{{ allowed_source_ip_prefix }}"
+    - name: create public ip for loadbalancer
+      azure_rm_publicipaddress:
+          resource_group: "{{ resource_group }}"
+          allocation_method: Static
+          name: "hanalb-pip{{ item }}"
+          domain_name: "hana-{{ item }}-{{ resource_group }}"
+          sku: Standard
+      register: ip_sample_lb
+      with_sequence: start=1 end="{{ n }}"
+    - name: set up the load balancers
+      azure_rm_loadbalancer:
+          resource_group: "{{ resource_group }}"
+          name: "hana{{ item }}-lb"
+          sku: Standard
+          frontend_ip_configurations:
+              - name: "frontendipconf{{ item }}"
+                public_ip_address: "hanalb-pip{{ item }}"
+          backend_address_pools:
+              - name: "backendaddrpool{{ item }}"
+          probes:
+              - name: "probe{{ item }}"
+                port: 80
+          inbound_nat_pools:
+              - name: "inboundnatpool{{ item }}"
+                frontend_ip_configuration_name: "frontendipconf{{ item }}"
+                protocol: Tcp
+                frontend_port_range_start: 80
+                frontend_port_range_end: 81
+                backend_port: 8080
+          load_balancing_rules:
+              - name: "lbrbalancingrule{{ item }}"
+                frontend_ip_configuration: "frontendipconf{{ item }}"
+                backend_address_pool: "backendaddrpool{{ item }}"
+                frontend_port: 80
+                backend_port: 80
+                probe: "probe{{ item }}"
+      with_sequence: start=1 end="{{ n }}"
     - name: NIC for the VMs
       azure_rm_networkinterface:
           resource_group: "{{ resource_group }}"
@@ -51,8 +88,11 @@
              - name: hana-ip-config
                public_ip_address_name: "hanavm-pip{{ item }}"
                primary: yes
+               load_balancer_backend_address_pools:
+                   - name: "backendaddrpool{{ item }}"
+                     load_balancer: "hana{{ item }}-lb"
       register: nic_sample
-      with_sequence: start=1 end="{{ vm_count }}"
+      with_sequence: start=1 end="{{ n }}"
     - add_host:
         name: "{{ item.state.dns_settings.fqdn }}"
         groups: "{{ vm_group }}"
@@ -60,7 +100,7 @@
         ansible_ssh_extra_args: "-o StrictHostKeyChecking=no"
         ansible_user: "{{ vm_user }}"
       with_items: "{{ ip_sample.results }}"
-    - name: create SLES  VM
+    - name: create hana VM
       vars:
         public_key_data: "{{ lookup('file','{{ ssh_public_key_file }}') }}"
       azure_rm_virtualmachine:
@@ -81,6 +121,6 @@
             publisher: SUSE
             sku: 12-SP3
             version: latest
-      with_sequence: start=1 end="{{ vm_count }}"
+      with_sequence: start=1 end="{{ n }}"
       async: 1500
 

--- a/deploy/vm/ansible/roles/create-vm-cluster/defaults/main.yml
+++ b/deploy/vm/ansible/roles/create-vm-cluster/defaults/main.yml
@@ -1,0 +1,8 @@
+resource_group:
+location: "eastus"
+ssh_private_key_file:
+allowed_source_ip_prefix:
+ssh_public_key_file:
+vm_user:
+vm_group: "hana"
+n:

--- a/deploy/vm/ansible/roles/create-vm-cluster/tasks/main.yml
+++ b/deploy/vm/ansible/roles/create-vm-cluster/tasks/main.yml
@@ -1,0 +1,126 @@
+---
+    - name: Create resource group
+      azure_rm_resourcegroup:
+        name: "{{ resource_group }}"
+        location: "{{ location }}"
+    - name: Create virtual network
+      azure_rm_virtualnetwork:
+        resource_group: "{{ resource_group }}"
+        name: hana-vnet
+        address_prefixes: "10.0.0.0/16" 
+    - name: Add subnet
+      azure_rm_subnet:
+        resource_group: "{{ resource_group }}"
+        name: hana-subnet
+        address_prefix: "10.0.1.0/24"
+        virtual_network: hana-vnet
+      register: hana_cluster_subnet
+    - name: Create public IP address
+      azure_rm_publicipaddress:
+        resource_group: "{{ resource_group }}"
+        allocation_method: Static
+        name: "hanavm-pip{{ item }}"
+        domain_name: "hanavm-{{ item }}-{{ resource_group }}"
+        sku: Standard
+      register: ip_sample
+      with_sequence: start=1 end="{{ n }}"
+    - debug:
+        msg: "hana vm :{{ ip_sample.results[0].state.dns_settings.fqdn }}"
+    - name: Create Network Security Group that allows SSH
+      azure_rm_securitygroup:
+         resource_group: "{{ resource_group }}"
+         name: "{{ resource_group }}-hana-nsg"
+         rules:
+           - name: SSH
+             protocol: Tcp
+             destination_port_range: 22
+             access: Allow
+             priority: 1001
+             direction: Inbound
+             source_address_prefix: "{{ allowed_source_ip_prefix }}"
+    - name: create public ip for loadbalancer
+      azure_rm_publicipaddress:
+          resource_group: "{{ resource_group }}"
+          allocation_method: Static
+          name: "hanalb-pip{{ item }}"
+          domain_name: "hana-{{ item }}-{{ resource_group }}"
+          sku: Standard
+      register: ip_sample_lb
+      with_sequence: start=1 end="{{ n }}"
+    - name: set up the load balancers
+      azure_rm_loadbalancer:
+          resource_group: "{{ resource_group }}"
+          name: "hana{{ item }}-lb"
+          sku: Standard
+          frontend_ip_configurations:
+              - name: "frontendipconf{{ item }}"
+                public_ip_address: "hanalb-pip{{ item }}"
+          backend_address_pools:
+              - name: "backendaddrpool{{ item }}"
+          probes:
+              - name: "probe{{ item }}"
+                port: 80
+          inbound_nat_pools:
+              - name: "inboundnatpool{{ item }}"
+                frontend_ip_configuration_name: "frontendipconf{{ item }}"
+                protocol: Tcp
+                frontend_port_range_start: 80
+                frontend_port_range_end: 81
+                backend_port: 8080
+          load_balancing_rules:
+              - name: "lbrbalancingrule{{ item }}"
+                frontend_ip_configuration: "frontendipconf{{ item }}"
+                backend_address_pool: "backendaddrpool{{ item }}"
+                frontend_port: 80
+                backend_port: 80
+                probe: "probe{{ item }}"
+      with_sequence: start=1 end="{{ n }}"
+    - name: NIC for the VMs
+      azure_rm_networkinterface:
+          resource_group: "{{ resource_group }}"
+          name: "{{ resource_group }}-nic{{ item }}"
+          virtual_network: "hana-vnet"
+          subnet: "hana-subnet"
+          public_ip_name: "hanavm-pip{{ item }}"
+          security_group: "{{ resource_group }}-hana-nsg"
+          enable_accelerated_networking: True
+          ip_configurations:
+             - name: hana-ip-config
+               public_ip_address_name: "hanavm-pip{{ item }}"
+               primary: yes
+               load_balancer_backend_address_pools:
+                   - name: "backendaddrpool{{ item }}"
+                     load_balancer: "hana{{ item }}-lb"
+      register: nic_sample
+      with_sequence: start=1 end="{{ n }}"
+    - add_host:
+        name: "{{ item.state.dns_settings.fqdn }}"
+        groups: "{{ vm_group }}"
+        ansible_ssh_private_key_file: "{{ ssh_private_key_file }}"
+        ansible_ssh_extra_args: "-o StrictHostKeyChecking=no"
+        ansible_user: "{{ vm_user }}"
+      with_items: "{{ ip_sample.results }}"
+    - name: create hana VM
+      vars:
+        public_key_data: "{{ lookup('file','{{ ssh_public_key_file }}') }}"
+      azure_rm_virtualmachine:
+        resource_group: "{{ resource_group }}"
+        managed_disk_type: Standard_LRS
+        name: "hanavm-{{ item }}"
+        vm_size: Standard_D8s_v3
+        admin_username: "{{ vm_user }}"
+        ssh_password_enabled: false
+        ssh_public_keys:
+            - path: "/home/{{ vm_user }}/.ssh/authorized_keys"
+              key_data: "{{ public_key_data }}"
+        network_interfaces: "{{ resource_group }}-nic{{ item }}"
+        started: yes
+        state: present
+        image:
+            offer: SLES
+            publisher: SUSE
+            sku: 12-SP3
+            version: latest
+      with_sequence: start=1 end="{{ n }}"
+      async: 1500
+

--- a/deploy/vm/ansible/roles/create-vm-cluster/tasks/main.yml
+++ b/deploy/vm/ansible/roles/create-vm-cluster/tasks/main.yml
@@ -19,13 +19,11 @@
       azure_rm_publicipaddress:
         resource_group: "{{ resource_group }}"
         allocation_method: Static
-        name: "hanavm-pip{{ item }}"
-        domain_name: "{{ domain_name_prefix }}-{{ item }}-{{ resource_group }}"
+        name: "{{ vm_group }}-pip{{ item }}"
+        domain_name: "{{ az_domain_name }}-{{ vm_group }}{{ item }}"
         sku: Standard
       register: ip_sample
       with_sequence: start=1 end="{{ vm_count }}"
-    - debug:
-        msg: "hana vm :{{ ip_sample.results[0].state.dns_settings.fqdn }}"
     - name: Create Network Security Group that allows SSH
       azure_rm_securitygroup:
          resource_group: "{{ resource_group }}"
@@ -41,15 +39,15 @@
     - name: NIC for the VMs
       azure_rm_networkinterface:
           resource_group: "{{ resource_group }}"
-          name: "{{ resource_group }}-nic{{ item }}"
+          name: "{{ vm_group }}-nic{{ item }}"
           virtual_network: "hana-vnet"
           subnet: "hana-subnet"
-          public_ip_name: "hanavm-pip{{ item }}"
+          public_ip_name: "{{ vm_group }}-pip{{ item }}"
           security_group: "{{ resource_group }}-hana-nsg"
           enable_accelerated_networking: True
           ip_configurations:
              - name: hana-ip-config
-               public_ip_address_name: "hanavm-pip{{ item }}"
+               public_ip_address_name: "{{ vm_group }}-pip{{ item }}"
                primary: yes
       register: nic_sample
       with_sequence: start=1 end="{{ vm_count }}"
@@ -66,14 +64,14 @@
       azure_rm_virtualmachine:
         resource_group: "{{ resource_group }}"
         managed_disk_type: Standard_LRS
-        name: "hanavm-{{ item }}"
+        name: "{{ vm_group }}-{{ item }}"
         vm_size: Standard_D8s_v3
         admin_username: "{{ vm_user }}"
         ssh_password_enabled: false
         ssh_public_keys:
             - path: "/home/{{ vm_user }}/.ssh/authorized_keys"
               key_data: "{{ public_key_data }}"
-        network_interfaces: "{{ resource_group }}-nic{{ item }}"
+        network_interfaces: "{{ vm_group }}-nic{{ item }}"
         started: yes
         state: present
         image:


### PR DESCRIPTION
For now, what this feature does is the following:

1. Creates resource group, vnet, security group
2. Create Network interface control for each VM
3. Creates n number of worker VMs
4. Attaches Managed disks to each of the worker VMs
5. Sets up n load balancers. Each worker VM is behind one internal load balancer. The load balancer is configured with high availability ports
6. Creates m number of stand by VMs