### PR TITLE
This fixes an issue where the windows bastion host is trying to share…

### DIFF
--- a/deploy/vm/ansible/roles/ssh-key-distribute/tasks/main.yml
+++ b/deploy/vm/ansible/roles/ssh-key-distribute/tasks/main.yml
@@ -16,8 +16,7 @@
   delegate_to: "{{ item }}"
   become: true
   when: item != inventory_hostname
-  with_items: "{{ groups['azure'] }}"
-
+  with_items: "{{ groups['linux'] }}"
 - debug:
     var: inventory_hostname
 
@@ -27,9 +26,6 @@
 - debug:
     var: ansible_facts['ssh_host_key_rsa_public']
 
-# - name: Tell the host about our servers it might want to ssh to with hostnames
-#   shell: ssh-keyscan {{ inventory_hostname }},{{ ansible_facts['eth0']['ipv4']['address'] }}
-#   register: host_key
 - set_fact:
     host_key_rsa: "{{ inventory_hostname }},{{ ansible_facts['eth0']['ipv4']['address'] }} ssh-rsa {{ ansible_facts['ssh_host_key_rsa_public'] }}"
 
@@ -45,4 +41,4 @@
   delegate_to: "{{ item }}"
   become: true
   when: item != inventory_hostname
-  with_items: "{{ groups['azure'] }}"
+  with_items: "{{ groups['linux'] }}"


### PR DESCRIPTION
… its ssh key, causing a sudo not allowed issue.
This was an issue with the `groups['azure']` reference.  This got all of the vms, not only the databases and iscsi. I have changed it to use the linux group. Since the linux bastion host is created later in the playbook, this will not affect any communication with the linux bastion host, simply fix the current problem