### PR TITLE
Capitals and length of resource group name will no longer affect wind…

### DIFF
--- a/deploy/vm/modules/ha_pair/main.tf
+++ b/deploy/vm/modules/ha_pair/main.tf
@@ -160,6 +160,7 @@ module "vm_and_disk_creation_iscsi" {
 module "windows_bastion_host" {
   source             = "../windows_bastion_host"
   allow_ips          = "${var.allow_ips}"
+  az_domain_name     = "${var.az_domain_name}"
   az_resource_group  = "${module.common_setup.resource_group_name}"
   az_region          = "${var.az_region}"
   sap_sid            = "${var.sap_sid}"

--- a/deploy/vm/modules/single_node_hana/single-node-hana.tf
+++ b/deploy/vm/modules/single_node_hana/single-node-hana.tf
@@ -35,6 +35,7 @@ module "create_hdb" {
 module "windows_bastion_host" {
   source             = "../windows_bastion_host"
   allow_ips          = "${var.allow_ips}"
+  az_domain_name     = "${var.az_domain_name}"
   az_resource_group  = "${module.common_setup.resource_group_name}"
   az_region          = "${var.az_region}"
   sap_sid            = "${var.sap_sid}"

--- a/deploy/vm/modules/windows_bastion_host/certificates.tf
+++ b/deploy/vm/modules/windows_bastion_host/certificates.tf
@@ -1,7 +1,7 @@
 data "azurerm_client_config" "current" {}
 
 resource "azurerm_key_vault" "main" {
-  name                = "${var.az_resource_group}-keyvault"
+  name                = "winbastion-keyvault"
   count               = "${var.windows_bastion ? 1 : 0}"
   location            = "${var.az_region}"
   resource_group_name = "${var.az_resource_group}"

--- a/deploy/vm/modules/windows_bastion_host/main.tf
+++ b/deploy/vm/modules/windows_bastion_host/main.tf
@@ -41,7 +41,7 @@ resource "azurerm_public_ip" "pip" {
   location                     = "${var.az_region}"
   resource_group_name          = "${var.az_resource_group}"
   public_ip_address_allocation = "dynamic"
-  domain_name_label            = "${lower(local.machine_name)}-${var.az_resource_group}"
+  domain_name_label            = "${lower(local.machine_name)}-${var.az_domain_name}"
 
   idle_timeout_in_minutes = 30
 

--- a/deploy/vm/modules/windows_bastion_host/variables.tf
+++ b/deploy/vm/modules/windows_bastion_host/variables.tf
@@ -3,6 +3,10 @@ variable "allow_ips" {
   type        = "list"
 }
 
+variable "az_domain_name" {
+  description = "Prefix to be used in the domain name"
+}
+
 variable "az_region" {}
 
 variable "az_resource_group" {


### PR DESCRIPTION
…ows bastion host creation

Removed the dependency of the resource group name on the public ip fqdn and on the keyvault