### PR TITLE
Pabowers hapair add timesync

### DIFF
--- a/deploy/vm/ansible/ha_pair_playbook.yml
+++ b/deploy/vm/ansible/ha_pair_playbook.yml
@@ -11,6 +11,13 @@
   roles:
     - iscsi-setup
 
+- hosts: iscsi,hdb0,hdb1
+  become: true
+  vars:
+    ntp_manage_config: true
+  roles:
+    - geerlingguy.ntp
+
 - hosts: win_bastion
   connection: winrm
   vars:

--- a/deploy/vm/ansible/requirements.yml
+++ b/deploy/vm/ansible/requirements.yml
@@ -1,0 +1,4 @@
+
+- name: Install NTP ansible role
+  src: geerlingguy.ntp
+  version: 1.6.2

--- a/deploy/vm/ansible/requirements.yml
+++ b/deploy/vm/ansible/requirements.yml
@@ -1,4 +1,3 @@
 
-- name: Install NTP ansible role
-  src: geerlingguy.ntp
+- src: geerlingguy.ntp
   version: 1.6.2

--- a/deploy/vm/modules/ha_pair/main.tf
+++ b/deploy/vm/modules/ha_pair/main.tf
@@ -176,6 +176,12 @@ resource "local_file" "write-config-to-json" {
   filename = "temp.json"
 }
 
+resource null_resource "install_ansible_roles" {
+  provisioner "local-exec" {
+    command = "ansible-galaxy install -r ../../ansible/requirements.yml"
+  }
+}
+
 module "configure_vm" {
   source = "../playbook-execution"
 


### PR DESCRIPTION
Although the errors are happening infrequently, this PR should fix the occasional issue that we get with the HA pair deployment where NTP is not installed.  According to SUSE, this is a requirement for the HA cluster even though the failure is not consistent.