### PR TITLE
Made naming unique for key vault

### DIFF
--- a/deploy/vm/modules/windows_bastion_host/certificates.tf
+++ b/deploy/vm/modules/windows_bastion_host/certificates.tf
@@ -1,7 +1,7 @@
 data "azurerm_client_config" "current" {}
 
 resource "azurerm_key_vault" "main" {
-  name                = "winbastion-keyvault"
+  name                = "kv-${lower(replace(replace(timestamp(),local.colon, local.empty_string), local.dash, local.empty_string))}"
   count               = "${var.windows_bastion ? 1 : 0}"
   location            = "${var.az_region}"
   resource_group_name = "${var.az_resource_group}"

--- a/deploy/vm/modules/windows_bastion_host/variables.tf
+++ b/deploy/vm/modules/windows_bastion_host/variables.tf
@@ -48,6 +48,9 @@ locals {
   all_ips      = "*"
   dynamic      = "Dynamic"
   empty_string = ""
+  colon        = ":"
+  dash         = "-"
+
   machine_name = "${lower(var.sap_sid)}-win-bastion"
   static       = "Static"
   winrm_port   = 5986


### PR DESCRIPTION
The name was not previously unique.  This caused failure every time you wanted to create a windows bastion host because someone has already created a keyvault called `winbastion-keyvault`.  It was not known that these names had to be unique.