### PR TITLE
Log the public IP and domain name of the bastion host in a file

### DIFF
--- a/deploy/vm/ansible/linux_bastion_host.yml
+++ b/deploy/vm/ansible/linux_bastion_host.yml
@@ -34,6 +34,18 @@
             - config_json: "{{ az_json }}"
       when: az_json.linux_bastion == true
 
+- hosts: localhost
+  tasks:
+    - name: Retrieve the public IP of the new linux bastion vm
+      azure_rm_publicipaddress_facts:
+        resource_group: "{{ az_json.az_resource_group }}"
+        name:  "{{ az_json.az_vm_name }}-pip"
+      register: lbh_metadata
+    - name: Log the information in a file
+      copy:
+        content: "{{ lbh_metadata }}"
+        dest: "pip-linux_bastion.json"
+
 - hosts: bastion_linux_group
   tasks:
     - include_vars:


### PR DESCRIPTION
This is an important information that we need to log in a file. For e.g., this will help the runner retrieve the public IP and domain name of the Linux bastion host , which is required for the failover test. Later as we move everything to ansible we can consolidate the logging mechanism