### PR TITLE
dbus-1-python does not need to be installed separately

### DIFF
--- a/deploy/vm/ansible/roles/iscsi-setup/tasks/main.yml
+++ b/deploy/vm/ansible/roles/iscsi-setup/tasks/main.yml
@@ -30,12 +30,6 @@
     state: present
     disable_recommends: no
 
-- name: Install dbus-1-python
-  package:
-    name: dbus-1-python
-    state: present
-    disable_recommends: no
-
 - name: Start and enable targetcli service
   service: name=targetcli enabled=yes state=started
 


### PR DESCRIPTION
installing dbus-1-python causes a conflict error with the existing python-dbus-python package which obsoletes dbus-1-python. I have tested this code with a failover test , which worked fine.