### PR TITLE
upgrading to Terraform 0.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,13 @@ In this simple example, we'll deploy a simple single-node SAP HANA instance (spe
    * **VM deployment:** Connect to your VM using an SSH client.
    * **Cloud Shell deployment:** From your Azure Portal, open your Cloud Shell (`>_` button in top bar).
    
+***Note**: Cloud Shell comes pre-installed with Terraform 0.12 which is now compatible with our scripts.
    
 2. Install the following software on your deployment machine as needed (not required for deployments on Cloud Shell):
    * [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest)
    * [Terraform](https://www.terraform.io/downloads.html)
+
+**Note**: The scripts have been tested with Terraform `v0.12.2` and `provider.azurerm v1.30.1`
    * [Ansible](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html)
    
    ***Note**: The scripts were built and tested with Ansible 2.6.x.*

--- a/README.md
+++ b/README.md
@@ -54,17 +54,10 @@ In this simple example, we'll deploy a simple single-node SAP HANA instance (spe
    * **VM deployment:** Connect to your VM using an SSH client.
    * **Cloud Shell deployment:** From your Azure Portal, open your Cloud Shell (`>_` button in top bar).
    
-   ***Note**: Cloud Shell comes pre-installed with Terraform 0.12 which, however, is not compatible with our scripts. To download the latest supported Terraform version 0.11.14 into your Cloud Shell home directory, please copy & paste the following command into a single line:*
    
-   `wget https://releases.hashicorp.com/terraform/0.11.14/terraform_0.11.14_linux_amd64.zip; unzip terraform_0.11.14_linux_amd64.zip; rm terraform_0.11.14_linux_amd64.zip`
-   
-   *To run Terraform 0.11.14 in later steps, you would execute `~/terraform` (instead of just `terraform`).*
-
 2. Install the following software on your deployment machine as needed (not required for deployments on Cloud Shell):
    * [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest)
    * [Terraform](https://www.terraform.io/downloads.html)
-   
-   ***Note**: The current version of the scripts uses Terraform 0.11; the latest compatible version (0.11.14) can be downloaded [here](https://releases.hashicorp.com/terraform/0.11.14/). We're currently working on updating our scripts to Terraform 0.12.*
    * [Ansible](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html)
    
    ***Note**: The scripts were built and tested with Ansible 2.6.x.*

--- a/deploy/vm/modules/common_setup/main.tf
+++ b/deploy/vm/modules/common_setup/main.tf
@@ -1,17 +1,17 @@
 # Create a resource group.
 
-resource null_resource "configuration-check" {
+resource "null_resource" "configuration-check" {
   provisioner "local-exec" {
     command = "ansible-playbook ../../ansible/configcheck.yml"
   }
 }
 
 resource "azurerm_resource_group" "hana-resource-group" {
-  depends_on = ["null_resource.configuration-check"]
-  name       = "${var.az_resource_group}"
-  location   = "${var.az_region}"
+  depends_on = [null_resource.configuration-check]
+  name       = var.az_resource_group
+  location   = var.az_region
 
-  tags {
+  tags = {
     environment = "Terraform SAP HANA deployment"
   }
 }
@@ -21,13 +21,14 @@ module "vnet" {
   version = "1.2.0"
 
   address_space       = "10.0.0.0/21"
-  location            = "${var.az_region}"
-  resource_group_name = "${var.az_resource_group}"
+  location            = var.az_region
+  resource_group_name = var.az_resource_group
   subnet_names        = ["hdb-subnet"]
   subnet_prefixes     = ["10.0.0.0/24"]
   vnet_name           = "${var.sap_sid}-vnet"
 
-  tags {
+  tags = {
     environment = "Terraform HANA vnet and subnet creation"
   }
 }
+

--- a/deploy/vm/modules/common_setup/nsg.tf
+++ b/deploy/vm/modules/common_setup/nsg.tf
@@ -1,8 +1,8 @@
 resource "azurerm_network_security_group" "sap_nsg" {
-  count               = "${var.use_existing_nsg ? 0 : 1}"
-  name                = "${local.new_nsg_name}"
-  resource_group_name = "${azurerm_resource_group.hana-resource-group.name}"
-  location            = "${azurerm_resource_group.hana-resource-group.location}"
+  count               = var.use_existing_nsg ? 0 : 1
+  name                = local.new_nsg_name
+  resource_group_name = azurerm_resource_group.hana-resource-group.name
+  location            = azurerm_resource_group.hana-resource-group.location
 
   security_rule {
     name                       = "SSH"
@@ -12,7 +12,7 @@ resource "azurerm_network_security_group" "sap_nsg" {
     protocol                   = "Tcp"
     source_port_range          = "*"
     destination_port_range     = 22
-    source_address_prefixes    = "${var.allow_ips}"
+    source_address_prefixes    = var.allow_ips
     destination_address_prefix = "*"
   }
 
@@ -24,42 +24,49 @@ resource "azurerm_network_security_group" "sap_nsg" {
     protocol                   = "Tcp"
     source_port_range          = "*"
     destination_port_range     = "3${var.sap_instancenum}00-3${var.sap_instancenum}99"
-    source_address_prefixes    = "${var.allow_ips}"
+    source_address_prefixes    = var.allow_ips
     destination_address_prefix = "*"
   }
 }
 
 resource "azurerm_network_security_rule" "hana-xsc-rules" {
-  count                       = "${var.use_existing_nsg ? 0 : (var.install_xsa ? 0 : length(local.hana_xsc_rules))}"
-  name                        = "${element(split(",", local.hana_xsc_rules[count.index]), 0)}"
-  priority                    = "${element(split(",", local.hana_xsc_rules[count.index]), 1)}"
+  count                       = var.use_existing_nsg ? 0 : var.install_xsa ? 0 : length(local.hana_xsc_rules)
+  name                        = element(split(",", local.hana_xsc_rules[count.index]), 0)
+  priority                    = element(split(",", local.hana_xsc_rules[count.index]), 1)
   direction                   = "Inbound"
   access                      = "Allow"
   protocol                    = "Tcp"
   source_port_range           = "*"
-  destination_port_range      = "${element(split(",", local.hana_xsc_rules[count.index]), 2)}"
-  source_address_prefixes     = "${local.all_ips}"
+  destination_port_range      = element(split(",", local.hana_xsc_rules[count.index]), 2)
+  source_address_prefixes     = local.all_ips
   destination_address_prefix  = "*"
-  resource_group_name         = "${azurerm_resource_group.hana-resource-group.name}"
-  network_security_group_name = "${azurerm_network_security_group.sap_nsg.name}"
+  resource_group_name         = azurerm_resource_group.hana-resource-group.name
+  network_security_group_name = azurerm_network_security_group.sap_nsg[0].name
 }
 
 resource "azurerm_network_security_rule" "hana-xsa-rules" {
-  count                       = "${var.use_existing_nsg ? 0 : (var.install_xsa ? length(local.hana_xsa_rules): 0)}"
-  name                        = "${element(split(",", local.hana_xsa_rules[count.index]), 0)}"
-  priority                    = "${element(split(",", local.hana_xsa_rules[count.index]), 1)}"
+  count                       = var.use_existing_nsg ? 0 : var.install_xsa ? length(local.hana_xsa_rules) : 0
+  name                        = element(split(",", local.hana_xsa_rules[count.index]), 0)
+  priority                    = element(split(",", local.hana_xsa_rules[count.index]), 1)
   direction                   = "Inbound"
   access                      = "Allow"
   protocol                    = "Tcp"
   source_port_range           = "*"
-  destination_port_range      = "${element(split(",", local.hana_xsa_rules[count.index]), 2)}"
-  source_address_prefixes     = "${local.all_ips}"
+  destination_port_range      = element(split(",", local.hana_xsa_rules[count.index]), 2)
+  source_address_prefixes     = local.all_ips
   destination_address_prefix  = "*"
-  resource_group_name         = "${azurerm_resource_group.hana-resource-group.name}"
-  network_security_group_name = "${azurerm_network_security_group.sap_nsg.name}"
+  resource_group_name         = azurerm_resource_group.hana-resource-group.name
+  network_security_group_name = azurerm_network_security_group.sap_nsg[0].name
 }
 
 data "azurerm_network_security_group" "nsg_info" {
-  name                = "${element(concat(azurerm_network_security_group.sap_nsg.*.name, list(var.existing_nsg_name)),0)}"
-  resource_group_name = "${var.use_existing_nsg ? var.existing_nsg_rg : azurerm_resource_group.hana-resource-group.name}"
+  name = element(
+    concat(
+      azurerm_network_security_group.sap_nsg.*.name,
+      [var.existing_nsg_name],
+    ),
+    0,
+  )
+  resource_group_name = var.use_existing_nsg ? var.existing_nsg_rg : azurerm_resource_group.hana-resource-group.name
 }
+

--- a/deploy/vm/modules/common_setup/outputs.tf
+++ b/deploy/vm/modules/common_setup/outputs.tf
@@ -1,19 +1,20 @@
 output "nsg_id" {
-  value = "${data.azurerm_network_security_group.nsg_info.id}"
+  value = data.azurerm_network_security_group.nsg_info.id
 }
 
 output "vnet_subnets" {
-  value = "${module.vnet.vnet_subnets}"
+  value = module.vnet.vnet_subnets
 }
 
 output "vnet_name" {
-  value = "${module.vnet.vnet_name}"
+  value = module.vnet.vnet_name
 }
 
 output "resource_group_name" {
-  value = "${azurerm_resource_group.hana-resource-group.name}"
+  value = azurerm_resource_group.hana-resource-group.name
 }
 
 output "resource_group_location" {
-  value = "${azurerm_resource_group.hana-resource-group.location}"
+  value = azurerm_resource_group.hana-resource-group.location
 }
+

--- a/deploy/vm/modules/common_setup/variables.tf
+++ b/deploy/vm/modules/common_setup/variables.tf
@@ -1,9 +1,10 @@
 variable "allow_ips" {
   description = "The ip addresses that will be allowed by the nsg"
-  type        = "list"
+  type        = list(string)
 }
 
-variable "az_region" {}
+variable "az_region" {
+}
 
 variable "az_resource_group" {
   description = "Which Azure resource group to deploy the HANA setup into.  i.e. <myResourceGroup>"
@@ -53,3 +54,4 @@ locals {
     "XSA,106,50000-59999",
   ]
 }
+

--- a/deploy/vm/modules/common_setup/versions.tf
+++ b/deploy/vm/modules/common_setup/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/deploy/vm/modules/common_setup/versions.tf
+++ b/deploy/vm/modules/common_setup/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.12, <= 0.12.2"
 }

--- a/deploy/vm/modules/create_hdb_node/main.tf
+++ b/deploy/vm/modules/create_hdb_node/main.tf
@@ -2,30 +2,33 @@
 module "nic_and_pip_setup" {
   source = "../generic_nic_and_pip"
 
-  az_resource_group         = "${var.az_resource_group}"
-  az_region                 = "${var.az_region}"
-  az_domain_name            = "${var.az_domain_name}"
-  name                      = "${local.machine_name}"
-  nsg_id                    = "${var.nsg_id}"
-  subnet_id                 = "${var.hana_subnet_id}"
-  private_ip_address        = "${var.private_ip_address}"
-  public_ip_allocation_type = "${var.public_ip_allocation_type}"
-  backend_ip_pool_ids       = "${var.backend_ip_pool_ids}"
+  az_resource_group         = var.az_resource_group
+  az_region                 = var.az_region
+  az_domain_name            = var.az_domain_name
+  name                      = local.machine_name
+  nsg_id                    = var.nsg_id
+  subnet_id                 = var.hana_subnet_id
+  private_ip_address        = var.private_ip_address
+  public_ip_allocation_type = var.public_ip_allocation_type
+  backend_ip_pool_ids       = var.backend_ip_pool_ids
 }
 
 # This module creates a VM and the disks that HANA db will need.
 module "vm_and_disk_creation" {
   source = "../generic_vm_and_disk_creation"
 
-  sshkey_path_public    = "${var.sshkey_path_public}"
-  az_resource_group     = "${var.az_resource_group}"
-  az_region             = "${var.az_region}"
-  storage_disk_sizes_gb = "${var.storage_disk_sizes_gb}"
-  machine_name          = "${local.machine_name}"
-  vm_user               = "${var.vm_user}"
-  vm_size               = "${var.vm_size}"
-  nic_id                = "${module.nic_and_pip_setup.nic_id}"
-  availability_set_id   = "${var.availability_set_id}"
+  sshkey_path_public    = var.sshkey_path_public
+  az_resource_group     = var.az_resource_group
+  az_region             = var.az_region
+  storage_disk_sizes_gb = var.storage_disk_sizes_gb
+  machine_name          = local.machine_name
+  vm_user               = var.vm_user
+  vm_size               = var.vm_size
+  nic_id                = module.nic_and_pip_setup.nic_id
+  availability_set_id   = var.availability_set_id
   machine_type          = "database-${var.az_resource_group}"
-  tags                  = "${map(local.vm_hdb_name, "")}"
+  tags = {
+    "${local.vm_hdb_name}" = ""
+  }
 }
+

--- a/deploy/vm/modules/create_hdb_node/outputs.tf
+++ b/deploy/vm/modules/create_hdb_node/outputs.tf
@@ -1,7 +1,8 @@
 output "machine_hostname" {
-  value = "${module.vm_and_disk_creation.machine_hostname}"
+  value = module.vm_and_disk_creation.machine_hostname
 }
 
 output "fqdn" {
-  value = "${module.nic_and_pip_setup.fqdn}"
+  value = module.nic_and_pip_setup.fqdn
 }
+

--- a/deploy/vm/modules/create_hdb_node/variables.tf
+++ b/deploy/vm/modules/create_hdb_node/variables.tf
@@ -1,20 +1,21 @@
 variable "availability_set_id" {
   description = "The id associated with the availability set to put this VM into."
-  default     = ""                                                                 # Empty string denotes that this VM is not in an availability set.
+  default     = "" # Empty string denotes that this VM is not in an availability set.
 }
 
 variable "az_domain_name" {
   description = "Prefix to be used in the domain name"
 }
 
-variable "az_region" {}
+variable "az_region" {
+}
 
 variable "az_resource_group" {
   description = "Which Azure resource group to deploy the HANA setup into.  i.e. <myResourceGroup>"
 }
 
 variable "backend_ip_pool_ids" {
-  type        = "list"
+  type        = list(string)
   description = "The ids that associate the load balancer's back end IP pool with this VM's NIC."
   default     = []
 }
@@ -49,7 +50,7 @@ variable "sshkey_path_public" {
 }
 
 variable "storage_disk_sizes_gb" {
-  type        = "list"
+  type        = list(string)
   description = "List disk sizes in GB for all disks this VM will need"
 }
 
@@ -65,3 +66,4 @@ locals {
   machine_name = "${lower(var.sap_sid)}-hdb${var.hdb_num}"
   vm_hdb_name  = "hdb${var.hdb_num}"
 }
+

--- a/deploy/vm/modules/create_hdb_node/versions.tf
+++ b/deploy/vm/modules/create_hdb_node/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/deploy/vm/modules/create_hdb_node/versions.tf
+++ b/deploy/vm/modules/create_hdb_node/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.12, <= 0.12.2"
 }

--- a/deploy/vm/modules/generic_nic_and_pip/main.tf
+++ b/deploy/vm/modules/generic_nic_and_pip/main.tf
@@ -1,37 +1,38 @@
 # Create public IPs
 resource "azurerm_public_ip" "pip" {
   name                         = "${var.name}-pip"
-  location                     = "${var.az_region}"
-  resource_group_name          = "${var.az_resource_group}"
-  public_ip_address_allocation = "${var.public_ip_allocation_type}"
+  location                     = var.az_region
+  resource_group_name          = var.az_resource_group
+  public_ip_address_allocation = var.public_ip_allocation_type
   domain_name_label            = "${lower(var.name)}-${lower(var.az_domain_name)}"
 
   idle_timeout_in_minutes = 30
 
-  tags {
+  tags = {
     environment = "Terraform SAP HANA deployment"
   }
 }
 
 # Create network interface
 resource "azurerm_network_interface" "nic" {
-  depends_on                = ["azurerm_public_ip.pip"]
+  depends_on                = [azurerm_public_ip.pip]
   name                      = "${var.name}-nic"
-  location                  = "${var.az_region}"
-  resource_group_name       = "${var.az_resource_group}"
-  network_security_group_id = "${var.nsg_id}"
+  location                  = var.az_region
+  resource_group_name       = var.az_resource_group
+  network_security_group_id = var.nsg_id
 
   ip_configuration {
     name      = "${var.name}-nic-configuration"
-    subnet_id = "${var.subnet_id}"
+    subnet_id = var.subnet_id
 
-    load_balancer_backend_address_pools_ids = ["${var.backend_ip_pool_ids}"]
-    private_ip_address_allocation           = "${var.private_ip_address != local.empty_string ? local.static : local.dynamic}"
-    private_ip_address                      = "${var.private_ip_address}"
-    public_ip_address_id                    = "${azurerm_public_ip.pip.id}"
+    load_balancer_backend_address_pools_ids = var.backend_ip_pool_ids
+    private_ip_address_allocation           = var.private_ip_address != local.empty_string ? local.static : local.dynamic
+    private_ip_address                      = var.private_ip_address
+    public_ip_address_id                    = azurerm_public_ip.pip.id
   }
 
-  tags {
+  tags = {
     environment = "Terraform SAP HANA deployment"
   }
 }
+

--- a/deploy/vm/modules/generic_nic_and_pip/outputs.tf
+++ b/deploy/vm/modules/generic_nic_and_pip/outputs.tf
@@ -1,19 +1,20 @@
 output "fqdn" {
   description = "The fully qualified domain name associated with the public IP that was created."
-  value       = "${azurerm_public_ip.pip.fqdn}"
+  value       = azurerm_public_ip.pip.fqdn
 }
 
 output "pip_name" {
   description = "name of the public ip"
-  value       = "${azurerm_public_ip.pip.name}"
+  value       = azurerm_public_ip.pip.name
 }
 
 output "nic_id" {
   description = "The id of the network interface card will be needed to attach it to the VM."
-  value       = "${azurerm_network_interface.nic.id}"
+  value       = azurerm_network_interface.nic.id
 }
 
 output "nic_name" {
   description = "The name of the network interface"
-  value       = "${azurerm_network_interface.nic.name}"
+  value       = azurerm_network_interface.nic.name
 }
+

--- a/deploy/vm/modules/generic_nic_and_pip/variables.tf
+++ b/deploy/vm/modules/generic_nic_and_pip/variables.tf
@@ -1,4 +1,5 @@
-variable "az_region" {}
+variable "az_region" {
+}
 
 variable "az_resource_group" {
   description = "Which Azure resource group to deploy the HANA setup into.  i.e. <myResourceGroup>"
@@ -9,7 +10,7 @@ variable "az_domain_name" {
 }
 
 variable "backend_ip_pool_ids" {
-  type        = "list"
+  type        = list(string)
   description = "The ids that associate the load balancer's back end IP pool with this NIC."
   default     = []
 }
@@ -40,3 +41,4 @@ locals {
   empty_string = ""
   static       = "Static"
 }
+

--- a/deploy/vm/modules/generic_nic_and_pip/versions.tf
+++ b/deploy/vm/modules/generic_nic_and_pip/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/deploy/vm/modules/generic_nic_and_pip/versions.tf
+++ b/deploy/vm/modules/generic_nic_and_pip/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.12, <= 0.12.2"
 }

--- a/deploy/vm/modules/generic_vm_and_disk_creation/main.tf
+++ b/deploy/vm/modules/generic_vm_and_disk_creation/main.tf
@@ -2,7 +2,7 @@
 resource "random_id" "randomId" {
   keepers = {
     # Generate a new id only when a new resource group is defined.
-    resource_group = "${var.az_resource_group}"
+    resource_group = var.az_resource_group
   }
 
   byte_length = 8
@@ -11,44 +11,44 @@ resource "random_id" "randomId" {
 # Create storage account for boot diagnostics
 resource "azurerm_storage_account" "bootdiagstorageaccount" {
   name                     = "diag${random_id.randomId.hex}"
-  resource_group_name      = "${var.az_resource_group}"
-  location                 = "${var.az_region}"
+  resource_group_name      = var.az_resource_group
+  location                 = var.az_region
   account_tier             = "Standard"
   account_replication_type = "LRS"
 
-  tags {
+  tags = {
     environment = "Terraform SAP HANA deployment"
   }
 }
 
 # All disks that are in the storage_disk_sizes_gb list will be created
 resource "azurerm_managed_disk" "disk" {
-  count                = "${length(var.storage_disk_sizes_gb)}"
+  count                = length(var.storage_disk_sizes_gb)
   name                 = "${var.machine_name}-disk${count.index}"
-  location             = "${var.az_region}"
+  location             = var.az_region
   storage_account_type = "Premium_LRS"
-  resource_group_name  = "${var.az_resource_group}"
-  disk_size_gb         = "${var.storage_disk_sizes_gb[count.index]}"
+  resource_group_name  = var.az_resource_group
+  disk_size_gb         = var.storage_disk_sizes_gb[count.index]
   create_option        = "Empty"
 }
 
 # All of the disks created above will now be attached to the VM
 resource "azurerm_virtual_machine_data_disk_attachment" "disk" {
-  count              = "${length(var.storage_disk_sizes_gb)}"
-  virtual_machine_id = "${azurerm_virtual_machine.vm.id}"
-  managed_disk_id    = "${element(azurerm_managed_disk.disk.*.id, count.index)}"
-  lun                = "${count.index}"
+  count              = length(var.storage_disk_sizes_gb)
+  virtual_machine_id = azurerm_virtual_machine.vm.id
+  managed_disk_id    = element(azurerm_managed_disk.disk.*.id, count.index)
+  lun                = count.index
   caching            = "ReadWrite"
 }
 
 # Create virtual machine
 resource "azurerm_virtual_machine" "vm" {
-  name                          = "${var.machine_name}"
-  location                      = "${var.az_region}"
-  resource_group_name           = "${var.az_resource_group}"
-  network_interface_ids         = ["${var.nic_id}"]
-  availability_set_id           = "${var.availability_set_id}"
-  vm_size                       = "${var.vm_size}"
+  name                          = var.machine_name
+  location                      = var.az_region
+  resource_group_name           = var.az_resource_group
+  network_interface_ids         = [var.nic_id]
+  availability_set_id           = var.availability_set_id
+  vm_size                       = var.vm_size
   delete_os_disk_on_termination = "true"
 
   storage_os_disk {
@@ -66,8 +66,8 @@ resource "azurerm_virtual_machine" "vm" {
   }
 
   os_profile {
-    computer_name  = "${var.machine_name}"
-    admin_username = "${var.vm_user}"
+    computer_name  = var.machine_name
+    admin_username = var.vm_user
   }
 
   os_profile_linux_config {
@@ -75,15 +75,21 @@ resource "azurerm_virtual_machine" "vm" {
 
     ssh_keys {
       path     = "/home/${var.vm_user}/.ssh/authorized_keys"
-      key_data = "${file("${var.sshkey_path_public}")}"
+      key_data = file(var.sshkey_path_public)
     }
   }
 
   boot_diagnostics {
     enabled = "true"
 
-    storage_uri = "${azurerm_storage_account.bootdiagstorageaccount.primary_blob_endpoint}"
+    storage_uri = azurerm_storage_account.bootdiagstorageaccount.primary_blob_endpoint
   }
 
-  tags = "${merge(map(var.machine_type, ""), var.tags)}"
+  tags = merge(
+    {
+      "${var.machine_type}" = ""
+    },
+    var.tags,
+  )
 }
+

--- a/deploy/vm/modules/generic_vm_and_disk_creation/outputs.tf
+++ b/deploy/vm/modules/generic_vm_and_disk_creation/outputs.tf
@@ -1,5 +1,6 @@
 output "machine_hostname" {
-  depends_on = ["azurerm_virtual_machine_data_disk_attachment.disk"]
+  depends_on = [azurerm_virtual_machine_data_disk_attachment.disk]
 
-  value = "${var.machine_name}"
+  value = var.machine_name
 }
+

--- a/deploy/vm/modules/generic_vm_and_disk_creation/variables.tf
+++ b/deploy/vm/modules/generic_vm_and_disk_creation/variables.tf
@@ -3,7 +3,8 @@ variable "availability_set_id" {
   default     = ""
 }
 
-variable "az_region" {}
+variable "az_region" {
+}
 
 variable "az_resource_group" {
   description = "Which Azure resource group to deploy the HANA setup into.  i.e. <myResourceGroup>"
@@ -26,12 +27,12 @@ variable "sshkey_path_public" {
 }
 
 variable "storage_disk_sizes_gb" {
-  type        = "list"
+  type        = list(string)
   description = "List disk sizes in GB for all disks this VM will need"
 }
 
 variable "tags" {
-  type        = "map"
+  type        = map(string)
   description = "tags to add to the machine"
   default     = {}
 }
@@ -43,3 +44,4 @@ variable "vm_size" {
 variable "vm_user" {
   description = "The username of your VM."
 }
+

--- a/deploy/vm/modules/generic_vm_and_disk_creation/versions.tf
+++ b/deploy/vm/modules/generic_vm_and_disk_creation/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/deploy/vm/modules/generic_vm_and_disk_creation/versions.tf
+++ b/deploy/vm/modules/generic_vm_and_disk_creation/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.12, <= 0.12.2"
 }

--- a/deploy/vm/modules/ha_pair/main.tf
+++ b/deploy/vm/modules/ha_pair/main.tf
@@ -1,50 +1,51 @@
 # Configure the Microsoft Azure Provider
-provider "azurerm" {}
+provider "azurerm" {
+  version = "~> 1.30.1"
+}
 
 module "common_setup" {
   source = "../common_setup"
 
-  allow_ips         = "${var.allow_ips}"
-  az_region         = "${var.az_region}"
-  az_resource_group = "${var.az_resource_group}"
-  existing_nsg_name = "${var.existing_nsg_name}"
-  existing_nsg_rg   = "${var.existing_nsg_rg}"
-  install_xsa       = "${var.install_xsa}"
-  sap_instancenum   = "${var.sap_instancenum}"
-  sap_instancenum   = "${var.sap_instancenum}"
-  sap_sid           = "${var.sap_sid}"
-  use_existing_nsg  = "${var.use_existing_nsg}"
+  allow_ips         = var.allow_ips
+  az_region         = var.az_region
+  az_resource_group = var.az_resource_group
+  existing_nsg_name = var.existing_nsg_name
+  existing_nsg_rg   = var.existing_nsg_rg
+  install_xsa       = var.install_xsa
+  sap_instancenum   = var.sap_instancenum
+  sap_sid           = var.sap_sid
+  use_existing_nsg  = var.use_existing_nsg
 }
 
 resource "azurerm_availability_set" "ha-pair-availset" {
   name                         = "hanaHAPairAvailabilitySet"
-  location                     = "${module.common_setup.resource_group_location}"
-  resource_group_name          = "${module.common_setup.resource_group_name}"
+  location                     = module.common_setup.resource_group_location
+  resource_group_name          = module.common_setup.resource_group_name
   platform_update_domain_count = 20
   platform_fault_domain_count  = 2
   managed                      = true
 
-  tags {
+  tags = {
     environment = "HA-Pair deployment"
   }
 }
 
 resource "azurerm_lb" "ha-pair-lb" {
   name                = "ha-pair-lb"
-  location            = "${var.az_region}"
-  resource_group_name = "${module.common_setup.resource_group_name}"
+  location            = var.az_region
+  resource_group_name = module.common_setup.resource_group_name
 
   frontend_ip_configuration {
     name                          = "hsr-front"
-    subnet_id                     = "${module.common_setup.vnet_subnets[0]}"
+    subnet_id                     = module.common_setup.vnet_subnets[0]
     private_ip_address_allocation = "Static"
-    private_ip_address            = "${var.private_ip_address_lb_frontend}"
+    private_ip_address            = var.private_ip_address_lb_frontend
   }
 }
 
 resource "azurerm_lb_probe" "health-probe" {
-  resource_group_name = "${module.common_setup.resource_group_name}"
-  loadbalancer_id     = "${azurerm_lb.ha-pair-lb.id}"
+  resource_group_name = module.common_setup.resource_group_name
+  loadbalancer_id     = azurerm_lb.ha-pair-lb.id
   name                = "health-probe"
   port                = "625${var.sap_instancenum}"
   interval_in_seconds = 5
@@ -52,22 +53,22 @@ resource "azurerm_lb_probe" "health-probe" {
 }
 
 resource "azurerm_lb_backend_address_pool" "availability-back-pool" {
-  resource_group_name = "${module.common_setup.resource_group_name}"
-  loadbalancer_id     = "${azurerm_lb.ha-pair-lb.id}"
+  resource_group_name = module.common_setup.resource_group_name
+  loadbalancer_id     = azurerm_lb.ha-pair-lb.id
   name                = "BackEndAddressPool-HA"
 }
 
 # These are the load balancing rules specifically for HANA1's HA pair pacemaker
 resource "azurerm_lb_rule" "lb-hana1-rule" {
-  count                          = "${var.useHana2 ? 0 : length(local.hana1_lb_ports)}"
+  count                          = var.useHana2 ? 0 : length(local.hana1_lb_ports)
   name                           = "lb-rule-${count.index}"
-  resource_group_name            = "${module.common_setup.resource_group_name}"
-  loadbalancer_id                = "${azurerm_lb.ha-pair-lb.id}"
+  resource_group_name            = module.common_setup.resource_group_name
+  loadbalancer_id                = azurerm_lb.ha-pair-lb.id
   protocol                       = "Tcp"
-  frontend_port                  = "${local.hana1_lb_ports[count.index]}"
-  backend_port                   = "${local.hana1_lb_ports[count.index]}"
-  backend_address_pool_id        = "${azurerm_lb_backend_address_pool.availability-back-pool.id}"
-  probe_id                       = "${azurerm_lb_probe.health-probe.id}"
+  frontend_port                  = local.hana1_lb_ports[count.index]
+  backend_port                   = local.hana1_lb_ports[count.index]
+  backend_address_pool_id        = azurerm_lb_backend_address_pool.availability-back-pool.id
+  probe_id                       = azurerm_lb_probe.health-probe.id
   idle_timeout_in_minutes        = 30
   enable_floating_ip             = true
   frontend_ip_configuration_name = "hsr-front"
@@ -75,15 +76,15 @@ resource "azurerm_lb_rule" "lb-hana1-rule" {
 
 # These are the load balancing rules specifically for HANA2's HA pair pacemaker
 resource "azurerm_lb_rule" "lb-hana2-rule" {
-  count                          = "${var.useHana2 ? length(local.hana2_lb_ports) : 0}"
+  count                          = var.useHana2 ? length(local.hana2_lb_ports) : 0
   name                           = "lb-rule-${count.index}"
-  resource_group_name            = "${module.common_setup.resource_group_name}"
-  loadbalancer_id                = "${azurerm_lb.ha-pair-lb.id}"
+  resource_group_name            = module.common_setup.resource_group_name
+  loadbalancer_id                = azurerm_lb.ha-pair-lb.id
   protocol                       = "Tcp"
-  frontend_port                  = "${local.hana2_lb_ports[count.index]}"
-  backend_port                   = "${local.hana2_lb_ports[count.index]}"
-  backend_address_pool_id        = "${azurerm_lb_backend_address_pool.availability-back-pool.id}"
-  probe_id                       = "${azurerm_lb_probe.health-probe.id}"
+  frontend_port                  = local.hana2_lb_ports[count.index]
+  backend_port                   = local.hana2_lb_ports[count.index]
+  backend_address_pool_id        = azurerm_lb_backend_address_pool.availability-back-pool.id
+  probe_id                       = azurerm_lb_probe.health-probe.id
   idle_timeout_in_minutes        = 30
   enable_floating_ip             = true
   frontend_ip_configuration_name = "hsr-front"
@@ -92,83 +93,83 @@ resource "azurerm_lb_rule" "lb-hana2-rule" {
 module "create_hdb0" {
   source = "../create_hdb_node"
 
-  availability_set_id       = "${azurerm_availability_set.ha-pair-availset.id}"
-  az_resource_group         = "${module.common_setup.resource_group_name}"
-  az_region                 = "${module.common_setup.resource_group_location}"
-  az_domain_name            = "${var.az_domain_name}"
-  backend_ip_pool_ids       = ["${azurerm_lb_backend_address_pool.availability-back-pool.id}"]
+  availability_set_id       = azurerm_availability_set.ha-pair-availset.id
+  az_resource_group         = module.common_setup.resource_group_name
+  az_region                 = module.common_setup.resource_group_location
+  az_domain_name            = var.az_domain_name
+  backend_ip_pool_ids       = [azurerm_lb_backend_address_pool.availability-back-pool.id]
   hdb_num                   = "0"
-  hana_subnet_id            = "${module.common_setup.vnet_subnets[0]}"
-  nsg_id                    = "${module.common_setup.nsg_id}"
-  private_ip_address        = "${var.private_ip_address_hdb0}"
-  public_ip_allocation_type = "${var.public_ip_allocation_type}"
-  sap_sid                   = "${var.sap_sid}"
-  sshkey_path_public        = "${var.sshkey_path_public}"
-  storage_disk_sizes_gb     = "${var.storage_disk_sizes_gb}"
-  vm_user                   = "${var.vm_user}"
-  vm_size                   = "${var.vm_size}"
+  hana_subnet_id            = module.common_setup.vnet_subnets[0]
+  nsg_id                    = module.common_setup.nsg_id
+  private_ip_address        = var.private_ip_address_hdb0
+  public_ip_allocation_type = var.public_ip_allocation_type
+  sap_sid                   = var.sap_sid
+  sshkey_path_public        = var.sshkey_path_public
+  storage_disk_sizes_gb     = var.storage_disk_sizes_gb
+  vm_user                   = var.vm_user
+  vm_size                   = var.vm_size
 }
 
 module "create_hdb1" {
   source = "../create_hdb_node"
 
-  availability_set_id       = "${azurerm_availability_set.ha-pair-availset.id}"
-  az_resource_group         = "${module.common_setup.resource_group_name}"
-  az_region                 = "${module.common_setup.resource_group_location}"
-  az_domain_name            = "${var.az_domain_name}"
-  backend_ip_pool_ids       = ["${azurerm_lb_backend_address_pool.availability-back-pool.id}"]
+  availability_set_id       = azurerm_availability_set.ha-pair-availset.id
+  az_resource_group         = module.common_setup.resource_group_name
+  az_region                 = module.common_setup.resource_group_location
+  az_domain_name            = var.az_domain_name
+  backend_ip_pool_ids       = [azurerm_lb_backend_address_pool.availability-back-pool.id]
   hdb_num                   = "1"
-  hana_subnet_id            = "${module.common_setup.vnet_subnets[0]}"
-  nsg_id                    = "${module.common_setup.nsg_id}"
-  private_ip_address        = "${var.private_ip_address_hdb1}"
-  public_ip_allocation_type = "${var.public_ip_allocation_type}"
-  sap_sid                   = "${var.sap_sid}"
-  sshkey_path_public        = "${var.sshkey_path_public}"
-  storage_disk_sizes_gb     = "${var.storage_disk_sizes_gb}"
-  vm_user                   = "${var.vm_user}"
-  vm_size                   = "${var.vm_size}"
+  hana_subnet_id            = module.common_setup.vnet_subnets[0]
+  nsg_id                    = module.common_setup.nsg_id
+  private_ip_address        = var.private_ip_address_hdb1
+  public_ip_allocation_type = var.public_ip_allocation_type
+  sap_sid                   = var.sap_sid
+  sshkey_path_public        = var.sshkey_path_public
+  storage_disk_sizes_gb     = var.storage_disk_sizes_gb
+  vm_user                   = var.vm_user
+  vm_size                   = var.vm_size
 }
 
 module "nic_and_pip_setup_iscsi" {
   source = "../generic_nic_and_pip"
 
-  az_region                 = "${module.common_setup.resource_group_location}"
-  az_resource_group         = "${module.common_setup.resource_group_name}"
-  az_domain_name            = "${var.az_domain_name}"
+  az_region                 = module.common_setup.resource_group_location
+  az_resource_group         = module.common_setup.resource_group_name
+  az_domain_name            = var.az_domain_name
   name                      = "iscsi"
-  nsg_id                    = "${module.common_setup.nsg_id}"
-  private_ip_address        = "${var.private_ip_address_iscsi}"
-  public_ip_allocation_type = "${var.public_ip_allocation_type}"
-  subnet_id                 = "${module.common_setup.vnet_subnets[0]}"
+  nsg_id                    = module.common_setup.nsg_id
+  private_ip_address        = var.private_ip_address_iscsi
+  public_ip_allocation_type = var.public_ip_allocation_type
+  subnet_id                 = module.common_setup.vnet_subnets[0]
 }
 
 module "vm_and_disk_creation_iscsi" {
   source = "../generic_vm_and_disk_creation"
 
-  sshkey_path_public    = "${var.sshkey_path_public}"
-  az_resource_group     = "${module.common_setup.resource_group_name}"
-  az_region             = "${module.common_setup.resource_group_location}"
+  sshkey_path_public    = var.sshkey_path_public
+  az_resource_group     = module.common_setup.resource_group_name
+  az_region             = module.common_setup.resource_group_location
   storage_disk_sizes_gb = [16]
   machine_name          = "${var.az_domain_name}-iscsi"
-  vm_user               = "${var.vm_user}"
+  vm_user               = var.vm_user
   vm_size               = "Standard_D2s_v3"
-  nic_id                = "${module.nic_and_pip_setup_iscsi.nic_id}"
-  availability_set_id   = "${azurerm_availability_set.ha-pair-availset.id}"
+  nic_id                = module.nic_and_pip_setup_iscsi.nic_id
+  availability_set_id   = azurerm_availability_set.ha-pair-availset.id
   machine_type          = "iscsi"
 }
 
 module "windows_bastion_host" {
   source             = "../windows_bastion_host"
-  allow_ips          = "${var.allow_ips}"
-  az_domain_name     = "${var.az_domain_name}"
-  az_resource_group  = "${module.common_setup.resource_group_name}"
-  az_region          = "${var.az_region}"
-  sap_sid            = "${var.sap_sid}"
-  subnet_id          = "${module.common_setup.vnet_subnets[0]}"
-  bastion_username   = "${var.bastion_username_windows}"
-  private_ip_address = "${var.private_ip_address_windows_bastion}"
-  pw_bastion         = "${var.pw_bastion_windows}"
-  windows_bastion    = "${var.windows_bastion}"
+  allow_ips          = var.allow_ips
+  az_domain_name     = var.az_domain_name
+  az_resource_group  = module.common_setup.resource_group_name
+  az_region          = var.az_region
+  sap_sid            = var.sap_sid
+  subnet_id          = module.common_setup.vnet_subnets[0]
+  bastion_username   = var.bastion_username_windows
+  private_ip_address = var.private_ip_address_windows_bastion
+  pw_bastion         = var.pw_bastion_windows
+  windows_bastion    = var.windows_bastion
 }
 
 # Write the required configuration variable to a file, that will be used by the Ansible playbook for creating a linux bastion host
@@ -177,7 +178,7 @@ resource "local_file" "write-config-to-json" {
   filename = "temp.json"
 }
 
-resource null_resource "install_ansible_roles" {
+resource "null_resource" "install_ansible_roles" {
   provisioner "local-exec" {
     command = "ansible-galaxy install -r ../../ansible/requirements.yml"
   }
@@ -186,52 +187,52 @@ resource null_resource "install_ansible_roles" {
 module "configure_vm" {
   source = "../playbook-execution"
 
-  ansible_playbook_path          = "${var.ansible_playbook_path}"
-  az_resource_group              = "${module.common_setup.resource_group_name}"
-  sshkey_path_private            = "${var.sshkey_path_private}"
-  sap_instancenum                = "${var.sap_instancenum}"
-  sap_sid                        = "${var.sap_sid}"
-  vm_user                        = "${var.vm_user}"
-  url_sap_sapcar                 = "${var.url_sap_sapcar_linux}"
-  url_sap_hdbserver              = "${var.url_sap_hdbserver}"
-  private_ip_address_hdb0        = "${var.private_ip_address_hdb0}"
-  private_ip_address_hdb1        = "${var.private_ip_address_hdb1}"
-  private_ip_address_lb_frontend = "${var.private_ip_address_lb_frontend}"
-  pw_hacluster                   = "${var.pw_hacluster}"
-  pw_os_sapadm                   = "${var.pw_os_sapadm}"
-  pw_os_sidadm                   = "${var.pw_os_sidadm}"
-  pw_db_system                   = "${var.pw_db_system}"
-  useHana2                       = "${var.useHana2}"
+  ansible_playbook_path          = var.ansible_playbook_path
+  az_resource_group              = module.common_setup.resource_group_name
+  sshkey_path_private            = var.sshkey_path_private
+  sap_instancenum                = var.sap_instancenum
+  sap_sid                        = var.sap_sid
+  vm_user                        = var.vm_user
+  url_sap_sapcar                 = var.url_sap_sapcar_linux
+  url_sap_hdbserver              = var.url_sap_hdbserver
+  private_ip_address_hdb0        = var.private_ip_address_hdb0
+  private_ip_address_hdb1        = var.private_ip_address_hdb1
+  private_ip_address_lb_frontend = var.private_ip_address_lb_frontend
+  pw_hacluster                   = var.pw_hacluster
+  pw_os_sapadm                   = var.pw_os_sapadm
+  pw_os_sidadm                   = var.pw_os_sidadm
+  pw_db_system                   = var.pw_db_system
+  useHana2                       = var.useHana2
   vms_configured                 = "${module.create_hdb0.machine_hostname}, ${module.create_hdb1.machine_hostname}, ${module.vm_and_disk_creation_iscsi.machine_hostname}"
-  hana1_db_mode                  = "${var.hana1_db_mode}"
-  url_xsa_runtime                = "${var.url_xsa_runtime}"
-  url_di_core                    = "${var.url_di_core}"
-  url_sapui5                     = "${var.url_sapui5}"
-  url_portal_services            = "${var.url_portal_services}"
-  url_xs_services                = "${var.url_xs_services}"
-  url_shine_xsa                  = "${var.url_shine_xsa}"
-  url_xsa_hrtt                   = "${var.url_xsa_hrtt}"
-  url_xsa_webide                 = "${var.url_xsa_webide}"
-  url_xsa_mta                    = "${var.url_xsa_mta}"
-  pwd_db_xsaadmin                = "${var.pwd_db_xsaadmin}"
-  pwd_db_tenant                  = "${var.pwd_db_tenant}"
-  pwd_db_shine                   = "${var.pwd_db_shine}"
-  email_shine                    = "${var.email_shine}"
-  url_cockpit                    = "${var.url_cockpit}"
-  install_xsa                    = "${var.install_xsa}"
-  install_shine                  = "${var.install_shine}"
-  install_cockpit                = "${var.install_cockpit}"
-  install_webide                 = "${var.install_webide}"
-  url_sapcar_windows             = "${var.url_sapcar_windows}"
-  url_hana_studio_windows        = "${var.url_hana_studio_windows}"
-  bastion_username_windows       = "${var.bastion_username_windows}"
-  pw_bastion_windows             = "${var.pw_bastion_windows}"
+  hana1_db_mode                  = var.hana1_db_mode
+  url_xsa_runtime                = var.url_xsa_runtime
+  url_di_core                    = var.url_di_core
+  url_sapui5                     = var.url_sapui5
+  url_portal_services            = var.url_portal_services
+  url_xs_services                = var.url_xs_services
+  url_shine_xsa                  = var.url_shine_xsa
+  url_xsa_hrtt                   = var.url_xsa_hrtt
+  url_xsa_webide                 = var.url_xsa_webide
+  url_xsa_mta                    = var.url_xsa_mta
+  pwd_db_xsaadmin                = var.pwd_db_xsaadmin
+  pwd_db_tenant                  = var.pwd_db_tenant
+  pwd_db_shine                   = var.pwd_db_shine
+  email_shine                    = var.email_shine
+  url_cockpit                    = var.url_cockpit
+  install_xsa                    = var.install_xsa
+  install_shine                  = var.install_shine
+  install_cockpit                = var.install_cockpit
+  install_webide                 = var.install_webide
+  url_sapcar_windows             = var.url_sapcar_windows
+  url_hana_studio_windows        = var.url_hana_studio_windows
+  bastion_username_windows       = var.bastion_username_windows
+  pw_bastion_windows             = var.pw_bastion_windows
 }
 
 # Delete the linux bastion host vm
-resource null_resource "destroy-vm" {
+resource "null_resource" "destroy-vm" {
   provisioner "local-exec" {
-    when = "destroy"
+    when = destroy
 
     command = <<EOT
                OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES \
@@ -241,11 +242,12 @@ resource null_resource "destroy-vm" {
 	       --private-key '${var.sshkey_path_private}' \
 	       --extra-vars="{az_resource_group: \"${module.common_setup.resource_group_name}\", az_vm_name:  \"${local.linux_vm_name}\"}" ../../ansible/delete_bastion_linux.yml
 EOT
+
   }
 }
 
-resource null_resource "delete-iscsi-public-ip" {
-  depends_on = ["module.configure_vm"]
+resource "null_resource" "delete-iscsi-public-ip" {
+  depends_on = [module.configure_vm]
 
   provisioner "local-exec" {
     command = <<EOT
@@ -256,5 +258,7 @@ resource null_resource "delete-iscsi-public-ip" {
 	       --private-key '${var.sshkey_path_private}' \
 	       --extra-vars="{ ip_config_name: \"iscsi-nic-configuration\",azure_nic: \"${module.nic_and_pip_setup_iscsi.nic_name}\", azure_vnet:  \"${module.common_setup.vnet_name}\", azure_subnet: \"hdb-subnet\", azure_nsg: \"${module.common_setup.nsg_id}\", azure_private_ip: \"${var.private_ip_address_iscsi}\", azure_resource_group: \"${module.common_setup.resource_group_name}\", azure_public_ip:  \"${module.nic_and_pip_setup_iscsi.pip_name}\"}" ../../ansible/delete_iscsi_public_ip.yml
 EOT
-  }
+
 }
+}
+

--- a/deploy/vm/modules/ha_pair/outputs.tf
+++ b/deploy/vm/modules/ha_pair/outputs.tf
@@ -1,27 +1,28 @@
 output "hdb0_ip" {
-  value = "${module.create_hdb0.fqdn}"
+  value = module.create_hdb0.fqdn
 }
 
 output "hdb1_ip" {
-  value = "${module.create_hdb1.fqdn}"
+  value = module.create_hdb1.fqdn
 }
 
 output "hdb_vm_user" {
-  value = "${var.vm_user}"
+  value = var.vm_user
 }
 
 output "windows_bastion_ip" {
-  value = "${module.windows_bastion_host.ip}"
+  value = module.windows_bastion_host.ip
 }
 
 output "windows_bastion_user" {
-  value = "${var.bastion_username_windows}"
+  value = var.bastion_username_windows
 }
 
 output "primary_hdb" {
-  value = "${module.create_hdb0.machine_hostname}"
+  value = module.create_hdb0.machine_hostname
 }
 
 output "secondary_hdb" {
-  value = "${module.create_hdb1.machine_hostname}"
+  value = module.create_hdb1.machine_hostname
 }
+

--- a/deploy/vm/modules/ha_pair/variables.tf
+++ b/deploy/vm/modules/ha_pair/variables.tf
@@ -12,7 +12,8 @@ variable "az_domain_name" {
   description = "Prefix to be used in the domain name"
 }
 
-variable "az_region" {}
+variable "az_region" {
+}
 
 variable "az_resource_group" {
   description = "Which Azure resource group to deploy the HANA setup into.  i.e. <myResourceGroup>"
@@ -98,7 +99,7 @@ variable "pw_db_system" {
 }
 
 variable "pw_hacluster" {
-  type        = "string"
+  type        = string
   description = "Password for the HA cluster nodes"
 }
 
@@ -172,7 +173,7 @@ variable "url_portal_services" {
 }
 
 variable "url_sap_hdbserver" {
-  type        = "string"
+  type        = string
   description = "The url that points to the HDB server 122.17 bits"
 }
 
@@ -272,3 +273,4 @@ locals {
     "3${var.sap_instancenum}42",
   ]
 }
+

--- a/deploy/vm/modules/ha_pair/versions.tf
+++ b/deploy/vm/modules/ha_pair/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/deploy/vm/modules/ha_pair/versions.tf
+++ b/deploy/vm/modules/ha_pair/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.12, <= 0.12.2"
 }

--- a/deploy/vm/modules/playbook-execution/main.tf
+++ b/deploy/vm/modules/playbook-execution/main.tf
@@ -46,7 +46,7 @@ resource null_resource "mount-disks-and-configure-hana" {
      -i '../../ansible/azure_rm.py' ${var.ansible_playbook_path}
      EOT
 
-    environment {
+    environment = {
       HOSTS = "${var.vms_configured}"
     }
   }

--- a/deploy/vm/modules/single_node_hana/outputs.tf
+++ b/deploy/vm/modules/single_node_hana/outputs.tf
@@ -1,15 +1,16 @@
 output "hdb_vm_user" {
-  value = "${var.vm_user}"
+  value = var.vm_user
 }
 
 output "hdb_ip" {
-  value = "${module.create_hdb.fqdn}"
+  value = module.create_hdb.fqdn
 }
 
 output "windows_bastion_ip" {
-  value = "${module.windows_bastion_host.ip}"
+  value = module.windows_bastion_host.ip
 }
 
 output "windows_bastion_user" {
-  value = "${var.bastion_username_windows}"
+  value = var.bastion_username_windows
 }
+

--- a/deploy/vm/modules/single_node_hana/single-node-hana.tf
+++ b/deploy/vm/modules/single_node_hana/single-node-hana.tf
@@ -1,49 +1,51 @@
 # Configure the Microsoft Azure Provider
-provider "azurerm" {}
+provider "azurerm" {
+  version = "~> 1.30.1"
+}
 
 module "common_setup" {
   source            = "../common_setup"
-  allow_ips         = "${var.allow_ips}"
-  az_region         = "${var.az_region}"
-  az_resource_group = "${var.az_resource_group}"
-  existing_nsg_name = "${var.existing_nsg_name}"
-  existing_nsg_rg   = "${var.existing_nsg_rg}"
-  install_xsa       = "${var.install_xsa}"
-  sap_instancenum   = "${var.sap_instancenum}"
-  sap_sid           = "${var.sap_sid}"
-  use_existing_nsg  = "${var.use_existing_nsg}"
+  allow_ips         = var.allow_ips
+  az_region         = var.az_region
+  az_resource_group = var.az_resource_group
+  existing_nsg_name = var.existing_nsg_name
+  existing_nsg_rg   = var.existing_nsg_rg
+  install_xsa       = var.install_xsa
+  sap_instancenum   = var.sap_instancenum
+  sap_sid           = var.sap_sid
+  use_existing_nsg  = var.use_existing_nsg
 }
 
 module "create_hdb" {
   source = "../create_hdb_node"
 
-  az_resource_group         = "${module.common_setup.resource_group_name}"
-  az_region                 = "${var.az_region}"
+  az_resource_group         = module.common_setup.resource_group_name
+  az_region                 = var.az_region
   hdb_num                   = 0
-  az_domain_name            = "${var.az_domain_name}"
-  hana_subnet_id            = "${module.common_setup.vnet_subnets[0]}"
-  nsg_id                    = "${module.common_setup.nsg_id}"
-  private_ip_address        = "${var.private_ip_address_hdb}"
-  public_ip_allocation_type = "${var.public_ip_allocation_type}"
-  sap_sid                   = "${var.sap_sid}"
-  sshkey_path_public        = "${var.sshkey_path_public}"
-  storage_disk_sizes_gb     = "${var.storage_disk_sizes_gb}"
-  vm_user                   = "${var.vm_user}"
-  vm_size                   = "${var.vm_size}"
+  az_domain_name            = var.az_domain_name
+  hana_subnet_id            = module.common_setup.vnet_subnets[0]
+  nsg_id                    = module.common_setup.nsg_id
+  private_ip_address        = var.private_ip_address_hdb
+  public_ip_allocation_type = var.public_ip_allocation_type
+  sap_sid                   = var.sap_sid
+  sshkey_path_public        = var.sshkey_path_public
+  storage_disk_sizes_gb     = var.storage_disk_sizes_gb
+  vm_user                   = var.vm_user
+  vm_size                   = var.vm_size
 }
 
 module "windows_bastion_host" {
   source             = "../windows_bastion_host"
-  allow_ips          = "${var.allow_ips}"
-  az_domain_name     = "${var.az_domain_name}"
-  az_resource_group  = "${module.common_setup.resource_group_name}"
-  az_region          = "${var.az_region}"
-  sap_sid            = "${var.sap_sid}"
-  subnet_id          = "${module.common_setup.vnet_subnets[0]}"
-  bastion_username   = "${var.bastion_username_windows}"
-  private_ip_address = "${var.private_ip_address_windows_bastion}"
-  pw_bastion         = "${var.pw_bastion_windows}"
-  windows_bastion    = "${var.windows_bastion}"
+  allow_ips          = var.allow_ips
+  az_domain_name     = var.az_domain_name
+  az_resource_group  = module.common_setup.resource_group_name
+  az_region          = var.az_region
+  sap_sid            = var.sap_sid
+  subnet_id          = module.common_setup.vnet_subnets[0]
+  bastion_username   = var.bastion_username_windows
+  private_ip_address = var.private_ip_address_windows_bastion
+  pw_bastion         = var.pw_bastion_windows
+  windows_bastion    = var.windows_bastion
 }
 
 # Writes the configuration to a file, which will be used by the Ansible playbook for creating linux bastion host
@@ -54,48 +56,48 @@ resource "local_file" "write-config-to-json" {
 
 module "configure_vm" {
   source                   = "../playbook-execution"
-  ansible_playbook_path    = "${var.ansible_playbook_path}"
-  az_resource_group        = "${module.common_setup.resource_group_name}"
-  sshkey_path_private      = "${var.sshkey_path_private}"
-  sap_instancenum          = "${var.sap_instancenum}"
-  sap_sid                  = "${var.sap_sid}"
-  vm_user                  = "${var.vm_user}"
-  url_sap_sapcar           = "${var.url_sap_sapcar_linux}"
-  url_sap_hdbserver        = "${var.url_sap_hdbserver}"
-  pw_os_sapadm             = "${var.pw_os_sapadm}"
-  pw_os_sidadm             = "${var.pw_os_sidadm}"
-  pw_db_system             = "${var.pw_db_system}"
-  useHana2                 = "${var.useHana2}"
+  ansible_playbook_path    = var.ansible_playbook_path
+  az_resource_group        = module.common_setup.resource_group_name
+  sshkey_path_private      = var.sshkey_path_private
+  sap_instancenum          = var.sap_instancenum
+  sap_sid                  = var.sap_sid
+  vm_user                  = var.vm_user
+  url_sap_sapcar           = var.url_sap_sapcar_linux
+  url_sap_hdbserver        = var.url_sap_hdbserver
+  pw_os_sapadm             = var.pw_os_sapadm
+  pw_os_sidadm             = var.pw_os_sidadm
+  pw_db_system             = var.pw_db_system
+  useHana2                 = var.useHana2
   vms_configured           = "${module.create_hdb.machine_hostname}, ${module.windows_bastion_host.machine_hostname}"
-  hana1_db_mode            = "${var.hana1_db_mode}"
-  url_xsa_runtime          = "${var.url_xsa_runtime}"
-  url_di_core              = "${var.url_di_core}"
-  url_sapui5               = "${var.url_sapui5}"
-  url_portal_services      = "${var.url_portal_services}"
-  url_xs_services          = "${var.url_xs_services}"
-  url_shine_xsa            = "${var.url_shine_xsa}"
-  url_xsa_hrtt             = "${var.url_xsa_hrtt}"
-  url_xsa_webide           = "${var.url_xsa_webide}"
-  url_xsa_mta              = "${var.url_xsa_mta}"
-  pwd_db_xsaadmin          = "${var.pwd_db_xsaadmin}"
-  pwd_db_tenant            = "${var.pwd_db_tenant}"
-  pwd_db_shine             = "${var.pwd_db_shine}"
-  email_shine              = "${var.email_shine}"
-  install_xsa              = "${var.install_xsa}"
-  install_shine            = "${var.install_shine}"
-  install_cockpit          = "${var.install_cockpit}"
-  install_webide           = "${var.install_webide}"
-  url_cockpit              = "${var.url_cockpit}"
-  url_sapcar_windows       = "${var.url_sapcar_windows}"
-  url_hana_studio_windows  = "${var.url_hana_studio_windows}"
-  bastion_username_windows = "${var.bastion_username_windows}"
-  pw_bastion_windows       = "${var.pw_bastion_windows}"
+  hana1_db_mode            = var.hana1_db_mode
+  url_xsa_runtime          = var.url_xsa_runtime
+  url_di_core              = var.url_di_core
+  url_sapui5               = var.url_sapui5
+  url_portal_services      = var.url_portal_services
+  url_xs_services          = var.url_xs_services
+  url_shine_xsa            = var.url_shine_xsa
+  url_xsa_hrtt             = var.url_xsa_hrtt
+  url_xsa_webide           = var.url_xsa_webide
+  url_xsa_mta              = var.url_xsa_mta
+  pwd_db_xsaadmin          = var.pwd_db_xsaadmin
+  pwd_db_tenant            = var.pwd_db_tenant
+  pwd_db_shine             = var.pwd_db_shine
+  email_shine              = var.email_shine
+  install_xsa              = var.install_xsa
+  install_shine            = var.install_shine
+  install_cockpit          = var.install_cockpit
+  install_webide           = var.install_webide
+  url_cockpit              = var.url_cockpit
+  url_sapcar_windows       = var.url_sapcar_windows
+  url_hana_studio_windows  = var.url_hana_studio_windows
+  bastion_username_windows = var.bastion_username_windows
+  pw_bastion_windows       = var.pw_bastion_windows
 }
 
 # Destroy the linux bastion host
-resource null_resource "destroy-vm" {
+resource "null_resource" "destroy-vm" {
   provisioner "local-exec" {
-    when = "destroy"
+    when = destroy
 
     command = <<EOT
                OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES \
@@ -105,5 +107,7 @@ resource null_resource "destroy-vm" {
                --private-key '${var.sshkey_path_private}' \
                --extra-vars="{az_resource_group: \"${module.common_setup.resource_group_name}\", az_vm_name: \"${local.linux_vm_name}\"}" ../../ansible/delete_bastion_linux.yml
 EOT
+
   }
 }
+

--- a/deploy/vm/modules/single_node_hana/variables.tf
+++ b/deploy/vm/modules/single_node_hana/variables.tf
@@ -12,7 +12,8 @@ variable "az_domain_name" {
   description = "Prefix to be used in the domain name"
 }
 
-variable "az_region" {}
+variable "az_region" {
+}
 
 variable "az_resource_group" {
   description = "Which Azure resource group to deploy the HANA setup into.  i.e. <myResourceGroup>"
@@ -156,7 +157,7 @@ variable "url_portal_services" {
 }
 
 variable "url_sap_hdbserver" {
-  type        = "string"
+  type        = string
   description = "The URL that points to the HDB server 122.17 bits"
 }
 
@@ -241,3 +242,4 @@ locals {
   #name of the linux vm
   linux_vm_name = "${var.az_domain_name}-linux-bastion"
 }
+

--- a/deploy/vm/modules/single_node_hana/versions.tf
+++ b/deploy/vm/modules/single_node_hana/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/deploy/vm/modules/single_node_hana/versions.tf
+++ b/deploy/vm/modules/single_node_hana/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.12, <= 0.12.2"
 }

--- a/deploy/vm/modules/windows_bastion_host/certificates.tf
+++ b/deploy/vm/modules/windows_bastion_host/certificates.tf
@@ -1,11 +1,18 @@
-data "azurerm_client_config" "current" {}
+data "azurerm_client_config" "current" {
+}
 
 resource "azurerm_key_vault" "main" {
-  name                = "kv-${lower(replace(replace(timestamp(),local.colon, local.empty_string), local.dash, local.empty_string))}"
-  count               = "${var.windows_bastion ? 1 : 0}"
-  location            = "${var.az_region}"
-  resource_group_name = "${var.az_resource_group}"
-  tenant_id           = "${data.azurerm_client_config.current.tenant_id}"
+  name = "kv-${lower(
+    replace(
+      replace(timestamp(), local.colon, local.empty_string),
+      local.dash,
+      local.empty_string,
+    ),
+  )}"
+  count               = var.windows_bastion ? 1 : 0
+  location            = var.az_region
+  resource_group_name = var.az_resource_group
+  tenant_id           = data.azurerm_client_config.current.tenant_id
 
   enabled_for_deployment          = true
   enabled_for_template_deployment = true
@@ -15,8 +22,8 @@ resource "azurerm_key_vault" "main" {
   }
 
   access_policy {
-    tenant_id = "${data.azurerm_client_config.current.tenant_id}"
-    object_id = "${data.azurerm_client_config.current.service_principal_object_id}"
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.service_principal_object_id
 
     certificate_permissions = [
       "create",
@@ -29,15 +36,15 @@ resource "azurerm_key_vault" "main" {
     secret_permissions = []
   }
 
-  tags {
+  tags = {
     bastion-key-vault = ""
   }
 }
 
 resource "azurerm_key_vault_certificate" "main" {
   name      = "${local.machine_name}-cert"
-  count     = "${var.windows_bastion ? 1 : 0}"
-  vault_uri = "${azurerm_key_vault.main.vault_uri}"
+  count     = var.windows_bastion ? 1 : 0
+  vault_uri = azurerm_key_vault.main[0].vault_uri
 
   certificate_policy {
     issuer_parameters {
@@ -80,3 +87,4 @@ resource "azurerm_key_vault_certificate" "main" {
     }
   }
 }
+

--- a/deploy/vm/modules/windows_bastion_host/main.tf
+++ b/deploy/vm/modules/windows_bastion_host/main.tf
@@ -1,8 +1,8 @@
 resource "azurerm_network_security_group" "windows_bastion_nsg" {
-  count               = "${var.windows_bastion ? 1 : 0}"
+  count               = var.windows_bastion ? 1 : 0
   name                = "windows_bastion_nsg"
-  location            = "${var.az_region}"
-  resource_group_name = "${var.az_resource_group}"
+  location            = var.az_region
+  resource_group_name = var.az_resource_group
 
   security_rule {
     name                       = "RDP"
@@ -11,8 +11,8 @@ resource "azurerm_network_security_group" "windows_bastion_nsg" {
     access                     = "Allow"
     protocol                   = "Tcp"
     source_port_range          = "*"
-    destination_port_range     = "${local.rdp_port}"
-    source_address_prefixes    = "${var.allow_ips}"
+    destination_port_range     = local.rdp_port
+    source_address_prefixes    = var.allow_ips
     destination_address_prefix = "*"
   }
 
@@ -23,60 +23,60 @@ resource "azurerm_network_security_group" "windows_bastion_nsg" {
     access                     = "Allow"
     protocol                   = "Tcp"
     source_port_range          = "*"
-    destination_port_range     = "${local.winrm_port}"
-    source_address_prefixes    = "${var.allow_ips}"
+    destination_port_range     = local.winrm_port
+    source_address_prefixes    = var.allow_ips
     destination_address_prefix = "*"
   }
 
-  tags {
+  tags = {
     environment = "windows_bastion"
   }
 }
 
 resource "azurerm_public_ip" "pip" {
-  count                        = "${var.windows_bastion ? 1 : 0}"
-  name                         = "${local.machine_name}-pip"
-  location                     = "${var.az_region}"
-  resource_group_name          = "${var.az_resource_group}"
-  public_ip_address_allocation = "dynamic"
-  domain_name_label            = "${lower(local.machine_name)}-${var.az_domain_name}"
+  count               = var.windows_bastion ? 1 : 0
+  name                = "${local.machine_name}-pip"
+  location            = var.az_region
+  resource_group_name = var.az_resource_group
+  allocation_method   = "Dynamic"
+  domain_name_label   = "${lower(local.machine_name)}-${var.az_domain_name}"
 
   idle_timeout_in_minutes = 30
 
-  tags {
+  tags = {
     environment = "Terraform SAP HANA deployment"
   }
 }
 
 # Create network interface
 resource "azurerm_network_interface" "nic" {
-  count                     = "${var.windows_bastion ? 1 : 0}"
-  depends_on                = ["azurerm_public_ip.pip"]
+  count                     = var.windows_bastion ? 1 : 0
+  depends_on                = [azurerm_public_ip.pip]
   name                      = "${local.machine_name}-nic"
-  location                  = "${var.az_region}"
-  resource_group_name       = "${var.az_resource_group}"
-  network_security_group_id = "${var.windows_bastion ? azurerm_network_security_group.windows_bastion_nsg.id : local.empty_string}"
+  location                  = var.az_region
+  resource_group_name       = var.az_resource_group
+  network_security_group_id = var.windows_bastion ? azurerm_network_security_group.windows_bastion_nsg[0].id : local.empty_string
 
   ip_configuration {
     name                          = "${local.machine_name}-nic-configuration"
-    subnet_id                     = "${var.subnet_id}"
-    public_ip_address_id          = "${azurerm_public_ip.pip.id}"
-    private_ip_address            = "${var.private_ip_address}"
-    private_ip_address_allocation = "${var.private_ip_address != local.empty_string ? local.static : local.dynamic}"
+    subnet_id                     = var.subnet_id
+    public_ip_address_id          = azurerm_public_ip.pip[0].id
+    private_ip_address            = var.private_ip_address
+    private_ip_address_allocation = var.private_ip_address != local.empty_string ? local.static : local.dynamic
   }
 
-  tags {
+  tags = {
     environment = "Terraform SAP HANA deployment"
   }
 }
 
 resource "azurerm_virtual_machine" "windows_bastion" {
-  name                  = "${local.machine_name}"
-  count                 = "${var.windows_bastion ? 1 : 0}"
-  location              = "${var.az_region}"
-  resource_group_name   = "${var.az_resource_group}"
-  network_interface_ids = ["${azurerm_network_interface.nic.id}"]
-  vm_size               = "${var.vm_size}"
+  name                  = local.machine_name
+  count                 = var.windows_bastion ? 1 : 0
+  location              = var.az_region
+  resource_group_name   = var.az_resource_group
+  network_interface_ids = [azurerm_network_interface.nic[0].id]
+  vm_size               = var.vm_size
 
   delete_os_disk_on_termination    = true
   delete_data_disks_on_termination = true
@@ -96,16 +96,16 @@ resource "azurerm_virtual_machine" "windows_bastion" {
   }
 
   os_profile {
-    computer_name  = "${local.machine_name}"
-    admin_username = "${var.bastion_username}"
-    admin_password = "${var.pw_bastion}"
+    computer_name  = local.machine_name
+    admin_username = var.bastion_username
+    admin_password = var.pw_bastion
   }
 
   os_profile_secrets {
-    source_vault_id = "${azurerm_key_vault.main.id}"
+    source_vault_id = azurerm_key_vault.main[0].id
 
     vault_certificates {
-      certificate_url   = "${azurerm_key_vault_certificate.main.secret_id}"
+      certificate_url   = azurerm_key_vault_certificate.main[0].secret_id
       certificate_store = "My"
     }
   }
@@ -119,7 +119,7 @@ resource "azurerm_virtual_machine" "windows_bastion" {
 
     winrm {
       protocol        = "Https"
-      certificate_url = "${azurerm_key_vault_certificate.main.secret_id}"
+      certificate_url = azurerm_key_vault_certificate.main[0].secret_id
     }
 
     # Auto-Login's required to configure WinRM
@@ -135,11 +135,12 @@ resource "azurerm_virtual_machine" "windows_bastion" {
       pass         = "oobeSystem"
       component    = "Microsoft-Windows-Shell-Setup"
       setting_name = "FirstLogonCommands"
-      content      = "${file("${path.module}/files/FirstLogonCommands.xml")}"
+      content      = file("${path.module}/files/FirstLogonCommands.xml")
     }
   }
 
-  tags {
+  tags = {
     win_bastion = ""
   }
 }
+

--- a/deploy/vm/modules/windows_bastion_host/outputs.tf
+++ b/deploy/vm/modules/windows_bastion_host/outputs.tf
@@ -1,11 +1,15 @@
 output "ip" {
-  depends_on = ["azurerm_key_vault_certificate"]
+  depends_on = [azurerm_key_vault_certificate]
 
-  value = "${azurerm_public_ip.pip.*.fqdn}"
+  value = azurerm_public_ip.pip.*.fqdn
 }
 
 output "machine_hostname" {
-  depends_on = ["azurerm_key_vault_certificate", "azurerm_virtual_machine.windows_bastion"]
+  depends_on = [
+    azurerm_key_vault_certificate,
+    azurerm_virtual_machine.windows_bastion,
+  ]
 
-  value = "${local.machine_name}"
+  value = local.machine_name
 }
+

--- a/deploy/vm/modules/windows_bastion_host/variables.tf
+++ b/deploy/vm/modules/windows_bastion_host/variables.tf
@@ -1,13 +1,14 @@
 variable "allow_ips" {
   description = "The IP addresses that will be allowed by the nsg"
-  type        = "list"
+  type        = list(string)
 }
 
 variable "az_domain_name" {
   description = "Prefix to be used in the domain name"
 }
 
-variable "az_region" {}
+variable "az_region" {
+}
 
 variable "az_resource_group" {
   description = "Which azure resource group to deploy the HANA setup into.  i.e. <myResourceGroup>"
@@ -55,3 +56,4 @@ locals {
   winrm_port   = 5986
   rdp_port     = 3389
 }
+

--- a/deploy/vm/modules/windows_bastion_host/versions.tf
+++ b/deploy/vm/modules/windows_bastion_host/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/deploy/vm/modules/windows_bastion_host/versions.tf
+++ b/deploy/vm/modules/windows_bastion_host/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.12, <= 0.12.2"
 }


### PR DESCRIPTION
Summary:
- Converted all of the Terraform modules to use the latest version of Terraform, 0.12.2. 
- Version locked the `azurerm` provider
- Removed the portion of the README that said that version 0.12 didn't work and the instructions for the workaround