### PR TITLE
HOTFIX: Explicitly made context global (python3)

### DIFF
--- a/monitor/sapmon.py
+++ b/monitor/sapmon.py
@@ -420,6 +420,7 @@ def monitor(args):
       h.disconnect()
       
 def main():
+   global ctx
    parser = argparse.ArgumentParser(description="SAP on Azure Monitor Payload")
    subParsers = parser.add_subparsers(dest="command", help="main functions")
    subParsers.required = True


### PR DESCRIPTION
- As CSE uses python3 and since context was not globally declared, deployment of SapMonitor failed during onboarding