### PR TITLE
Exclude monitor and README from the pipeline trigger path

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,7 +5,9 @@
 trigger: none
 # Only trigger build when a PR is opened
 pr:
-- master
+  branches:
+    include:
+    - master
   paths:
     exclude:
     - README.md

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,6 +6,10 @@ trigger: none
 # Only trigger build when a PR is opened
 pr:
 - master
+  paths:
+    exclude:
+    - README.md
+    - monitor/*
 jobs:
 - job: "single_node_hana"
   variables:


### PR DESCRIPTION
The monitor folder contains scripts for collecting load history from DB. Hence changes to scripts in monitor is not relevant to automated deployment. Same applies to README.md