### PR TITLE
Include build id in the resource group instead of source branch name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,9 +30,4 @@ Coding Guidelines
   * This repository integrates with [Azure Pipelines](https://azure.microsoft.com/en-us/services/devops/pipelines/), which invokes build checks on the submitted pull requests. The pipeline runs the tests on the merge branch. The pull request is required to pass the Azure pipelines test before it can be merged.
 * Branch Policy
   * The contributor needs to create a branch in the main repo so that the integrated Azure pipelines can test the submitted pull request.
-  * The Azure Pipelines build deploy resources by running terraform on the merge branch of the source branch and master to validate and verify the submitted pull request. Please note that the deployed resource group and the domain name are named after the source branch to allow exclusive test deployments for multiple pull requests and branches. **So the branch name can only contain small case alphanumeric characters and hyphens**.
-  A recommended format of the branch name can be:
-  ```sh
-  <Contributor's github handle>-<feature name>
-  ```
   

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -66,8 +66,8 @@ jobs:
     env:
       TF_VAR_azure_service_principal_id: $(hana-pipeline-spn-id)
       TF_VAR_azure_service_principal_pw: $(hana-pipeline-spn-pw)
-      TF_VAR_az_resource_group: single-node-$(System.PullRequest.SourceBranch)
-      TF_VAR_az_domain_name: single-node-$(System.PullRequest.SourceBranch)
+      TF_VAR_az_resource_group: single-node-$(Build.BuildId)
+      TF_VAR_az_domain_name: single-node-$(Build.BuildId)
       TF_VAR_url_sap_sapcar_linux: $(hana-int-sapcar-721-linux)
       TF_VAR_url_sap_hdbserver: $(hana-int-hana2sps03-server)
       TF_VAR_url_hana_studio_linux: $(hana-int-hanastudio-linux)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,8 +41,8 @@ jobs:
     env:
       TF_VAR_azure_service_principal_id: $(hana-pipeline-spn-id)
       TF_VAR_azure_service_principal_pw: $(hana-pipeline-spn-pw)
-      TF_VAR_az_resource_group: single-node-$(System.PullRequest.SourceBranch)
-      TF_VAR_az_domain_name: single-node-$(System.PullRequest.SourceBranch)
+      TF_VAR_az_resource_group: single-node-$(Build.BuildId)
+      TF_VAR_az_domain_name: single-node-$(Build.BuildId)
       TF_VAR_url_sap_sapcar_linux: $(hana-int-sapcar-721-linux)
       TF_VAR_url_sap_hdbserver: $(hana-int-hana2sps03-server)
       TF_VAR_url_hana_studio_linux: $(hana-int-hanastudio-linux)


### PR DESCRIPTION
Resource group name has the source branch of a PR that is created. This causes manual CI build to fail since there is no PR and then resource group name becomes invalid. Hence changing to include buildID instead

Also looks like enforcing a fixed branch is probably a bad experience for dev