### PR TITLE
Fix HA pair by disabling Cloud-Netconfig

### DIFF
--- a/deploy/vm/ansible/ha_pair_playbook.yml
+++ b/deploy/vm/ansible/ha_pair_playbook.yml
@@ -5,6 +5,11 @@
 
 - hosts: hdb0,hdb1
   become: true
+  roles:
+    - disable-cloud-netconfig
+
+- hosts: hdb0,hdb1
+  become: true
 
   roles:
     - disk-setup

--- a/deploy/vm/ansible/roles/disable-cloud-netconfig/tasks/main.yml
+++ b/deploy/vm/ansible/roles/disable-cloud-netconfig/tasks/main.yml
@@ -1,6 +1,7 @@
-- name: set CLOUD_NETCONFIG to no
+- name: disable CLOUD_NETCONFIG_MANAGE
   shell: |
     TARGET_KEY="CLOUD_NETCONFIG_MANAGE"
     REPLACEMENT_VALUE="\'no\'"
     CONFIG_FILE="/etc/sysconfig/network/ifcfg-eth0"
     sed -i "s/\($TARGET_KEY *= *\).*/\1$REPLACEMENT_VALUE/" $CONFIG_FILE
+

--- a/deploy/vm/ansible/roles/disable-cloud-netconfig/tasks/main.yml
+++ b/deploy/vm/ansible/roles/disable-cloud-netconfig/tasks/main.yml
@@ -1,0 +1,6 @@
+- name: set CLOUD_NETCONFIG to no
+  shell: |
+    TARGET_KEY="CLOUD_NETCONFIG_MANAGE"
+    REPLACEMENT_VALUE="\'no\'"
+    CONFIG_FILE="/etc/sysconfig/network/ifcfg-eth0"
+    sed -i "s/\($TARGET_KEY *= *\).*/\1$REPLACEMENT_VALUE/" $CONFIG_FILE


### PR DESCRIPTION
- SLES12 includes [Cloud-Netconfig](https://github.com/SUSE-Enceladus/cloud-netconfig), which is a tool that automatically control network interface cards on Azure VMs. This apparently has impact on the stability of Pacemaker clusters as it interferes with the configuration of the floating IP address.
- This change will manually disable Cloud-Netconfig during automated HANA HA pair deployment by adding an Ansible role that sets `CLOUD_NETCONFIG_MANAGE=no` in `/etc/sysconfig/network/ifcfg-eth0`.