### PR TITLE
[FIX] Fix calculation of result hash

### DIFF
--- a/monitor/sapmon.py
+++ b/monitor/sapmon.py
@@ -191,6 +191,7 @@ ORDER BY h.TIME ASC
          else:
             if ctx.lastResultHashes[query] == resultHash:
                logger.info("result is identical to last execution")
+               resultHash = None
             else:
                logger.info("result has changed from last execution")
       return resultHash   


### PR DESCRIPTION
This PR addresses a bug introduced with the logging implementation (PR #189):
- `SapHana.getNewResultHash(query, resultRows)` calculates the MD5 hash of a query result set and returns it **only** if it is different from the previous execution.
- Due to the re-factoring required for the loggers, I missed to set r`esultHash = None` (sapmon.py, line 194), in case the hash is identical to the one from the previous execution.
- While not impacting stability/performance, this resulted in redundancy, as the same row was ingested into Log Analytics with every execution, although there was no change.