### PR TITLE
[HOTFIX] adding timeout and retries for all content downloads

### DIFF
--- a/deploy/vm/ansible/roles/cockpit-download/tasks/main.yml
+++ b/deploy/vm/ansible/roles/cockpit-download/tasks/main.yml
@@ -4,6 +4,11 @@
   get_url:
     url: "{{ url_cockpit }}"
     dest: /hana/shared/install/SAPHANACOCKPIT07_11-70002299.SAR
+    timeout: "{{ url_timeout }}"
+  register: result
+  until: result is succeeded
+  retries: "{{ url_retries_cnt }}"
+  delay: "{{ url_retries_delay }}"
 
 - name: Extract HANA Cockpit
   command: ./SAPCAR_LINUX.EXE -manifest SIGNATURE.SMF -xvf SAPHANACOCKPIT07_11-70002299.SAR -R SAP_HANA_COCKPIT

--- a/deploy/vm/ansible/roles/saphana-install/tasks/main.yml
+++ b/deploy/vm/ansible/roles/saphana-install/tasks/main.yml
@@ -20,7 +20,6 @@
     dest: /hana/shared/install/SAPCAR_LINUX.EXE
     mode: 0755
     timeout: "{{ url_timeout }}"
-  # 10 retries with 10 second in between
   register: result
   until: result is succeeded
   retries: "{{ url_retries_cnt }}"

--- a/deploy/vm/ansible/roles/saphana-install/tasks/main.yml
+++ b/deploy/vm/ansible/roles/saphana-install/tasks/main.yml
@@ -19,11 +19,22 @@
     url: "{{ url_sapcar }}"
     dest: /hana/shared/install/SAPCAR_LINUX.EXE
     mode: 0755
+    timeout: "{{ url_timeout }}"
+  # 10 retries with 10 second in between
+  register: result
+  until: result is succeeded
+  retries: "{{ url_retries_cnt }}"
+  delay: "{{ url_retries_delay }}"
 
 - name: download hdbserver
   get_url:
     url: "{{ url_hdbserver }}"
     dest: /hana/shared/install/IMDB_SERVER_LINUX.SAR
+    timeout: "{{ url_timeout }}"
+  register: result
+  until: result is succeeded
+  retries: "{{ url_retries_cnt }}"
+  delay: "{{ url_retries_delay }}"
 
 - name: extract hdbserver
   command: ./SAPCAR_LINUX.EXE -manifest SIGNATURE.SMF -xvf IMDB_SERVER_LINUX.SAR

--- a/deploy/vm/ansible/roles/set-up-windows-bastion/tasks/main.yml
+++ b/deploy/vm/ansible/roles/set-up-windows-bastion/tasks/main.yml
@@ -2,11 +2,21 @@
   win_get_url:
     url: "{{ url_sapcar_windows }}"
     dest: C:\Users\{{ bastion_username_windows }}\Downloads\SAPCAR_WINDOWS.EXE
+    timeout: "{{ url_timeout }}"
+  register: result
+  until: result is succeeded
+  retries: "{{ url_retries_cnt }}"
+  delay: "{{ url_retries_delay }}"
 
 - name: download HANA Studio
   win_get_url:
     url: "{{ url_hana_studio_windows }}"
     dest: C:\Users\{{ bastion_username_windows }}\Downloads\HANA_STUDIO_WINDOWS.SAR
+    timeout: "{{ url_timeout }}"
+  register: result
+  until: result is succeeded
+  retries: "{{ url_retries_cnt }}"
+  delay: "{{ url_retries_delay }}"
 
 - name: Extract HANA Studio
   win_command: SAPCAR_WINDOWS.EXE -xvf HANA_STUDIO_WINDOWS.SAR

--- a/deploy/vm/ansible/roles/setup-linux-hana-studio/tasks/main.yml
+++ b/deploy/vm/ansible/roles/setup-linux-hana-studio/tasks/main.yml
@@ -2,6 +2,12 @@
   get_url:
       url: "{{sapcar_url}}"
       dest: "/home/{{ azure_user }}/SAPCAR.EXE"
+      timeout: "{{ url_timeout }}"
+  register: result
+  until: result is succeeded
+  retries: "{{ url_retries_cnt }}"
+  delay: "{{ url_retries_delay }}"
+
 - name: change permission of SAPCAR.EXE
   file:
       path: "/home/{{ azure_user }}/SAPCAR.EXE"
@@ -10,6 +16,13 @@
   get_url:
       url: "{{hana_studio_url}}"
       dest: "/home/{{ azure_user }}/HANA_STUDIO.SAR"
+      timeout: "{{ url_timeout }}"
+  register: result
+  until: result is succeeded
+  retries: "{{ url_retries_cnt }}"
+  delay: "{{ url_retries_delay }}"
+
 - name: extract HANA Studio
   shell: ./SAPCAR.EXE -manifest SIGNATURE.SMF -xvf HANA_STUDIO.SAR
+
 

--- a/deploy/vm/ansible/roles/shine-install/tasks/main.yml
+++ b/deploy/vm/ansible/roles/shine-install/tasks/main.yml
@@ -4,6 +4,11 @@
   get_url:
     url: "{{ url_shine_xsa }}"
     dest: /usr/sap/{{ sap_sid|upper }}/HDB{{ sap_instancenum }}/XSASHINE.ZIP
+    timeout: "{{ url_timeout }}"
+  register: result
+  until: result is succeeded
+  retries: "{{ url_retries_cnt }}"
+  delay: "{{ url_retries_delay }}"
 
 - name: Log into XSA
   shell: |

--- a/deploy/vm/ansible/roles/webide-install/tasks/main.yml
+++ b/deploy/vm/ansible/roles/webide-install/tasks/main.yml
@@ -4,17 +4,32 @@
   get_url:
     url: "{{ url_xsa_hrtt }}"
     dest: /usr/sap/{{ sap_sid|upper }}/HDB{{ sap_instancenum }}/XSAHRTT.ZIP
+    timeout: "{{ url_timeout }}"
+  register: result
+  until: result is succeeded
+  retries: "{{ url_retries_cnt }}"
+  delay: "{{ url_retries_delay }}"
   when: install_cockpit == false
   
 - name: Download WebIDE
   get_url:
     url: "{{ url_xsa_webide }}"
     dest: /usr/sap/{{ sap_sid|upper }}/HDB{{ sap_instancenum }}/XSAWEBIDE.ZIP
+    timeout: "{{ url_timeout }}"
+  register: result
+  until: result is succeeded
+  retries: "{{ url_retries_cnt }}"
+  delay: "{{ url_retries_delay }}"
 
 - name: Download MTA ext
   get_url:
     url: "{{ url_xsa_mta }}"
     dest: /usr/sap/{{ sap_sid|upper }}/HDB{{ sap_instancenum }}/XSAWEBIDE.mtaext
+    timeout: "{{ url_timeout }}"
+  register: result
+  until: result is succeeded
+  retries: "{{ url_retries_cnt }}"
+  delay: "{{ url_retries_delay }}"
 
 - name: Log into XSA
   shell: |

--- a/deploy/vm/ansible/roles/xsa-install/tasks/main.yml
+++ b/deploy/vm/ansible/roles/xsa-install/tasks/main.yml
@@ -14,26 +14,51 @@
   get_url:
     url: "{{ url_xsa_runtime }}"
     dest: /hana/shared/install/
+    timeout: "{{ url_timeout }}"
+  register: result
+  until: result is succeeded
+  retries: "{{ url_retries_cnt }}"
+  delay: "{{ url_retries_delay }}"
 
 - name: Download DI Core
   get_url:
     url: "{{ url_di_core }}"
     dest: /hana/shared/install/
+    timeout: "{{ url_timeout }}"
+  register: result
+  until: result is succeeded
+  retries: "{{ url_retries_cnt }}"
+  delay: "{{ url_retries_delay }}"
 
 - name: Download SAPUI5
   get_url:
     url: "{{ url_sapui5 }}"
     dest: /hana/shared/install/
+    timeout: "{{ url_timeout }}"
+  register: result
+  until: result is succeeded
+  retries: "{{ url_retries_cnt }}"
+  delay: "{{ url_retries_delay }}"
 
 - name: Download Portal Services
   get_url:
     url: "{{ url_portal_services }}"
     dest: /hana/shared/install/
+    timeout: "{{ url_timeout }}"
+  register: result
+  until: result is succeeded
+  retries: "{{ url_retries_cnt }}"
+  delay: "{{ url_retries_delay }}"
 
 - name: Download XS Services
   get_url:
     url: "{{ url_xs_services }}"
     dest: /hana/shared/install/
+    timeout: "{{ url_timeout }}"
+  register: result
+  until: result is succeeded
+  retries: "{{ url_retries_cnt }}"
+  delay: "{{ url_retries_delay }}"
 
 - name: Extract XSA Runtime
   command: ./SAPCAR_LINUX.EXE -manifest SIGNATURE.SMF -xvf EXTAPPSER00P_87-70001316.SAR -R EXTAPPSER00P_87

--- a/deploy/vm/modules/playbook-execution/main.tf
+++ b/deploy/vm/modules/playbook-execution/main.tf
@@ -32,6 +32,9 @@ resource null_resource "mount-disks-and-configure-hana" {
      \"url_xsa_mta\": \"${var.url_xsa_mta}\", \
      \"url_sapcar_windows\": \"${var.url_sapcar_windows}\", \
      \"url_hana_studio_windows\": \"${var.url_hana_studio_windows}\", \
+     \"url_timeout\": \"${var.url_timeout}\", \
+     \"url_retries_cnt\": \"${var.url_retries_cnt}\", \
+     \"url_retries_delay\": \"${var.url_retries_delay}\",\
      \"pwd_db_xsaadmin\": \"${var.pwd_db_xsaadmin}\", \
      \"pw_bastion_windows\": \"${var.pw_bastion_windows}\", \
      \"bastion_username_windows\": \"${var.bastion_username_windows}\", \

--- a/deploy/vm/modules/playbook-execution/variables.tf
+++ b/deploy/vm/modules/playbook-execution/variables.tf
@@ -167,6 +167,21 @@ variable "url_xsa_mta" {
   default     = ""
 }
 
+variable "url_timeout" {
+  description = "Timeout in seconds for URL request."
+  default     = 30
+}
+
+variable "url_retries_cnt" {
+  description = "The number of attempts to download the installation bits from the URLs."
+  default     = 10
+}
+
+variable "url_retries_delay" {
+  description = "The time between each attempt to download the installation bits from the URLs"
+  default     = 10
+}
+
 variable "useHana2" {
   description = "If this is set to true, then, ports specifically for HANA 2.0 will be opened."
   default     = false
@@ -189,3 +204,4 @@ variable "linux_bastion" {
   description = "flag to determine if linux bastion host is needed or not"
   default     = false
 }
+


### PR DESCRIPTION
- The download of the SAP binaries from an Azure blob can be quite spotty some time, which would lead to failed deployment

- To reduce the amount of failures caused by the above reason, we introduce below 2 precautions to all `get_url` and `win_get_url` tasks:
  - adding parameter `timeout`, and set to 30s (can be changed by `url_timeout`).
  - if the download is not successful, the above tasks will retry 10 times (can be changed by variable `url_retries_cnt`) with 10s in between (can be changed by `url_retries_delay`).

Below is an example output when the download fails:
[sample_output.log](https://github.com/Azure/sap-hana/files/3429943/sample_output.log)
