### PR TITLE
[HOTFIX] Assign nsg to subnet to avoid NRMS nsg to be added

### DIFF
--- a/deploy/vm/modules/common_setup/main.tf
+++ b/deploy/vm/modules/common_setup/main.tf
@@ -16,19 +16,17 @@ resource "azurerm_resource_group" "hana-resource-group" {
   }
 }
 
-module "vnet" {
-  source  = "Azure/vnet/azurerm"
-  version = "1.2.0"
-
-  address_space       = "10.0.0.0/21"
-  location            = var.az_region
-  resource_group_name = var.az_resource_group
-  subnet_names        = ["hdb-subnet"]
-  subnet_prefixes     = ["10.0.0.0/24"]
-  vnet_name           = "${var.sap_sid}-vnet"
-
-  tags = {
-    environment = "Terraform HANA vnet and subnet creation"
-  }
+resource "azurerm_virtual_network" "vnet" {
+  name                = "${var.sap_sid}-vnet"
+  location            =  azurerm_resource_group.hana-resource-group.location
+  resource_group_name =  azurerm_resource_group.hana-resource-group.name
+  address_space       = ["10.0.0.0/21"]
 }
 
+resource "azurerm_subnet" "subnet" {
+  name                      = "hdb-subnet"
+  resource_group_name       = azurerm_resource_group.hana-resource-group.name
+  virtual_network_name      = azurerm_virtual_network.vnet.name
+  address_prefix            = "10.0.0.0/24"
+  network_security_group_id = azurerm_network_security_group.sap_nsg[0].id
+}

--- a/deploy/vm/modules/common_setup/outputs.tf
+++ b/deploy/vm/modules/common_setup/outputs.tf
@@ -3,11 +3,11 @@ output "nsg_id" {
 }
 
 output "vnet_subnets" {
-  value = module.vnet.vnet_subnets
+  value = azurerm_subnet.subnet.id
 }
 
 output "vnet_name" {
-  value = module.vnet.vnet_name
+  value = azurerm_subnet.subnet.name
 }
 
 output "resource_group_name" {

--- a/deploy/vm/modules/ha_pair/main.tf
+++ b/deploy/vm/modules/ha_pair/main.tf
@@ -37,7 +37,7 @@ resource "azurerm_lb" "ha-pair-lb" {
 
   frontend_ip_configuration {
     name                          = "hsr-front"
-    subnet_id                     = module.common_setup.vnet_subnets[0]
+    subnet_id                     = module.common_setup.vnet_subnets
     private_ip_address_allocation = "Static"
     private_ip_address            = var.private_ip_address_lb_frontend
   }
@@ -99,7 +99,7 @@ module "create_hdb0" {
   az_domain_name            = var.az_domain_name
   backend_ip_pool_ids       = [azurerm_lb_backend_address_pool.availability-back-pool.id]
   hdb_num                   = "0"
-  hana_subnet_id            = module.common_setup.vnet_subnets[0]
+  hana_subnet_id            = module.common_setup.vnet_subnets
   nsg_id                    = module.common_setup.nsg_id
   private_ip_address        = var.private_ip_address_hdb0
   public_ip_allocation_type = var.public_ip_allocation_type
@@ -119,7 +119,7 @@ module "create_hdb1" {
   az_domain_name            = var.az_domain_name
   backend_ip_pool_ids       = [azurerm_lb_backend_address_pool.availability-back-pool.id]
   hdb_num                   = "1"
-  hana_subnet_id            = module.common_setup.vnet_subnets[0]
+  hana_subnet_id            = module.common_setup.vnet_subnets
   nsg_id                    = module.common_setup.nsg_id
   private_ip_address        = var.private_ip_address_hdb1
   public_ip_allocation_type = var.public_ip_allocation_type
@@ -140,7 +140,7 @@ module "nic_and_pip_setup_iscsi" {
   nsg_id                    = module.common_setup.nsg_id
   private_ip_address        = var.private_ip_address_iscsi
   public_ip_allocation_type = var.public_ip_allocation_type
-  subnet_id                 = module.common_setup.vnet_subnets[0]
+  subnet_id                 = module.common_setup.vnet_subnets
 }
 
 module "vm_and_disk_creation_iscsi" {
@@ -165,7 +165,7 @@ module "windows_bastion_host" {
   az_resource_group  = module.common_setup.resource_group_name
   az_region          = var.az_region
   sap_sid            = var.sap_sid
-  subnet_id          = module.common_setup.vnet_subnets[0]
+  subnet_id          = module.common_setup.vnet_subnets
   bastion_username   = var.bastion_username_windows
   private_ip_address = var.private_ip_address_windows_bastion
   pw_bastion         = var.pw_bastion_windows

--- a/deploy/vm/modules/single_node_hana/single-node-hana.tf
+++ b/deploy/vm/modules/single_node_hana/single-node-hana.tf
@@ -23,7 +23,7 @@ module "create_hdb" {
   az_region                 = var.az_region
   hdb_num                   = 0
   az_domain_name            = var.az_domain_name
-  hana_subnet_id            = module.common_setup.vnet_subnets[0]
+  hana_subnet_id            = module.common_setup.vnet_subnets
   nsg_id                    = module.common_setup.nsg_id
   private_ip_address        = var.private_ip_address_hdb
   public_ip_allocation_type = var.public_ip_allocation_type
@@ -41,7 +41,7 @@ module "windows_bastion_host" {
   az_resource_group  = module.common_setup.resource_group_name
   az_region          = var.az_region
   sap_sid            = var.sap_sid
-  subnet_id          = module.common_setup.vnet_subnets[0]
+  subnet_id          = module.common_setup.vnet_subnets
   bastion_username   = var.bastion_username_windows
   private_ip_address = var.private_ip_address_windows_bastion
   pw_bastion         = var.pw_bastion_windows


### PR DESCRIPTION
In the previous code, subnet does not have an assigned nsg.

This will cause sporadic failure during the deployment:
- The created subnet does not have nsg assigned to it.
- A nsg naming contains **\*NRMS\*** will be created and assigned to vnet.
- This nsg only contains basic inbound rules, therefore it blocks SSH connection, which is required by the Ansible script to continue the deployment on the created VM.

Details about NRMS [here](http://aka.ms/nrms)

For the same reason, all the PRs are blocked since our pipline test will fail.