### PR TITLE
Add Azure Pipeline Test for deploy/v2

### DIFF
--- a/azure-pipelines-wft.yaml
+++ b/azure-pipelines-wft.yaml
@@ -56,7 +56,7 @@ stages:
         inputJSONFile: '../pipelineInputJSON/input.auto.tfvars.existingVnet.json'
         testCaseName: 'wft-existingVnet'
         replacePlaceHolder: 'VAR_AZ_VNET_ID'
-        replaceValue: $(arm_id_1)
+        replaceValue: $(arm_id)
   - job: reuseNSG
     dependsOn: createAllNew
     steps:

--- a/azure-pipelines-wft.yaml
+++ b/azure-pipelines-wft.yaml
@@ -1,0 +1,101 @@
+# This Azure pipeline YAML contains tests to validate and verify the pull requests made for automated deployment of SAP landscape.
+# This pipeline will only run all the tests if the PR is made from a branch of Azure/sap-hana repo.
+# Branches from forked repositories will fail in the Azure provider authentication phase due to security reason
+# Only trigger build when a PR is opened for code under deploy/v2
+
+pr:
+  branches:
+    include:
+    - master
+  paths:
+    include:
+    - deploy/v2/*
+variables:
+  - group: azure-config-variables
+  - group: azure-sap-hana-pipeline-secrets
+stages: 
+#####################################################################
+# This stage create resources for below test cases:                 # 
+# - createAllNew: it creates all resources from scratch             # 
+# - reuseRG: it only reuses an existing resource group              #
+# - reuseVnet: it only reuses an existing vnet from createAllNew    #
+# - reuseNSG: it only reuses an existing NSG from createAllNew      #
+#####################################################################
+- stage: CreatingResources
+  jobs:
+  - job: createAllNew
+    pool:
+      vmImage: "ubuntu-16.04"
+    steps:        
+    - template: templates/terraform-deployment-steps.yaml
+      parameters:
+        inputJSONFile: '../pipelineInputJSON/input.auto.tfvars.allNew.json'
+        testCaseName: 'wft-allNew'
+        replacePlaceHolder: 'VAR_AZ_RG_NAME'
+        replaceValue: 'wft-allNew-$(Build.BuildId)'
+  - job: reuseRG
+    steps:
+    - script: |
+        az login --service-principal --user $(hana-pipeline-spn-id) --password  $(hana-pipeline-spn-pw) --tenant $(landscape-tenant) --output none
+        az group create --location westus2 -n wft-existingRG-$(Build.BuildId)
+        echo '##vso[task.setvariable variable=arm_id]$(az group show --name wft-existingRG-$(Build.BuildId) --query id --output tsv)'
+    - template: templates/terraform-deployment-steps.yaml
+      parameters:
+        inputJSONFile: '../pipelineInputJSON/input.auto.tfvars.existingRG.json'
+        testCaseName: 'wft-existingRG'
+        replacePlaceHolder: 'VAR_AZ_RG_ID'
+        replaceValue: $(arm_id)
+  - job: reuseVnet
+    dependsOn: createAllNew
+    steps:
+    - script: |
+        az login --service-principal --user $(hana-pipeline-spn-id) --password  $(hana-pipeline-spn-pw) --tenant $(landscape-tenant) --output none
+        echo '##vso[task.setvariable variable=arm_id]$(az network vnet show --resource-group wft-allNew-$(Build.BuildId) --name vnet-management --query id --output tsv)'
+    - template: templates/terraform-deployment-steps.yaml
+      parameters:
+        inputJSONFile: '../pipelineInputJSON/input.auto.tfvars.existingVnet.json'
+        testCaseName: 'wft-existingVnet'
+        replacePlaceHolder: 'VAR_AZ_VNET_ID'
+        replaceValue: $(arm_id_1)
+  - job: reuseNSG
+    dependsOn: createAllNew
+    steps:
+    - script: |
+        az login --service-principal --user $(hana-pipeline-spn-id) --password  $(hana-pipeline-spn-pw) --tenant $(landscape-tenant) --output none
+        echo '##vso[task.setvariable variable=arm_id]$(az network nsg show --resource-group wft-allNew-$(Build.BuildId) --name nsg-mgmt --query id --output tsv)'
+    - template: templates/terraform-deployment-steps.yaml
+      parameters:
+        inputJSONFile: '../pipelineInputJSON/input.auto.tfvars.existingNSG.json'
+        testCaseName: 'wft-existingNSG'
+        replacePlaceHolder: 'VAR_AZ_NSG_ID'
+        replaceValue: $(arm_id)
+#####################################################################
+# This stage destroy resources crated from all above test cases.    #
+# It will be triggered after stage CreatingResources is finished.   #
+# It will always be triggered, regardless the status of stage one - #
+# success of fail                                                   #
+#####################################################################
+- stage: DestroyingResources
+  dependsOn: CreatingResources
+  condition: succeededOrFailed()
+  jobs:
+  - job: cleanUp
+    steps:
+      - script: |
+          az login --service-principal --user $(hana-pipeline-spn-id) --password  $(hana-pipeline-spn-pw) --tenant $(landscape-tenant) --output none
+          az group delete -n wft-allNew-$(Build.BuildId) --no-wait -y
+          az group delete -n wft-existingRG-$(Build.BuildId) --no-wait -y
+          az group delete -n wft-existingVnet-$(Build.BuildId) --no-wait -y
+          az group delete -n wft-existingNSG-$(Build.BuildId) --no-wait -y
+        displayName: 'Clean up'
+        env:
+          TF_VAR_azure_service_principal_id: $(hana-pipeline-spn-id)
+          TF_VAR_azure_service_principal_pw: $(hana-pipeline-spn-pw)
+          AZURE_CLIENT_ID: $(hana-pipeline-spn-id)
+          AZURE_SECRET: $(hana-pipeline-spn-pw)
+          AZURE_TENANT: $(landscape-tenant)
+          AZURE_SUBSCRIPTION_ID: $(landscape-subscription)
+          ARM_CLIENT_ID: $(hana-pipeline-spn-id)
+          ARM_CLIENT_SECRET: $(hana-pipeline-spn-pw)
+          ARM_TENANT_ID: $(landscape-tenant)
+          ARM_SUBSCRIPTION_ID: $(landscape-subscription)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,6 +12,7 @@ pr:
     exclude:
     - README.md
     - monitor/*
+    - deploy/v2/*
 jobs:
 - job: single_node_hana
   variables:

--- a/deploy/v2/pipelineInputJSON/input.auto.tfvars.allNew.json
+++ b/deploy/v2/pipelineInputJSON/input.auto.tfvars.allNew.json
@@ -1,0 +1,51 @@
+{
+
+    "infrastructure" : {
+            "region" : "westus2",
+
+            "resource_group" : {
+                    "is_existing" : "false",
+                    "name" : "VAR_AZ_RG_NAME"
+            },
+
+            "vnets" : {
+                    "management" : {
+                            "is_existing" : "false",
+                            "name" : "vnet-management",
+                            "address_space" : "10.0.0.0/16",
+                            "subnet_mgmt" : {
+                                    "is_existing" : "false",
+                                    "name" : "subnet-mgmt",
+                                    "prefix" : "10.0.1.0/24",
+                                    "nsg" : {
+                                            "is_existing" : "false",
+                                            "name" : "nsg-mgmt"
+                                    }
+                            }
+                    },
+                    "sap" : {
+                            "is_existing" : "false",
+                            "name" : "vnet-sap",
+                            "address_space" : "10.1.0.0/16",
+                            "subnet_admin" : {
+                                    "is_existing" : "false",
+                                    "name" : "subnet-admin",
+                                    "prefix" : "10.1.1.0/24",
+                                    "nsg" : {
+                                            "is_existing" : "false",
+                                            "name" : "nsg-admin"
+                                    }
+                            },
+                            "subnet_db" : {
+                                    "is_existing" : "false",
+                                    "name" : "subnet-db",
+                                    "prefix" : "10.1.2.0/24",
+                                    "nsg" : {
+                                            "is_existing" : "false",
+                                            "name" : "nsg-db"
+                                    }
+                            }
+                    }
+            }
+    }
+}

--- a/deploy/v2/pipelineInputJSON/input.auto.tfvars.empty.json
+++ b/deploy/v2/pipelineInputJSON/input.auto.tfvars.empty.json
@@ -1,0 +1,60 @@
+{
+
+    "infrastructure" : {
+            "region" : "",
+
+            "resource_group" : {
+                    "is_existing" : "",
+                    "arm_id" : "",
+                    "name" : ""
+            },
+
+            "vnets" : {
+                    "management" : {
+                            "is_existing" : "",
+                            "arm_id" : "",
+                            "name" : "",
+                            "address_space" : "",
+                            "subnet_mgmt" : {
+                                    "is_existing" : "",
+                                    "arm_id" : "",
+                                    "name" : "",
+                                    "prefix" : "",
+                                    "nsg" : {
+                                            "is_existing" : "",
+                                            "arm_id" : "",
+                                            "name" : ""
+                                    }
+                            }
+                    },
+                    "sap" : {
+                            "is_existing" : "",
+                            "arm_id" : "",
+                            "name" : "",
+                            "address_space" : "",
+                            "subnet_admin" : {
+                                    "is_existing" : "",
+                                    "arm_id" : "",
+                                    "name" : "",
+                                    "prefix" : "",
+                                    "nsg" : {
+                                            "is_existing" : "",
+                                            "arm_id" : "",
+                                            "name" : ""
+                                    }
+                            },
+                            "subnet_db" : {
+                                    "is_existing" : "",
+                                    "arm_id" : "",
+                                    "name" : "",
+                                    "prefix" : "",
+                                    "nsg" : {
+                                            "is_existing" : "",
+                                            "arm_id" : "",
+                                            "name" : ""
+                                    }
+                            }
+                    }
+            }
+    }
+}

--- a/deploy/v2/pipelineInputJSON/input.auto.tfvars.existingNSG.json
+++ b/deploy/v2/pipelineInputJSON/input.auto.tfvars.existingNSG.json
@@ -1,0 +1,51 @@
+{
+
+    "infrastructure" : {
+            "region" : "westus2",
+
+            "resource_group" : {
+                    "is_existing" : "false",
+                    "name" : "VAR_AZ_RG_NAME"
+            },
+
+            "vnets" : {
+                    "management" : {
+                            "is_existing" : "false",
+                            "name" : "vnet-management",
+                            "address_space" : "10.0.0.0/16",
+                            "subnet_mgmt" : {
+                                    "is_existing" : "false",
+                                    "name" : "subnet-mgmt",
+                                    "prefix" : "10.0.1.0/24",
+                                    "nsg" : {
+                                            "is_existing" : "true",
+                                            "arm_id" : "VAR_AZ_NSG_ID"
+                                    }
+                            }
+                    },
+                    "sap" : {
+                            "is_existing" : "false",
+                            "name" : "vnet-sap",
+                            "address_space" : "10.1.0.0/16",
+                            "subnet_admin" : {
+                                    "is_existing" : "false",
+                                    "name" : "subnet-admin",
+                                    "prefix" : "10.1.1.0/24",
+                                    "nsg" : {
+                                            "is_existing" : "false",
+                                            "name" : "nsg-admin"
+                                    }
+                            },
+                            "subnet_db" : {
+                                    "is_existing" : "false",
+                                    "name" : "subnet-db",
+                                    "prefix" : "10.1.2.0/24",
+                                    "nsg" : {
+                                            "is_existing" : "false",
+                                            "name" : "nsg-db"
+                                    }
+                            }
+                    }
+            }
+    }
+}

--- a/deploy/v2/pipelineInputJSON/input.auto.tfvars.existingRG.json
+++ b/deploy/v2/pipelineInputJSON/input.auto.tfvars.existingRG.json
@@ -1,0 +1,51 @@
+{
+
+    "infrastructure" : {
+            "region" : "westus2",
+
+            "resource_group" : {
+                    "is_existing" : "true",
+					"arm_id" : "VAR_AZ_RG_ID"
+            },
+
+            "vnets" : {
+                    "management" : {
+                            "is_existing" : "false",
+                            "name" : "vnet-management",
+                            "address_space" : "10.0.0.0/16",
+                            "subnet_mgmt" : {
+                                    "is_existing" : "false",
+                                    "name" : "subnet-mgmt",
+                                    "prefix" : "10.0.1.0/24",
+                                    "nsg" : {
+                                            "is_existing" : "false",
+                                            "name" : "nsg-mgmt"
+                                    }
+                            }
+                    },
+                    "sap" : {
+                            "is_existing" : "false",
+                            "name" : "vnet-sap",
+                            "address_space" : "10.1.0.0/16",
+                            "subnet_admin" : {
+                                    "is_existing" : "false",
+                                    "name" : "subnet-admin",
+                                    "prefix" : "10.1.1.0/24",
+                                    "nsg" : {
+                                            "is_existing" : "false",
+                                            "name" : "nsg-admin"
+                                    }
+                            },
+                            "subnet_db" : {
+                                    "is_existing" : "false",
+                                    "name" : "subnet-db",
+                                    "prefix" : "10.1.2.0/24",
+                                    "nsg" : {
+                                            "is_existing" : "false",
+                                            "name" : "nsg-db"
+                                    }
+                            }
+                    }
+            }
+    }
+}

--- a/deploy/v2/pipelineInputJSON/input.auto.tfvars.existingVnet.json
+++ b/deploy/v2/pipelineInputJSON/input.auto.tfvars.existingVnet.json
@@ -1,0 +1,50 @@
+{
+
+    "infrastructure" : {
+            "region" : "westus2",
+
+            "resource_group" : {
+                    "is_existing" : "false",
+                    "name" : "VAR_AZ_RG_NAME"
+            },
+
+            "vnets" : {
+                    "management" : {
+                            "is_existing" : "true",
+                            "arm_id" : "VAR_AZ_VNET_ID",
+                            "subnet_mgmt" : {
+                                    "is_existing" : "false",
+                                    "name" : "subnet-mgmt-new",
+                                    "prefix" : "10.0.2.0/24",
+                                    "nsg" : {
+                                            "is_existing" : "false",
+                                            "name" : "nsg-mgmt"
+                                    }
+                            }
+                    },
+                    "sap" : {
+                            "is_existing" : "false",
+                            "name" : "vnet-sap",
+                            "address_space" : "10.2.0.0/16",
+                            "subnet_admin" : {
+                                    "is_existing" : "false",
+                                    "name" : "subnet-admin",
+                                    "prefix" : "10.2.1.0/24",
+                                    "nsg" : {
+                                            "is_existing" : "false",
+                                            "name" : "nsg-admin"
+                                    }
+                            },
+                            "subnet_db" : {
+                                    "is_existing" : "false",
+                                    "name" : "subnet-db",
+                                    "prefix" : "10.2.2.0/24",
+                                    "nsg" : {
+                                            "is_existing" : "false",
+                                            "name" : "nsg-db"
+                                    }
+                            }
+                    }
+            }
+    }
+}

--- a/monitor/sapmon.py
+++ b/monitor/sapmon.py
@@ -18,7 +18,7 @@ import re
 
 ###############################################################################
 
-PAYLOAD_VERSION              = "0.4.4"
+PAYLOAD_VERSION              = "0.4.3"
 PAYLOAD_DIRECTORY            = os.path.dirname(os.path.realpath(__file__))
 STATE_FILE                   = "%s/sapmon.state" % PAYLOAD_DIRECTORY
 INITIAL_LOADHISTORY_TIMESPAN = -(60 * 1)
@@ -66,12 +66,10 @@ LOG_CONFIG = {
 
 ###############################################################################
 
-ERROR_GETTING_AUTH_TOKEN       = 10
-ERROR_SETTING_KEYVAULT_SECRET  = 20
-ERROR_KEYVAULT_NOT_FOUND       = 21
-ERROR_GETTING_LOG_CREDENTIALS  = 22
-ERROR_GETTING_HANA_CREDENTIALS = 23
-ERROR_HANA_CONNECTION          = 30
+ERROR_GETTING_AUTH_TOKEN      = 10
+ERROR_SETTING_KEYVAULT_SECRET = 20
+ERROR_KEYVAULT_NOT_FOUND      = 21
+ERROR_HANA_CONNECTION         = 30
 
 ###############################################################################
 
@@ -384,13 +382,13 @@ class AzureKeyVault:
       return secrets
 
    @staticmethod
-   def exists(kvName, msiClientId):
+   def exists(kvName):
       """
       Check if a KeyVault with a specified name exists
       """
       logger.info("checking if KeyVault %s exists" % kvName)
       try:
-         kv = AzureKeyVault(kvName, msiClientId=msiClientId)
+         kv = AzureKeyVault(kvName)
          logger.debug("probing secrets of %s" % kv.uri)
          (success, response) = kv._sendRequest("%s/secrets" % kv.uri)
       except Exception as e:
@@ -398,6 +396,7 @@ class AzureKeyVault:
       return success
 
 ###############################################################################
+
 class AzureLogAnalytics:
    """
    Provide access to an Azure Log Analytics WOrkspace
@@ -481,7 +480,7 @@ class _Context(object):
       azKv = None
       kvNames = [ k % self.sapmonId for k in KEYVAULT_NAMING_CONVENTIONS ]
       for k in kvNames:
-         if AzureKeyVault.exists(k, msiClientId):
+         if AzureKeyVault.exists(k):
             logger.debug("KeyVault %s exists" % k)
             azKv = AzureKeyVault(k, msiClientId)
             break
@@ -590,8 +589,8 @@ class _Context(object):
                hanaDetails["HanaDbPassword"] = password
                logger.debug("retrieved HANA password successfully from KeyVault; password=%s" % password)
             except Exception as e:
-               logger.critical("could not fetch HANA password (instance=%s) from separate KeyVault (%s)" % (h, e))
-               sys.exit(ERROR_GETTING_HANA_CREDENTIALS)
+               logger.error("could not fetch HANA password (instance=%s) from separate KeyVault (%s)" % (h, e))
+               continue
          try:
             hanaInstance = SapHana(hanaDetails = hanaDetails)
          except Exception as e:
@@ -603,8 +602,7 @@ class _Context(object):
       try:
          laSecret = json.loads(secrets["AzureLogAnalytics"])
       except Exception as e:
-         logger.critical("could not fetch Log Analytics credentials (%s)" % e)
-         sys.exit(ERROR_GETTING_LOG_CREDENTIALS)
+         logger.error("could not parse Log Analytics credentials (%s)" % e)
       self.azLa = AzureLogAnalytics(
          laSecret["LogAnalyticsWorkspaceId"],
          laSecret["LogAnalyticsSharedKey"]

--- a/templates/terraform-deployment-steps.yaml
+++ b/templates/terraform-deployment-steps.yaml
@@ -1,0 +1,48 @@
+# This Azure pipeline YAML is a step template that will perform:
+# - Install python tools
+# - Deployment for the current test case
+
+parameters:
+#####################################################################
+# Eg:  inputJSONFile: '../pipelineInputJSON/input.auto.tfvars.      #   
+#      allNew.json'                                                 #
+#      testCaseName: 'wft-all-new'                                  #
+#      replacePlaceHolder: 'AZ_RG_NAME'                             #
+#      replaceValue: 'wft-allNew-$(Build.BuildId)'                  #
+#####################################################################
+    inputJSONFile: ''
+    testCaseName: ''
+    replacePlaceHolder: ''
+    replaceValue: ''
+steps:
+        - checkout: self
+          clean: "all"
+          path: "sap-hana"
+          persistCredentials: true
+        - script: |
+            pip install packaging
+            pip install --ignore-installed pyyaml ansible[azure]
+            sudo -H pip install msrest==0.6.0
+          displayName: 'Install python tools'
+        - script: |
+            ssh-keygen -b 4096 -t rsa -f /tmp/sshkey -q -N ""
+            cd deploy/v2/terraform
+            sed -i "s|VAR_AZ_RG_NAME|${{parameters.testCaseName}}-$(Build.BuildId)|g" $VAR_FILE_NAME
+            sed -i "s|${{parameters.replacePlaceHolder}}|${{parameters.replaceValue}}|g" $VAR_FILE_NAME
+            cat $VAR_FILE_NAME
+            terraform init
+            terraform apply -auto-approve -var-file=$VAR_FILE_NAME
+          displayName: 'Deploy test case ${{parameters.testCaseName}}'
+          env:
+            VAR_FILE_NAME: ${{parameters.inputJSONFile}}
+            VAR_AZ_RG_NAME: ${{parameters.testCaseName}}-$(Build.BuildId)
+            TF_VAR_azure_service_principal_id: $(hana-pipeline-spn-id)
+            TF_VAR_azure_service_principal_pw: $(hana-pipeline-spn-pw)
+            AZURE_CLIENT_ID: $(hana-pipeline-spn-id)
+            AZURE_SECRET: $(hana-pipeline-spn-pw)
+            AZURE_TENANT: $(landscape-tenant)
+            AZURE_SUBSCRIPTION_ID: $(landscape-subscription)
+            ARM_CLIENT_ID: $(hana-pipeline-spn-id)
+            ARM_CLIENT_SECRET: $(hana-pipeline-spn-pw)
+            ARM_TENANT_ID: $(landscape-tenant)
+            ARM_SUBSCRIPTION_ID: $(landscape-subscription)


### PR DESCRIPTION
Adding below test case for code submitted under `deploy/v2`:

- createAllNew: it creates all resources from scratch 
- reuseRG: it only reuses an existing resource group
- reuseVnet: it only reuses an existing vnet from createAllNew
- reuseNSG: it only reuses an existing NSG from createAllNew

Azure pipeline uses `azure-pipelines-wft.yaml`.
Input templates are stored under `deploy/v2/pipelineInputJSON`.

For PRs:

- That have code change(s) under `deploy/v2`
- Against master
- Contain new parameter in the JSON file

Please adjust the above templates accordingly in the PR to pass this test.