### PR TITLE
Change condition for job cleanup_rg

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -90,7 +90,7 @@ jobs:
       - group: azure-config-variables
       - group: azure-sap-hana-pipeline-secrets
   dependsOn: single_node_hana
-  condition: failed()
+  condition: or(succeededOrFailed(), always())
   steps:
   - script: |
       az login --service-principal --user $(hana-pipeline-spn-id) --password  $(hana-pipeline-spn-pw) --tenant $(landscape-tenant) --output none

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -94,5 +94,7 @@ jobs:
   steps:
   - script: |
       az login --service-principal --user $(hana-pipeline-spn-id) --password  $(hana-pipeline-spn-pw) --tenant $(landscape-tenant) --output none
-      az group delete -n single-node-$(Build.BuildId) --yes --subscription $(landscape-subscription)
+      if $(az group exists -n single-node-$(Build.BuildId)); then
+         az group delete -n single-node-$(Build.BuildId) --yes --subscription $(landscape-subscription)
+      fi     
     displayName: 'Delete resource group single-node-$(Build.BuildId)'


### PR DESCRIPTION
We have seen test failures when there are too many resource groups not been cleaned up after the execution.
With this new condition, the clean up job will run when the other jobs are: succeeded, failed, or cancelled.
This way we can keep the pipeline subscription clean, hence prevent test failure.