### PR TITLE
Exclude code paths that do not required v2 check

### DIFF
--- a/azure-pipelines-v2.yaml
+++ b/azure-pipelines-v2.yaml
@@ -10,6 +10,10 @@ pr:
   paths:
     include:
     - deploy/v2/*
+    exclude:
+    - README.md
+    - monitor/*
+    - deploy/*
 variables:
   - group: azure-config-variables
   - group: azure-sap-hana-pipeline-secrets


### PR DESCRIPTION
Explicitly exclude paths that do not need to be checked by azure-pipeline-v2.