### PR TITLE
[Bug fix] HA Pair deployment fails due to wrong Vnet name

### DIFF
--- a/deploy/v2/input.tfvars.json
+++ b/deploy/v2/input.tfvars.json
@@ -56,5 +56,62 @@
                 }
             }
         }
+    },
+
+    "jumpboxes": {
+        "windows_jumpbox": {
+	    "name": "",
+            "destroy_after_deploy": "",
+            "private_ip_address" : "",
+	    "os": {
+	        "publisher": "",
+                "offer": "",
+                "sku" : ""
+	    },
+	    "authentication": {
+	        "type": "",
+	        "username": "",
+		"password": ""
+	    },
+	    "components": []
+        },
+        
+        "linux_jumpbox" : {
+            "name": "",
+            "destroy_after_deploy": "",
+            "private_ip_address" : "",
+	    "os": {
+	        "publisher": "",
+                "offer": "",
+                "sku" : ""
+	    },
+	    "authentication": {
+	        "type": "",
+	        "username": "",
+	        "use_existing": "",
+	        "path_to_public_key": "",
+		"path_to_private_key": ""
+	    },
+	    "components": []
+        },
+        
+	"rti_box" : {
+	    "name": "",
+            "destroy_after_deploy": "",
+            "private_ip_address" : "",
+	    "os": {
+	        "publisher": "",
+                "offer": "",
+                "sku" : ""
+	    },
+	    "authentication": {
+	        "type": "",
+	        "username": "",
+	        "use_existing": "",
+	        "path_to_public_key": "",
+	        "path_to_private_key": ""
+	    },
+	    "components": []
+       	}
     }
 }

--- a/deploy/v2/template_samples/single_node_hana.tfvars.json
+++ b/deploy/v2/template_samples/single_node_hana.tfvars.json
@@ -1,0 +1,113 @@
+{
+
+    "infrastructure" : {
+        "region" : "eastus",
+
+        "resource_group" : {
+            "is_existing" : "false",
+            "name" : "test-rg"
+        },
+
+        "vnets" : {
+            "management" : {
+                "is_existing" : "false",
+                "name" : "vnet-mgmt",
+                "address_space" : "10.0.0.0/16",
+                "subnet_mgmt" : {
+                    "is_existing" : "false",
+                    "name" : "subnet-mgmt",
+                    "prefix" : "10.0.1.0/24",
+                    "nsg" : {
+                        "is_existing" : "false",
+                        "name" : "nsg-mgmt"
+                    }
+                }
+            },
+            "sap" : {
+                "is_existing" : "false",
+                "name" : "vnet-sap",
+                "address_space" : "10.1.0.0/16",
+                "subnet_admin" : {
+                    "is_existing" : "false",
+                    "name" : "subnet-admin",
+                    "prefix" : "10.1.1.0/24",
+                    "nsg" : {
+                        "is_existing" : "false",
+                        "name" : "nsg-admin"
+                    }
+                },
+                "subnet_db" : {
+                    "is_existing" : "false",
+                    "name" : "subnet-db",
+                    "prefix" : "10.1.2.0/24",
+                    "nsg" : {
+                        "is_existing" : "false",
+                        "name" : "nsg-db"
+                    }
+                }
+            }
+        }
+    },
+
+    "jumpboxes": {
+        "windows_jumpbox": {
+                "name": "jumpbox-windows",
+                "destroy_after_deploy": "false",
+                "os": {
+	            "publisher": "MicrosoftWindowsServer",
+                    "offer": "WindowsServer",
+                    "sku" : "2016-Datacenter"
+		},
+	        "authentication": {
+		    "type": "credentials",
+		    "username": "azureadm",
+		    "password": "Sap@hana2019!"
+	        },
+	        "components": [
+	            "hana_studio_windows",
+		    "sap_router"
+	        ]  
+        },
+        
+        "linux_jumpbox" : {
+            "name": "jumpbox-linux",
+            "destroy_after_deploy": "false",
+	    "os": {
+	        "publisher": "Redhat",
+                "offer": "RHEL-SAP",
+                "sku" : "7.5"
+	    },
+	    "authentication": {
+	        "type": "key",
+		"username": "azureadm",
+		"use_existing": "true",
+		"path_to_public_key": "~/.ssh/ssh_key.pub",
+		"path_to_private_key": "~/.ssh/ssh_key"
+	    },
+	    "components": [
+	        "hana_studio_linux",
+		"sap_router"
+	    ]
+        },
+
+	"rti_box" : {
+	    "name": "rti",
+            "destroy_after_deploy": "true",
+	    "os": {
+	        "publisher": "Redhat",
+                "offer": "RHEL-SAP",
+                "sku" : "7.5"
+	    },
+	    "authentication": {
+	        "type": "key",
+		"username": "azureadm",
+		"use_existing": "false",
+		"path_to_public_key": "~/.ssh/ssh_key.pub",
+		"path_to_private_key": "~/.ssh/ssh_key"
+	    },
+	    "components": [
+	        "ansible"
+	    ]
+        }
+    }   
+}

--- a/deploy/v2/terraform/main.tf
+++ b/deploy/v2/terraform/main.tf
@@ -9,3 +9,14 @@ module "common_infrastructure" {
   is_single_node_hana = "true"
   infrastructure      = var.infrastructure
 }
+
+# Create Jumpboxes and RTI box
+module "jumpbox" {
+  source         = "./modules/jumpbox"
+  infrastructure = var.infrastructure
+  jumpboxes      = var.jumpboxes
+  rg             = module.common_infrastructure.rg
+  subnet-mgmt    = module.common_infrastructure.subnet-mgmt
+  nsg-mgmt       = module.common_infrastructure.nsg-mgmt
+
+}

--- a/deploy/v2/terraform/main.tf
+++ b/deploy/v2/terraform/main.tf
@@ -18,5 +18,4 @@ module "jumpbox" {
   rg             = module.common_infrastructure.rg
   subnet-mgmt    = module.common_infrastructure.subnet-mgmt
   nsg-mgmt       = module.common_infrastructure.nsg-mgmt
-
 }

--- a/deploy/v2/terraform/modules/common_infrastructure/outputs.tf
+++ b/deploy/v2/terraform/modules/common_infrastructure/outputs.tf
@@ -1,0 +1,11 @@
+output "rg" {
+  value = var.infrastructure.resource_group.is_existing ? data.azurerm_resource_group.rg : azurerm_resource_group.rg
+}
+
+output "subnet-mgmt" {
+  value = var.infrastructure.vnets.management.subnet_mgmt.is_existing ? data.azurerm_subnet.subnet-mgmt : azurerm_subnet.subnet-mgmt
+}
+
+output "nsg-mgmt" {
+  value = var.infrastructure.vnets.management.subnet_mgmt.nsg.is_existing ? data.azurerm_network_security_group.nsg-mgmt : azurerm_network_security_group.nsg-mgmt
+}

--- a/deploy/v2/terraform/modules/jumpbox/main.tf
+++ b/deploy/v2/terraform/modules/jumpbox/main.tf
@@ -24,7 +24,7 @@ resource "azurerm_storage_account" "storageaccount-bootdiagnostics" {
 
 # NETWORK SECURITY RULES =========================================================================================
 
-# Creates jumpbox rdp network security rule
+# Creates jumpbox RDP network security rule
 resource "azurerm_network_security_rule" "nsr-rdp" {
   name                        = "rdp"
   resource_group_name         = var.rg[0].name
@@ -39,7 +39,7 @@ resource "azurerm_network_security_rule" "nsr-rdp" {
   destination_address_prefix  = "*"
 }
 
-# Creates jumpbox ssh network security rule
+# Creates jumpbox SSH network security rule
 resource "azurerm_network_security_rule" "nsr-ssh" {
   name                        = "ssh"
   resource_group_name         = var.rg[0].name
@@ -56,7 +56,7 @@ resource "azurerm_network_security_rule" "nsr-ssh" {
 
 # NICS ============================================================================================================
 
-# Creates the jumpbox nic and ip
+# Creates the jumpbox NIC and IP address
 resource "azurerm_network_interface" "nic-primary" {
   for_each                      = var.jumpboxes
   name                          = "${each.value.name}-nic1"
@@ -75,7 +75,7 @@ resource "azurerm_network_interface" "nic-primary" {
 
 # VIRTUAL MACHINES ================================================================================================
 
-# Creates linux vm
+# Creates Linux VM
 resource "azurerm_virtual_machine" "vm-linux" {
   for_each                      = { for k, v in var.jumpboxes : (k) => (v) if replace(v.os.publisher, "Windows", "") == v.os.publisher }
   name                          = each.value.name
@@ -116,10 +116,9 @@ resource "azurerm_virtual_machine" "vm-linux" {
     enabled     = true
     storage_uri = azurerm_storage_account.storageaccount-bootdiagnostics.primary_blob_endpoint
   }
-
 }
 
-# Creates windows vm
+# Creates Windows VM
 resource "azurerm_virtual_machine" "vm-windows" {
   for_each                      = { for k, v in var.jumpboxes : (k) => (v) if replace(v.os.publisher, "Windows", "") != v.os.publisher }
   name                          = each.value.name
@@ -156,5 +155,4 @@ resource "azurerm_virtual_machine" "vm-windows" {
     enabled     = true
     storage_uri = azurerm_storage_account.storageaccount-bootdiagnostics.primary_blob_endpoint
   }
-
 }

--- a/deploy/v2/terraform/modules/jumpbox/main.tf
+++ b/deploy/v2/terraform/modules/jumpbox/main.tf
@@ -1,0 +1,161 @@
+##################################################################################################################
+# JUMPBOXES
+##################################################################################################################
+
+# BOOT DIAGNOSTICS ===============================================================================================
+
+# Generates random text for boot diagnostics storage account name
+resource "random_id" "random-id" {
+  keepers = {
+    # Generate a new id only when a new resource group is defined
+    resource_group = var.rg[0].name
+  }
+  byte_length = 8
+}
+
+# Creates boot diagnostics storage account
+resource "azurerm_storage_account" "storageaccount-bootdiagnostics" {
+  name                     = "diag${random_id.random-id.hex}"
+  resource_group_name      = var.rg[0].name
+  location                 = var.rg[0].location
+  account_replication_type = "LRS"
+  account_tier             = "Standard"
+}
+
+# NETWORK SECURITY RULES =========================================================================================
+
+# Creates jumpbox rdp network security rule
+resource "azurerm_network_security_rule" "nsr-rdp" {
+  name                        = "rdp"
+  resource_group_name         = var.rg[0].name
+  network_security_group_name = var.nsg-mgmt[0].name
+  priority                    = 101
+  direction                   = "Inbound"
+  access                      = "allow"
+  protocol                    = "Tcp"
+  source_port_range           = "*"
+  destination_port_range      = 3389
+  source_address_prefix       = "*"
+  destination_address_prefix  = "*"
+}
+
+# Creates jumpbox ssh network security rule
+resource "azurerm_network_security_rule" "nsr-ssh" {
+  name                        = "ssh"
+  resource_group_name         = var.rg[0].name
+  network_security_group_name = var.nsg-mgmt[0].name
+  priority                    = 102
+  direction                   = "Inbound"
+  access                      = "allow"
+  protocol                    = "Tcp"
+  source_port_range           = "*"
+  destination_port_range      = 22
+  source_address_prefix       = "*"
+  destination_address_prefix  = "*"
+}
+
+# NICS ============================================================================================================
+
+# Creates the jumpbox nic and ip
+resource "azurerm_network_interface" "nic-primary" {
+  for_each                      = var.jumpboxes
+  name                          = "${each.value.name}-nic1"
+  location                      = var.rg[0].location
+  resource_group_name           = var.rg[0].name
+  network_security_group_id     = var.nsg-mgmt[0].id
+  enable_accelerated_networking = "true"
+
+  ip_configuration {
+    name                          = "${each.value.name}-nic1-ip"
+    subnet_id                     = var.subnet-mgmt[0].id
+    private_ip_address            = var.infrastructure.vnets.management.subnet_mgmt.is_existing ? each.value.private_ip_address : each.key == "linux_jumpbox" ? lookup(var.jumpboxes.linux_jumpbox, "private_ip_address", false) != false ? each.value.private_ip_address : cidrhost(var.infrastructure.vnets.management.subnet_mgmt.prefix, 4) : each.key == "windows_jumpbox" ? lookup(var.jumpboxes.windows_jumpbox, "private_ip_address", false) != false ? each.value.private_ip_address : cidrhost(var.infrastructure.vnets.management.subnet_mgmt.prefix, 5) : each.key == "rti_box" ? lookup(var.jumpboxes.rti_box, "private_ip_address", false) != false ? each.value.private_ip_address : cidrhost(var.infrastructure.vnets.management.subnet_mgmt.prefix, 6) : null
+    private_ip_address_allocation = "static"
+  }
+}
+
+# VIRTUAL MACHINES ================================================================================================
+
+# Creates linux vm
+resource "azurerm_virtual_machine" "vm-linux" {
+  for_each                      = { for k, v in var.jumpboxes : (k) => (v) if replace(v.os.publisher, "Windows", "") == v.os.publisher }
+  name                          = each.value.name
+  location                      = var.rg[0].location
+  resource_group_name           = var.rg[0].name
+  network_interface_ids         = [azurerm_network_interface.nic-primary[each.key].id]
+  vm_size                       = "Standard_D4s_v3"
+  delete_os_disk_on_termination = "true"
+
+  storage_os_disk {
+    name              = "${each.value.name}-osdisk"
+    caching           = "ReadWrite"
+    create_option     = "FromImage"
+    managed_disk_type = "StandardSSD_LRS"
+  }
+
+  storage_image_reference {
+    publisher = each.value.os.publisher
+    offer     = each.value.os.offer
+    sku       = each.value.os.sku
+    version   = "latest"
+  }
+
+  os_profile {
+    computer_name  = each.value.name
+    admin_username = each.value.authentication.username
+  }
+
+  os_profile_linux_config {
+    disable_password_authentication = true
+    ssh_keys {
+      path     = "/home/${each.value.authentication.username}/.ssh/authorized_keys"
+      key_data = file(lookup(each.value.authentication, "path_to_public_key", "~/.ssh/ssh_key.pub"))
+    }
+  }
+
+  boot_diagnostics {
+    enabled     = true
+    storage_uri = azurerm_storage_account.storageaccount-bootdiagnostics.primary_blob_endpoint
+  }
+
+}
+
+
+# Creates windows vm
+resource "azurerm_virtual_machine" "vm-windows" {
+  for_each                      = { for k, v in var.jumpboxes : (k) => (v) if replace(v.os.publisher, "Windows", "") != v.os.publisher }
+  name                          = each.value.name
+  location                      = var.rg[0].location
+  resource_group_name           = var.rg[0].name
+  network_interface_ids         = [azurerm_network_interface.nic-primary[each.key].id]
+  vm_size                       = "Standard_D4s_v3"
+  delete_os_disk_on_termination = "true"
+
+  storage_os_disk {
+    name              = "${each.value.name}-osdisk"
+    caching           = "ReadWrite"
+    create_option     = "FromImage"
+    managed_disk_type = "StandardSSD_LRS"
+  }
+
+  storage_image_reference {
+    publisher = each.value.os.publisher
+    offer     = each.value.os.offer
+    sku       = each.value.os.sku
+    version   = "latest"
+  }
+
+  os_profile {
+    computer_name  = each.value.name
+    admin_username = each.value.authentication.username
+    admin_password = each.value.authentication.password
+  }
+
+  os_profile_windows_config {
+  }
+
+  boot_diagnostics {
+    enabled     = true
+    storage_uri = azurerm_storage_account.storageaccount-bootdiagnostics.primary_blob_endpoint
+  }
+
+}

--- a/deploy/v2/terraform/modules/jumpbox/main.tf
+++ b/deploy/v2/terraform/modules/jumpbox/main.tf
@@ -119,7 +119,6 @@ resource "azurerm_virtual_machine" "vm-linux" {
 
 }
 
-
 # Creates windows vm
 resource "azurerm_virtual_machine" "vm-windows" {
   for_each                      = { for k, v in var.jumpboxes : (k) => (v) if replace(v.os.publisher, "Windows", "") != v.os.publisher }

--- a/deploy/v2/terraform/modules/jumpbox/main.tf
+++ b/deploy/v2/terraform/modules/jumpbox/main.tf
@@ -108,7 +108,7 @@ resource "azurerm_virtual_machine" "vm-linux" {
     disable_password_authentication = true
     ssh_keys {
       path     = "/home/${each.value.authentication.username}/.ssh/authorized_keys"
-      key_data = file(lookup(each.value.authentication, "path_to_public_key", "~/.ssh/ssh_key.pub"))
+      key_data = file(each.value.authentication.path_to_public_key)
     }
   }
 

--- a/deploy/v2/terraform/modules/jumpbox/main.tf
+++ b/deploy/v2/terraform/modules/jumpbox/main.tf
@@ -28,7 +28,7 @@ resource "azurerm_storage_account" "storageaccount-bootdiagnostics" {
 resource "azurerm_network_security_rule" "nsr-rdp" {
   count                       = lookup(var.jumpboxes, "windows_jumpbox", false) != false ? 1 : 0
   name                        = "rdp"
-  resource_group_name         = var.rg[0].name
+  resource_group_name         = var.nsg-mgmt[0].resource_group_name
   network_security_group_name = var.nsg-mgmt[0].name
   priority                    = 101
   direction                   = "Inbound"
@@ -44,7 +44,7 @@ resource "azurerm_network_security_rule" "nsr-rdp" {
 resource "azurerm_network_security_rule" "nsr-ssh" {
   for_each                    = { for k, v in var.jumpboxes : (k) => (v) if replace(v.os.publisher, "Windows", "") == v.os.publisher }
   name                        = "${each.key}-ssh"
-  resource_group_name         = var.rg[0].name
+  resource_group_name         = var.nsg-mgmt[0].resource_group_name
   network_security_group_name = var.nsg-mgmt[0].name
   priority                    = each.key == "linux_jumpbox" ? 102 : 103
   direction                   = "Inbound"

--- a/deploy/v2/terraform/modules/jumpbox/variables.tf
+++ b/deploy/v2/terraform/modules/jumpbox/variables.tf
@@ -15,5 +15,5 @@ variable "subnet-mgmt" {
 }
 
 variable "nsg-mgmt" {
-  description = "Details of the management nsg"
+  description = "Details of the management NSG"
 }

--- a/deploy/v2/terraform/modules/jumpbox/variables.tf
+++ b/deploy/v2/terraform/modules/jumpbox/variables.tf
@@ -1,0 +1,19 @@
+variable "jumpboxes" {
+  description = "Details of the jumpboxes"
+}
+
+variable "infrastructure" {
+  description = "Details of the Azure infrastructure to deploy the SAP landscape into"
+}
+
+variable "rg" {
+  description = "Details of the resource group"
+}
+
+variable "subnet-mgmt" {
+  description = "Details of the management subnet"
+}
+
+variable "nsg-mgmt" {
+  description = "Details of the management nsg"
+}

--- a/deploy/v2/terraform/variables.tf
+++ b/deploy/v2/terraform/variables.tf
@@ -1,3 +1,7 @@
 variable "infrastructure" {
   description = "Details of the Azure infrastructure to deploy the SAP landscape into"
 }
+
+variable "jumpboxes" {
+  description = "Details of the jumpboxes and RTI box"
+}

--- a/deploy/vm/modules/common_setup/outputs.tf
+++ b/deploy/vm/modules/common_setup/outputs.tf
@@ -7,7 +7,7 @@ output "vnet_subnets" {
 }
 
 output "vnet_name" {
-  value = azurerm_subnet.subnet.name
+  value = azurerm_virtual_network.vnet.name
 }
 
 output "resource_group_name" {


### PR DESCRIPTION
Error message:
>TASK [detach public ip from the nic] *******************************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Error creating or updating network interface iscsi-nic - Azure Error: InvalidResourceReference\nMessage: Resource /subscriptions/c4106f40-4f28-442e-b67f-a24d892bf7ad/resourceGroups/nancyc_ha3/providers/Microsoft.Network/virtualNetworks/hdb-subnet/subnets/hdb-subnet referenced by resource /subscriptions/c4106f40-4f28-442e-b67f-a24d892bf7ad/resourceGroups/nancyc_ha3/providers/Microsoft.Network/networkInterfaces/iscsi-nic was not found. Please make sure that the referenced resource exists, and that both resources are in the same region."}

This is due to a wrong assignment for vnet_name in common_setup/outputs.tf
