### PR TITLE
[HOT FIX] HA Pair deployment fails due to wrong vnet name

### DIFF
--- a/deploy/vm/modules/common_setup/outputs.tf
+++ b/deploy/vm/modules/common_setup/outputs.tf
@@ -7,7 +7,7 @@ output "vnet_subnets" {
 }
 
 output "vnet_name" {
-  value = azurerm_subnet.subnet.name
+  value = azurerm_virtual_network.vnet.name
 }
 
 output "resource_group_name" {


### PR DESCRIPTION
Error message:
>TASK [detach public ip from the nic] *******************************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Error creating or updating network interface iscsi-nic - Azure Error: InvalidResourceReference\nMessage: Resource /subscriptions/c4106f40-4f28-442e-b67f-a24d892bf7ad/resourceGroups/nancyc_ha3/providers/Microsoft.Network/virtualNetworks/hdb-subnet/subnets/hdb-subnet referenced by resource /subscriptions/c4106f40-4f28-442e-b67f-a24d892bf7ad/resourceGroups/nancyc_ha3/providers/Microsoft.Network/networkInterfaces/iscsi-nic was not found. Please make sure that the referenced resource exists, and that both resources are in the same region."}

This is due to a wrong assignment for vnet_name in common_setup/outputs.tf