### PR TITLE
Exclude folders from azure pipeline testing

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,6 +13,8 @@ pr:
     - README.md
     - monitor/*
     - deploy/v2/*
+    - templates/*
+    - tools/*
 jobs:
 - job: single_node_hana
   variables:


### PR DESCRIPTION
The code under folders `tools` and `templates` are irrelevant to single HANA deployment.
Therefore exclude them from azure pipeline testing.
