### PR TITLE
[Bug fix] Remove --no-wait from rg deletion

### DIFF
--- a/azure-pipelines-v2.yaml
+++ b/azure-pipelines-v2.yaml
@@ -130,7 +130,7 @@ stages:
       parameters:
         testCaseName: $(testcase)
 #####################################################################
-# This stage destroy resources created from all above test cases.    #
+# This stage destroy resources created from all above test cases.   #
 # It will be triggered after stage CreatingResources is finished.   #
 # It will always be triggered, regardless the status of stage one - #
 # success of fail                                                   #
@@ -152,7 +152,7 @@ stages:
           for rg in "${rg_list[@]}"
           do
             if $(az group exists -n $rg); then
-              az group delete -n $rg --no-wait -y
+              az group delete -n $rg -y
               echo $rg
             fi
           done


### PR DESCRIPTION
Due to the resource dependencies between different scenarios, the az group deletion has to be executed sequentially and has to wait for the previous one to finish. 
Otherwise we see errors in resource group deletion when the previous deletion takes longer.

Error example for deleting v2-reuseVNET-359:
>Network security group /subscriptions/91a338db-aa0d-4a34-aed0-dbbbc698de30/resourceGroups/v2-reuseVNET-359/providers/Microsoft.Network/networkSecurityGroups/nsg-mgmt cannot be deleted because it is in use by the following resources: /subscriptions/91a338db-aa0d-4a34-aed0-dbbbc698de30/resourceGroups/v2-allNew-359/providers/Microsoft.Network/virtualNetworks/vnet-mgmt/subnets/subnet-mgmt-new. In order to delete the Network security group, remove the association with the resource(s). To learn how to do this, see aka.ms/deletensg.