### PR TITLE
[HOT FIX] Disable CI trigger for azure pipeline Azure.sap-hana.v2

### DIFF
--- a/azure-pipelines-v2.yaml
+++ b/azure-pipelines-v2.yaml
@@ -1,8 +1,9 @@
 # This Azure pipeline YAML contains tests to validate and verify the pull requests made for automated deployment of SAP landscape.
 # This pipeline will only run all the tests if the PR is made from a branch of Azure/sap-hana repo.
 # Branches from forked repositories will fail in the Azure provider authentication phase due to security reason
+# A pipeline with no CI trigger
+trigger: none
 # Only trigger build when a PR is opened for code under deploy/v2
-
 pr:
   branches:
     include:


### PR DESCRIPTION
After more resources are introduced into the deployment, to have both CI trigger and PR trigger easily max out the quota limits:

>2019-08-21T03:48:48.3769799Z [1m[31mError: [0m[0m[1mcompute.VirtualMachinesClient#CreateOrUpdate: Failure sending request: StatusCode=0 -- Original Error: autorest/azure: Service returned an error. Status=<nil> Code="OperationNotAllowed" Message="Operation results in exceeding quota limits of Core. Maximum allowed: 100, Current in use: 100, Additional requested: 4. Please read more about quota increase at https://aka.ms/ProdportalCRP/?#create/Microsoft.Support/Parameters/{\"subId\":\"***\",\"pesId\":\"15621\",\"supportTopicId\":\"32447243\"}."[0m

This prevent new PRs from passing the pipeline test.