### PR TITLE
Fix issue where some VLI systems wouldn't be recognized

### DIFF
--- a/tools/checksystem.sh
+++ b/tools/checksystem.sh
@@ -52,8 +52,9 @@ checkNicConfig()
   # Verify that flags are properly set to avoid port flapping on VLI systems
 
   # If this isn't a HPE VLI system, then there are no NIC flags to be concerned of
+  #   Note that product name can be one of: UV300, HPE, or "HPE Integrity MC990 X Server"
   PRODUCT_NAME=$(dmidecode -s system-product-name)
-  if [ "${PRODUCT_NAME}" != "UV300" ] && [ "${PRODUCT_NAME}" != "HPE" ]; then
+  if [ "${PRODUCT_NAME}" != "UV300" ] && [ "${PRODUCT_NAME}" != "HPE" ] && [[ ! "${PRODUCT_NAME}" =~ "MC990 X" ]]; then
     echo "Note: System is not a VLI system - skipping NIC checks"
     return
   fi


### PR DESCRIPTION
We were using "dmidecode" to determine what type of system we were
running on, with expected answers of "UV300" or "HPE". Turns out
that the system can also report as "HPE Integrity MC990 X Server".

If "MC990 X" is anywhere in the response, allow that as recognition
of a VLI system.