### PR TITLE
Map Log Analytics TimeGenerated field to UTC_TIMESTAMP column

### DIFF
--- a/monitor/sapmon.py
+++ b/monitor/sapmon.py
@@ -18,7 +18,7 @@ import re
 
 ###############################################################################
 
-PAYLOAD_VERSION              = "0.4.4"
+PAYLOAD_VERSION              = "0.4.5"
 PAYLOAD_DIRECTORY            = os.path.dirname(os.path.realpath(__file__))
 STATE_FILE                   = "%s/sapmon.state" % PAYLOAD_DIRECTORY
 INITIAL_LOADHISTORY_TIMESPAN = -(60 * 1)
@@ -437,6 +437,7 @@ x-ms-date:%s
          "Authorization": buildSig(jsonData, timestamp),
          "Log-Type":      logType,
          "x-ms-date":     timestamp,
+         "time-generated-field": "UTC_TIMESTAMP",
       }
       logger.debug("headers=%s" % headers)
       logger.debug("data=%s" % jsonData)


### PR DESCRIPTION
- This PR maps the TimeGenerated field in Log Analytics to the UTC_TIMESTAMP column of the SQL result set as described [here](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/data-collector-api).
- This was requested internally (MSIT), as KQL relies on the TimeGenerated field for predictive analytics/anomaly detection.