### PR TITLE
Remove logic to cover multiple KeyVault naming conventions

### DIFF
--- a/monitor/sapmon.py
+++ b/monitor/sapmon.py
@@ -18,7 +18,7 @@ import re
 
 ###############################################################################
 
-PAYLOAD_VERSION              = "0.4.4"
+PAYLOAD_VERSION              = "0.4.5"
 PAYLOAD_DIRECTORY            = os.path.dirname(os.path.realpath(__file__))
 STATE_FILE                   = "%s/sapmon.state" % PAYLOAD_DIRECTORY
 INITIAL_LOADHISTORY_TIMESPAN = -(60 * 1)
@@ -437,6 +437,7 @@ x-ms-date:%s
          "Authorization": buildSig(jsonData, timestamp),
          "Log-Type":      logType,
          "x-ms-date":     timestamp,
+         "time-generated-field": "UTC_TIMESTAMP",
       }
       logger.debug("headers=%s" % headers)
       logger.debug("data=%s" % jsonData)


### PR DESCRIPTION
- We've now closed on the naming convention for all required resources inside the managed resource group; specifically, the KeyVault is named `sapmon-kv-1234567890abcd` (where 1234567890abcd denotes the unique sapmonId).
  - Since there are no more SAP Monitor instances using the legacy naming convention (`sapmon1234567890abcd`), it is unnecessary to check for it.
- Therefore, the logic introduced in PR #197 to identify the correct KeyVault name (`function _Context.identifyKeyVault()`) is no longer needed and has been removed in this PR.
