### PR TITLE
[HOTFIX] fix error in targetcli-fb install

### DIFF
--- a/deploy/vm/ansible/roles/iscsi-setup/tasks/main.yml
+++ b/deploy/vm/ansible/roles/iscsi-setup/tasks/main.yml
@@ -24,6 +24,10 @@
     name: targetcli
     state: absent
 
+# HOTFIX for issue 220
+- name: Re-register the SLE instance against its respective cloud repository
+  command: /usr/sbin/registercloudguest --force-new
+
 - name: Install iSCSI target packages
   package:
     name: targetcli-fb


### PR DESCRIPTION
Currently HA pair deployment fails due to [bug 1150395](https://bugzilla.suse.com/show_bug.cgi?id=1150395) with SUSE.
Before we are able to updating cloud-regionsrv-client package to version 9.0.3, this fix will force re-register the SLES instance against its respective cloud repository to avoid the problem.