### PR TITLE
Fix JSON de-serializer for SAP Monitor state file

### DIFF
--- a/monitor/configureMonitorVM.sh
+++ b/monitor/configureMonitorVM.sh
@@ -35,3 +35,5 @@ ExecuteCommand "pip3 install pyhdb"
 ExecuteCommand "pip3 install azure_storage_logging"
 # Install azure-mgmt-storage
 ExecuteCommand "pip3 install azure-mgmt-storage"
+# Install JSON-Datetime
+ExecuteCommand "pip3 install json-datetime"

--- a/monitor/sapmon.py
+++ b/monitor/sapmon.py
@@ -18,6 +18,7 @@ import hashlib
 import hmac
 import http.client as http_client
 import json
+import jsondatetime
 import logging
 import logging.config
 import os
@@ -28,10 +29,11 @@ import sys
 
 ###############################################################################
 
-PAYLOAD_VERSION                   = "0.6.1"
+PAYLOAD_VERSION                   = "0.6.2"
 PAYLOAD_DIRECTORY                 = os.path.dirname(os.path.realpath(__file__))
 STATE_FILE                        = "%s/sapmon.state" % PAYLOAD_DIRECTORY
 TIME_FORMAT_LOG_ANALYTICS         = "%a, %d %b %Y %H:%M:%S GMT"
+TIME_FORMAT_JSON                  = "%Y-%m-%dT%H:%M:%S.%fZ"
 DEFAULT_CONSOLE_LOG_LEVEL         = logging.INFO
 DEFAULT_FILE_LOG_LEVEL            = logging.INFO
 DEFAULT_QUEUE_LOG_LEVEL           = logging.DEBUG
@@ -646,7 +648,7 @@ class _Context(object):
          logger.debug("STATE_FILE=%s" % STATE_FILE)
          with open(STATE_FILE, "r") as file:
             data = file.read()
-         jsonData = json.loads(data, object_hook=_JsonDecoder.datetimeHook)
+         jsonData = jsondatetime.loads(data)
       except FileNotFoundError as e:
          logger.warning("state file %s does not exist" % STATE_FILE)
       except Exception as e:
@@ -675,8 +677,8 @@ class _Context(object):
          for c in self.availableChecks:
             sectionKey = "%s_%s" % (c.prefix, c.name)
             jsonData[sectionKey] = c.state
-         with open(STATE_FILE, "w") as f:
-            json.dump(jsonData, f, indent=3, cls=_JsonEncoder)
+         with open(STATE_FILE, "w") as file:
+            json.dump(jsonData, file, indent=3, cls=_JsonEncoder)
          success = True
       except Exception as e:
          logger.error("could not write state file %s (%s)" % (STATE_FILE, e))
@@ -753,20 +755,8 @@ class _JsonEncoder(json.JSONEncoder):
       if isinstance(o, decimal.Decimal):
          return float(o)
       elif isinstance(o, (datetime, date)):
-         return o.isoformat()
+         return datetime.strftime(o, TIME_FORMAT_JSON)
       return super(_JsonEncoder, self).default(o)
-
-class _JsonDecoder(json.JSONDecoder):
-   """
-   Helper class to de-serialize JSON into datetime and Decimal objects
-   """
-   def datetimeHook(jsonData):
-      for (k, v) in jsonData.items():
-         try:
-            jsonData[k] = datetime.strptime(v, "%Y-%m-%dT%H:%M:%S.%f")
-         except Exception as e:
-            pass
-      return jsonData
 
 ###############################################################################
 


### PR DESCRIPTION
- A bug in the JSON de-serializer (module _JsonDecoder) resulted in incorrect lastRun timestamps being read from the payload state file. This led to monitoring checks being skipped although they should have been executed.
- This fix addresses this issue by using a more robust JSON decoder for datetime data types.