### PR TITLE
[HOTFIX] Revert json datetime encoding and fix the typeerror

### DIFF
--- a/monitor/configureMonitorVM.sh
+++ b/monitor/configureMonitorVM.sh
@@ -35,5 +35,3 @@ ExecuteCommand "pip3 install pyhdb"
 ExecuteCommand "pip3 install azure_storage_logging"
 # Install azure-mgmt-storage
 ExecuteCommand "pip3 install azure-mgmt-storage"
-# Install JSON-Datetime
-ExecuteCommand "pip3 install json-datetime"

--- a/monitor/sapmon.py
+++ b/monitor/sapmon.py
@@ -165,9 +165,9 @@ class SapHanaCheck(SapmonCheck):
             logger.info("time series query for check %s_%s has been run at %s, filter out only new records since then" % \
                (self.prefix, self.name, lastRunServer.strftime(self.TIME_FORMAT_HANA)))
             try:
-               sqlUntilNow = " WHERE ADD_SECONDS(h.TIME, i.VALUE*(-1)) > '%s' AND" % lastRunServer.strftime(self.TIME_FORMAT_HANA)
+               sqlUntilNow = " WHERE ADD_SECONDS(h.TIME, i.VALUE*(-1)) > '%s' AND" % lastRunServer
             except Exception as e:
-               logger.error("could not format lastRunServer=%s (%s)" % (str(lastRunServer), e))
+               logger.error("could not format lastRunServer=%s (%s)" % lastRunServer, e)
                return None
          logger.debug("sqlUntilNow=%s" % sqlUntilNow)
          sql = sql.replace(" WHERE", sqlUntilNow, 1)

--- a/monitor/sapmon.py
+++ b/monitor/sapmon.py
@@ -18,7 +18,6 @@ import hashlib
 import hmac
 import http.client as http_client
 import json
-import jsondatetime
 import logging
 import logging.config
 import os
@@ -34,7 +33,6 @@ PAYLOAD_VERSION                   = "0.6.3"
 PAYLOAD_DIRECTORY                 = os.path.dirname(os.path.realpath(__file__))
 STATE_FILE                        = "%s/sapmon.state" % PAYLOAD_DIRECTORY
 TIME_FORMAT_LOG_ANALYTICS         = "%a, %d %b %Y %H:%M:%S GMT"
-TIME_FORMAT_JSON                  = "%Y-%m-%dT%H:%M:%S.%fZ"
 DEFAULT_CONSOLE_LOG_LEVEL         = logging.INFO
 DEFAULT_FILE_LOG_LEVEL            = logging.INFO
 DEFAULT_QUEUE_LOG_LEVEL           = logging.DEBUG
@@ -649,7 +647,7 @@ class _Context(object):
          logger.debug("STATE_FILE=%s" % STATE_FILE)
          with open(STATE_FILE, "r") as file:
             data = file.read()
-         jsonData = jsondatetime.loads(data)
+         jsonData = json.loads(data, object_hook=_JsonDecoder.datetimeHook)
       except FileNotFoundError as e:
          logger.warning("state file %s does not exist" % STATE_FILE)
       except Exception as e:
@@ -678,8 +676,8 @@ class _Context(object):
          for c in self.availableChecks:
             sectionKey = "%s_%s" % (c.prefix, c.name)
             jsonData[sectionKey] = c.state
-         with open(STATE_FILE, "w") as file:
-            json.dump(jsonData, file, indent=3, cls=_JsonEncoder)
+         with open(STATE_FILE, "w") as f:
+            json.dump(jsonData, f, indent=3, cls=_JsonEncoder)
          success = True
       except Exception as e:
          logger.error("could not write state file %s (%s)" % (STATE_FILE, e))
@@ -756,8 +754,20 @@ class _JsonEncoder(json.JSONEncoder):
       if isinstance(o, decimal.Decimal):
          return float(o)
       elif isinstance(o, (datetime, date)):
-         return datetime.strftime(o, TIME_FORMAT_JSON)
+         return o.isoformat()
       return super(_JsonEncoder, self).default(o)
+
+class _JsonDecoder(json.JSONDecoder):
+   """
+   Helper class to de-serialize JSON into datetime and Decimal objects
+   """
+   def datetimeHook(jsonData):
+      for (k, v) in jsonData.items():
+         try:
+            jsonData[k] = datetime.strptime(v, "%Y-%m-%dT%H:%M:%S.%f")
+         except Exception as e:
+            pass
+      return jsonData
 
 ###############################################################################
 


### PR DESCRIPTION
This PR reverts the last commit that uses jsondatetime to handle json of datetime object since the python library is not compatible and breaking deployment as well. 
This PR also fixes the typeerror that is a result of the revert stated above.