### PR TITLE
Add HANA System Availability check

### DIFF
--- a/monitor/SapHana.json
+++ b/monitor/SapHana.json
@@ -1,6 +1,6 @@
 {
         "contentType": "HANA",
-        "contentVersion": "0.1.0",
+        "contentVersion": "0.2.0",
         "checks": [
                 {
                         "name": "HostConfig",
@@ -18,8 +18,19 @@
                         "frequencySecs": 60,
                         "hanaOptions": {
                                 "isTimeSeries": true,
-                                "initialTimespanSecs": 30,
-                                "query": "SELECT h.TIME AS _SERVER_LOCALTIME, i.VALUE AS _SERVER_UTC_OFFSET, ADD_SECONDS(h.TIME, i.VALUE*(-1)) AS _TIMESERIES_UTC, h.HOST AS HOST, 'HOST' AS SCOPE, MAP(h.CPU, null, -1 , -1, -1, ROUND(100 * h.CPU / 1) / 100) AS CPU, MAP(h.MEMORY_RESIDENT, null, -1 , -1, -1, ROUND(100 * h.MEMORY_RESIDENT / 1048576) / 100) AS MEMORY_RESIDENT, MAP(h.MEMORY_TOTAL_RESIDENT, null, -1 , -1, -1,  ROUND(100 * h.MEMORY_TOTAL_RESIDENT / 1048576) / 100) AS MEMORY_TOTAL_RESIDENT, MAP(h.MEMORY_SIZE, null, -1 , -1, -1, ROUND(100 * h.MEMORY_SIZE / 1048576) / 100) AS MEMORY_SIZE, MAP(h.MEMORY_USED, null, -1 , -1, -1, ROUND(100 * h.MEMORY_USED / 1048576) / 100) AS MEMORY_USED, MAP(h.MEMORY_ALLOCATION_LIMIT, null, -1 , -1, -1, ROUND(100 * h.MEMORY_ALLOCATION_LIMIT / 1048576) / 100) AS MEMORY_ALLOCATION_LIMIT, MAP(h.DISK_USED, null, -1 , -1, -1, ROUND(100 * h.DISK_USED / 1073741824) / 100) AS DISK_USED, MAP(h.DISK_SIZE, null, -1 , -1, -1, ROUND(100 * h.DISK_SIZE / 1073741824) / 100) AS DISK_SIZE, MAP(lag(h.TIME) OVER (order by h.host, h.time) , null , -1,  MAP(SUBSTRING(cast (h.NETWORK_IN as VARCHAR),0,1) ,'-',-1, 'n',-1,  round( 10000000*( 100 * h.NETWORK_IN / (NANO100_BETWEEN(lag(h.time) OVER (order by h.host, h.time),h.time) )) / 1048576) / 100)) AS NETWORK_IN, MAP(lag(h.TIME) OVER (order by h.host, h.time) , null , -1, MAP(SUBSTRING(cast (h.NETWORK_OUT as VARCHAR),0,1) ,'-',-1, 'n',-1,  round( 10000000*( 100 * h.NETWORK_OUT / (NANO100_BETWEEN(lag(h.time) OVER (order by h.host, h.time),h.time) )) / 1048576) / 100)) AS NETWORK_OUT FROM SYS.M_LOAD_HISTORY_HOST h, SYS.M_HOST_INFORMATION i WHERE h.HOST = i.HOST AND UPPER(i.KEY) = 'TIMEZONE_OFFSET' ORDER BY h.TIME ASC"
+                                "initialTimespanSecs": 3600,
+                                "query": "SELECT h.TIME AS _SERVER_LOCALTIME, i.VALUE AS _SERVER_UTC_OFFSET, ADD_SECONDS(h.TIME, i.VALUE*(-1)) AS _TIMESERIES_UTC, h.HOST AS HOST, 'HOST' AS SCOPE, MAP(h.CPU, null, -1 , -1, -1, ROUND(100 * h.CPU / 1) / 100) AS CPU, MAP(h.MEMORY_RESIDENT, null, -1 , -1, -1, ROUND(100 * h.MEMORY_RESIDENT / 1048576) / 100) AS MEMORY_RESIDENT, MAP(h.MEMORY_TOTAL_RESIDENT, null, -1 , -1, -1,  ROUND(100 * h.MEMORY_TOTAL_RESIDENT / 1048576) / 100) AS MEMORY_TOTAL_RESIDENT, MAP(h.MEMORY_SIZE, null, -1 , -1, -1, ROUND(100 * h.MEMORY_SIZE / 1048576) / 100) AS MEMORY_SIZE, MAP(h.MEMORY_USED, null, -1 , -1, -1, ROUND(100 * h.MEMORY_USED / 1048576) / 100) AS MEMORY_USED, MAP(h.MEMORY_ALLOCATION_LIMIT, null, -1 , -1, -1, ROUND(100 * h.MEMORY_ALLOCATION_LIMIT / 1048576) / 100) AS MEMORY_ALLOCATION_LIMIT, MAP(h.DISK_USED, null, -1 , -1, -1, ROUND(100 * h.DISK_USED / 1073741824) / 100) AS DISK_USED, MAP(h.DISK_SIZE, null, -1 , -1, -1, ROUND(100 * h.DISK_SIZE / 1073741824) / 100) AS DISK_SIZE, MAP(lag(h.TIME) OVER (order by h.host, h.time) , null , -1,  MAP(SUBSTRING(cast (h.NETWORK_IN as VARCHAR),0,1) ,'-',-1, 'n',-1,  round( 10000000*( 100 * h.NETWORK_IN / (NANO100_BETWEEN(lag(h.time) OVER (order by h.host, h.time),h.time) )) / 1048576) / 100)) AS NETWORK_IN, MAP(lag(h.TIME) OVER (order by h.host, h.time) , null , -1, MAP(SUBSTRING(cast (h.NETWORK_OUT as VARCHAR),0,1) ,'-',-1, 'n',-1,  round( 10000000*( 100 * h.NETWORK_OUT / (NANO100_BETWEEN(lag(h.time) OVER (order by h.host, h.time),h.time) )) / 1048576) / 100)) AS NETWORK_OUT FROM SYS.M_LOAD_HISTORY_HOST h, SYS.M_HOST_INFORMATION i WHERE h.HOST = i.HOST AND UPPER(i.KEY) = 'TIMEZONE_OFFSET' AND ADD_SECONDS(h.TIME, i.VALUE*(-1)) > {lastRunServerUtc} ORDER BY h.TIME ASC"
+                        }
+                },
+                {
+                        "name": "SystemAvailability",
+                        "description": "SAP HANA System Availability",
+                        "customLog": "SapHana_SystemAvailability",
+                        "frequencySecs": 60,
+                        "hanaOptions": {
+                                "isTimeSeries": true,
+                                "initialTimespanSecs": 31536000,
+                                "query": "SELECT h.EVENT_TIME AS _SERVER_LOCALTIME, i.VALUE AS _SERVER_UTC_OFFSET, ADD_SECONDS(h.EVENT_TIME, i.VALUE*(-1)) AS _TIMESERIES_UTC, h.* FROM SYS.M_SYSTEM_AVAILABILITY h, SYS.M_HOST_INFORMATION i WHERE h.HOST = i.HOST AND UPPER(i.KEY) = 'TIMEZONE_OFFSET' AND ADD_SECONDS(h.EVENT_TIME, i.VALUE*(-1)) > {lastRunServerUtc} ORDER BY h.EVENT_TIME ASC"
                         }
                 }
         ]


### PR DESCRIPTION
- This PR adds a new check to the HANA monitoring content: [M_SYSTEM_AVAILABILITY](https://help.sap.com/viewer/4fe29514fd584807ac9f2a04f6754767/2.0.04/en-US/1ef9723a03214bd889c4fb8947765aa4.html) is a time-series query that provides important information on individual HANA services (or an entire instance) starting/stopping/failing over.
- Since the underlying HANA monitoring view uses different column names than our other checks (e.g. EVENT_TIME instead of TIME), a few modifications were necessary to the `prepareSql()` method.