### PR TITLE
[HOTFIX] Add flag enable_secure_transfer to enable secure transfer for all storage account 

### DIFF
--- a/deploy/v2/input.json
+++ b/deploy/v2/input.json
@@ -1,10 +1,69 @@
 {
+<<<<<<< HEAD
   "infrastructure": {
     "region": "",
     "resource_group": {
       "is_existing": "",
       "arm_id": "",
       "name": ""
+=======
+    "infrastructure" : {
+        "region" : "",
+        "resource_group" : {
+            "is_existing" : "",
+            "arm_id" : "",
+            "name" : ""
+        },
+        "vnets" : {
+            "management" : {
+                "is_existing" : "",
+                "arm_id" : "",
+                "name" : "",
+                "address_space" : "",
+                "subnet_mgmt" : {
+                    "is_existing" : "",
+                    "arm_id" : "",
+                    "name" : "",
+                    "prefix" : "",
+                    "nsg" : {
+                        "is_existing" : "",
+                        "arm_id" : "",
+                        "name" : "",
+                        "allowed_ips" :[] 
+                    }
+                }
+            },
+            "sap" : {
+                "is_existing" : "",
+                "arm_id" : "",
+                "name" : "",
+                "address_space" : "",
+                "subnet_admin" : {
+                    "is_existing" : "",
+                    "arm_id" : "",
+                    "name" : "",
+                    "prefix" : "",
+                    "nsg" : {
+                        "is_existing" : "",
+                        "arm_id" : "",
+                        "name" : ""
+                    }
+                },
+                "subnet_db" : {
+                    "is_existing" : "",
+                    "arm_id" : "",
+                    "name" : "",
+                    "prefix" : "",
+                    "nsg" : {
+                        "is_existing" : "",
+                        "arm_id" : "",
+                        "name" : ""
+                    }
+                }
+            }
+        },
+    "boot_diagnostics_account_name" : ""
+>>>>>>> Adjust the templates accordingly
     },
     "vnets": {
       "management": {
@@ -187,6 +246,7 @@
     "path_to_private_key": ""
   },
   "options": {
-    "read_tf_output_from_file": ""
+    "read_tf_output_from_file": "",
+    "enable_secure_transfer": false
   }
 }

--- a/deploy/v2/input.json
+++ b/deploy/v2/input.json
@@ -1,69 +1,10 @@
 {
-<<<<<<< HEAD
   "infrastructure": {
     "region": "",
     "resource_group": {
       "is_existing": "",
       "arm_id": "",
       "name": ""
-=======
-    "infrastructure" : {
-        "region" : "",
-        "resource_group" : {
-            "is_existing" : "",
-            "arm_id" : "",
-            "name" : ""
-        },
-        "vnets" : {
-            "management" : {
-                "is_existing" : "",
-                "arm_id" : "",
-                "name" : "",
-                "address_space" : "",
-                "subnet_mgmt" : {
-                    "is_existing" : "",
-                    "arm_id" : "",
-                    "name" : "",
-                    "prefix" : "",
-                    "nsg" : {
-                        "is_existing" : "",
-                        "arm_id" : "",
-                        "name" : "",
-                        "allowed_ips" :[] 
-                    }
-                }
-            },
-            "sap" : {
-                "is_existing" : "",
-                "arm_id" : "",
-                "name" : "",
-                "address_space" : "",
-                "subnet_admin" : {
-                    "is_existing" : "",
-                    "arm_id" : "",
-                    "name" : "",
-                    "prefix" : "",
-                    "nsg" : {
-                        "is_existing" : "",
-                        "arm_id" : "",
-                        "name" : ""
-                    }
-                },
-                "subnet_db" : {
-                    "is_existing" : "",
-                    "arm_id" : "",
-                    "name" : "",
-                    "prefix" : "",
-                    "nsg" : {
-                        "is_existing" : "",
-                        "arm_id" : "",
-                        "name" : ""
-                    }
-                }
-            }
-        },
-    "boot_diagnostics_account_name" : ""
->>>>>>> Adjust the templates accordingly
     },
     "vnets": {
       "management": {

--- a/deploy/v2/input.json
+++ b/deploy/v2/input.json
@@ -188,6 +188,6 @@
   },
   "options": {
     "read_tf_output_from_file": "",
-    "enable_secure_transfer": false
+    "enable_secure_transfer": true
   }
 }

--- a/deploy/v2/template_samples/single_node_hana.json
+++ b/deploy/v2/template_samples/single_node_hana.json
@@ -36,7 +36,6 @@
             "name": "nsg-admin"
           }
         },
-<<<<<<< HEAD
         "subnet_db": {
           "is_existing": "false",
           "name": "subnet-db",
@@ -45,47 +44,6 @@
             "is_existing": "false",
             "name": "nsg-db"
           }
-=======
-        "vnets" : {
-            "management" : {
-                "is_existing" : "false",
-                "name" : "vnet-mgmt",
-                "address_space" : "10.0.0.0/16",
-                "subnet_mgmt" : {
-                    "is_existing" : "false",
-                    "name" : "subnet-mgmt",
-                    "prefix" : "10.0.1.0/24",
-                    "nsg" : {
-                        "is_existing" : "false",
-                        "name" : "nsg-mgmt",
-			"allowed_ips" : []
-                    }
-                }
-            },
-            "sap" : {
-                "is_existing" : "false",
-                "name" : "vnet-sap",
-                "address_space" : "10.1.0.0/16",
-                "subnet_admin" : {
-                    "is_existing" : "false",
-                    "name" : "subnet-admin",
-                    "prefix" : "10.1.1.0/24",
-                    "nsg" : {
-                        "is_existing" : "false",
-                        "name" : "nsg-admin"
-                    }
-                },
-                "subnet_db" : {
-                    "is_existing" : "false",
-                    "name" : "subnet-db",
-                    "prefix" : "10.1.2.0/24",
-                    "nsg" : {
-                        "is_existing" : "false",
-                        "name" : "nsg-db"
-                    }
-                }
-            }
->>>>>>> Adjust the templates accordingly
         }
       }
     }

--- a/deploy/v2/template_samples/single_node_hana.json
+++ b/deploy/v2/template_samples/single_node_hana.json
@@ -36,6 +36,7 @@
             "name": "nsg-admin"
           }
         },
+<<<<<<< HEAD
         "subnet_db": {
           "is_existing": "false",
           "name": "subnet-db",
@@ -44,6 +45,47 @@
             "is_existing": "false",
             "name": "nsg-db"
           }
+=======
+        "vnets" : {
+            "management" : {
+                "is_existing" : "false",
+                "name" : "vnet-mgmt",
+                "address_space" : "10.0.0.0/16",
+                "subnet_mgmt" : {
+                    "is_existing" : "false",
+                    "name" : "subnet-mgmt",
+                    "prefix" : "10.0.1.0/24",
+                    "nsg" : {
+                        "is_existing" : "false",
+                        "name" : "nsg-mgmt",
+			"allowed_ips" : []
+                    }
+                }
+            },
+            "sap" : {
+                "is_existing" : "false",
+                "name" : "vnet-sap",
+                "address_space" : "10.1.0.0/16",
+                "subnet_admin" : {
+                    "is_existing" : "false",
+                    "name" : "subnet-admin",
+                    "prefix" : "10.1.1.0/24",
+                    "nsg" : {
+                        "is_existing" : "false",
+                        "name" : "nsg-admin"
+                    }
+                },
+                "subnet_db" : {
+                    "is_existing" : "false",
+                    "name" : "subnet-db",
+                    "prefix" : "10.1.2.0/24",
+                    "nsg" : {
+                        "is_existing" : "false",
+                        "name" : "nsg-db"
+                    }
+                }
+            }
+>>>>>>> Adjust the templates accordingly
         }
       }
     }
@@ -174,5 +216,8 @@
   "sshkey": {
     "path_to_public_key": "~/.ssh/id_rsa.pub",
     "path_to_private_key": "~/.ssh/id_rsa"
+  },
+  "options": {
+    "enable_secure_transfer": false
   }
 }

--- a/deploy/v2/template_samples/single_node_hana.json
+++ b/deploy/v2/template_samples/single_node_hana.json
@@ -176,6 +176,6 @@
     "path_to_private_key": "~/.ssh/id_rsa"
   },
   "options": {
-    "enable_secure_transfer": false
+    "enable_secure_transfer": true
   }
 }

--- a/deploy/v2/terraform/main.tf
+++ b/deploy/v2/terraform/main.tf
@@ -9,6 +9,7 @@ module "common_infrastructure" {
   is_single_node_hana = "true"
   infrastructure      = var.infrastructure
   software            = var.software
+  options             = var.options
 }
 
 # Create Jumpboxes and RTI box

--- a/deploy/v2/terraform/modules/common_infrastructure/main.tf
+++ b/deploy/v2/terraform/modules/common_infrastructure/main.tf
@@ -248,13 +248,14 @@ resource "random_id" "random-id" {
 
 # Creates storage account for storing SAP Bits
 resource "azurerm_storage_account" "storage-sapbits" {
-  count                    = var.software.storage_account_sapbits.is_existing ? 0 : 1
-  name                     = lookup(var.software.storage_account_sapbits, "name", false) ? var.software.storage_account_sapbits.name : "sapbits${random_id.random-id.hex}"
-  resource_group_name      = var.infrastructure.resource_group.is_existing ? data.azurerm_resource_group.resource-group[0].name : azurerm_resource_group.resource-group[0].name
-  location                 = var.infrastructure.region
-  account_replication_type = "LRS"
-  account_tier             = "Premium"
-  account_kind             = var.software.storage_account_sapbits.account_kind
+  count                     = var.software.storage_account_sapbits.is_existing ? 0 : 1
+  name                      = lookup(var.software.storage_account_sapbits, "name", false) ? var.software.storage_account_sapbits.name : "sapbits${random_id.random-id.hex}"
+  resource_group_name       = var.infrastructure.resource_group.is_existing ? data.azurerm_resource_group.resource-group[0].name : azurerm_resource_group.resource-group[0].name
+  location                  = var.infrastructure.region
+  account_replication_type  = "LRS"
+  account_tier              = "Premium"
+  account_kind              = var.software.storage_account_sapbits.account_kind
+  enable_https_traffic_only = var.options.enable_secure_transfer
 }
 
 # Creates the storage container inside the storage account for SAP bits
@@ -274,9 +275,10 @@ data "azurerm_storage_account" "storage-sapbits" {
 
 # Creates boot diagnostics storage account
 resource "azurerm_storage_account" "storage-bootdiag" {
-  name                     = lookup(var.infrastructure, "boot_diagnostics_account_name", false) == false ? "sabootdiag${random_id.random-id.hex}" : var.infrastructure.boot_diagnostics_account_name
-  resource_group_name      = var.infrastructure.resource_group.is_existing ? data.azurerm_resource_group.resource-group[0].name : azurerm_resource_group.resource-group[0].name
-  location                 = var.infrastructure.region
-  account_replication_type = "LRS"
-  account_tier             = "Standard"
+  name                      = lookup(var.infrastructure, "boot_diagnostics_account_name", false) == false ? "sabootdiag${random_id.random-id.hex}" : var.infrastructure.boot_diagnostics_account_name
+  resource_group_name       = var.infrastructure.resource_group.is_existing ? data.azurerm_resource_group.resource-group[0].name : azurerm_resource_group.resource-group[0].name
+  location                  = var.infrastructure.region
+  account_replication_type  = "LRS"
+  account_tier              = "Standard"
+  enable_https_traffic_only = var.options.enable_secure_transfer
 }

--- a/deploy/v2/terraform/modules/common_infrastructure/variables.tf
+++ b/deploy/v2/terraform/modules/common_infrastructure/variables.tf
@@ -10,3 +10,7 @@ variable "is_single_node_hana" {
 variable "software" {
   description = "Details of the infrastructure components required for SAP installation"
 }
+
+variable "options" {
+  description = "Configuration options"
+}

--- a/deploy/v2/terraform/variables.tf
+++ b/deploy/v2/terraform/variables.tf
@@ -17,3 +17,7 @@ variable "software" {
 variable "sshkey" {
   description = "Details of ssh key pair"
 }
+
+variable "options" {
+  description = "Configuration options"
+}

--- a/templates/tempGen/template.json
+++ b/templates/tempGen/template.json
@@ -173,5 +173,8 @@
   "sshkey": {
     "path_to_public_key": "/tmp/sshkey.pub",
     "path_to_private_key": "/tmp/sshkey"
+  },
+  "options": {
+    "enable_secure_transfer": false
   }
 }

--- a/templates/tempGen/template.json
+++ b/templates/tempGen/template.json
@@ -175,6 +175,6 @@
     "path_to_private_key": "/tmp/sshkey"
   },
   "options": {
-    "enable_secure_transfer": false
+    "enable_secure_transfer": true
   }
 }


### PR DESCRIPTION
There are s360 violations for having storage accounts without the secure transfer enabled.
Therefore we now add flag enable_secure_transfer under options in input JSON:
```JSON
  "options": {
    "read_tf_output_from_file": "",
    "enable_secure_transfer": true
  }
```
If set to true, it will enable secure transfer for **all storage account** for better security.