### PR TITLE
Remove workaround to use sap-playbook.yml

### DIFF
--- a/templates/ansible-deployment-steps.yaml
+++ b/templates/ansible-deployment-steps.yaml
@@ -13,10 +13,6 @@ steps:
       cd deploy/v2/ansible_config_files
       rti_user=$(cat output.json | jq -r '.jumpboxes.linux[] | select(.destroy_after_deploy == "true") | .authentication.username')
       rti_public_ip=$(cat output.json | jq -r '.jumpboxes.linux[] | select(.destroy_after_deploy == "true") | .public_ip_address')
-      ssh -i /tmp/sshkey -o StrictHostKeyChecking=no "${rti_user}"@"${rti_public_ip}" << EOF
-        cd sap-hana
-        git checkout wft-ansible-os
-      EOF
       ssh -i /tmp/sshkey -o StrictHostKeyChecking=no "${rti_user}"@"${rti_public_ip}" 'OBJC_DISABLE_INITIALIZE_FORK_SAFETY="YES" ANSIBLE_HOST_KEY_CHECKING="False" ansible-playbook -i hosts sap-hana/deploy/v2/ansible/sap_playbook.yml'
     displayName: 'Ansible Deployment'
     env:


### PR DESCRIPTION
Since now the first ansible playbook is now in `master`, I removed the workaround (which is by checking out a branch `wft-ansible-os`) from v2 azure pipeline test.