### PR TITLE
Add option to execute Ansible playbook from Terraform

### DIFF
--- a/deploy/v2/input.json
+++ b/deploy/v2/input.json
@@ -129,8 +129,8 @@
       "high_availability": "",
       "authentication": {
         "type": "",
-        "username": "",
-        "password": ""
+        "os_username": "",
+        "os_password": ""
       },
       "instance": {
         "sid": "",

--- a/deploy/v2/input.json
+++ b/deploy/v2/input.json
@@ -64,6 +64,7 @@
         "name": "",
         "destroy_after_deploy": "",
         "size": "",
+        "nic_name": "",
         "private_ip_address": "",
         "os": {
           "publisher": "",
@@ -83,6 +84,7 @@
         "name": "",
         "destroy_after_deploy": "",
         "size": "",
+        "nic_name": "",
         "private_ip_address": "",
         "os": {
           "publisher": "",
@@ -100,6 +102,7 @@
         "name": "",
         "destroy_after_deploy": "",
         "size": "",
+        "nic_name": "",
         "private_ip_address": "",
         "os": {
           "publisher": "",

--- a/deploy/v2/input.json
+++ b/deploy/v2/input.json
@@ -64,7 +64,6 @@
         "name": "",
         "destroy_after_deploy": "",
         "size": "",
-        "nic_name": "",
         "private_ip_address": "",
         "os": {
           "publisher": "",
@@ -84,7 +83,6 @@
         "name": "",
         "destroy_after_deploy": "",
         "size": "",
-        "nic_name": "",
         "private_ip_address": "",
         "os": {
           "publisher": "",
@@ -102,7 +100,6 @@
         "name": "",
         "destroy_after_deploy": "",
         "size": "",
-        "nic_name": "",
         "private_ip_address": "",
         "os": {
           "publisher": "",
@@ -132,8 +129,8 @@
       "high_availability": "",
       "authentication": {
         "type": "",
-        "os_username": "",
-        "os_password": ""
+        "username": "",
+        "password": ""
       },
       "instance": {
         "sid": "",
@@ -228,6 +225,7 @@
   },
   "options": {
     "read_tf_output_from_file": "",
-    "enable_secure_transfer": true
+    "enable_secure_transfer": true,
+    "ansible_execution": true
   }
 }

--- a/deploy/v2/template_samples/single_node_hana.json
+++ b/deploy/v2/template_samples/single_node_hana.json
@@ -216,6 +216,7 @@
   },
   "options": {
     "read_tf_output_from_file": "../ansible_config_files/output.json",
-    "enable_secure_transfer": true
+    "enable_secure_transfer": true,
+    "ansible_execution": true
   }
 }

--- a/deploy/v2/terraform/main.tf
+++ b/deploy/v2/terraform/main.tf
@@ -19,6 +19,7 @@ module "jumpbox" {
   jumpboxes         = var.jumpboxes
   databases         = var.databases
   sshkey            = var.sshkey
+  ssh-timeout       = var.ssh-timeout
   resource-group    = module.common_infrastructure.resource-group
   subnet-mgmt       = module.common_infrastructure.subnet-mgmt
   nsg-mgmt          = module.common_infrastructure.nsg-mgmt
@@ -55,4 +56,25 @@ module "output_files" {
   public-ips-jumpboxes-linux   = module.jumpbox.public-ips-jumpboxes-linux
   nics-dbnodes-admin           = module.hdb_node.nics-dbnodes-admin
   nics-dbnodes-db              = module.hdb_node.nics-dbnodes-db
+}
+
+resource "null_resource" "ansible_playbook" {
+  depends_on = [module.hdb_node.dbnodes, module.jumpbox.prepare-rti]
+  connection {
+    type        = "ssh"
+    host        = module.jumpbox.rti-info.public_ip_address
+    user        = module.jumpbox.rti-info.authentication.username
+    private_key = module.jumpbox.rti-info.authentication.type == "key" ? file(var.sshkey.path_to_private_key) : null
+    password    = lookup(module.jumpbox.rti-info.authentication, "password", null)
+    timeout     = var.ssh-timeout
+  }
+
+  # Run Ansible Playbook on jumpbox if ansible_execution set to true
+  provisioner "remote-exec" {
+    inline = [
+      "export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES",
+      "export ANSIBLE_HOST_KEY_CHECKING=False",
+      var.options.ansible_execution ? "ansible-playbook -i hosts ~/sap-hana/deploy/v2/ansible/sap_playbook.yml" : "ansible-playbook --version"
+    ]
+  }
 }

--- a/deploy/v2/terraform/modules/hdb_node/outputs.tf
+++ b/deploy/v2/terraform/modules/hdb_node/outputs.tf
@@ -5,3 +5,8 @@ output "nics-dbnodes-admin" {
 output "nics-dbnodes-db" {
   value = azurerm_network_interface.nics-dbnodes-db
 }
+
+# Workaround to create dependency betweeen ../main.tf ansible_execution and module hdb_node
+output "dbnodes" {
+  value = azurerm_virtual_machine.vm-dbnode
+}

--- a/deploy/v2/terraform/modules/jumpbox/outputs.tf
+++ b/deploy/v2/terraform/modules/jumpbox/outputs.tf
@@ -13,3 +13,12 @@ output "public-ips-jumpboxes-linux" {
 output "public-ips-jumpboxes-windows" {
   value = azurerm_public_ip.public-ip-windows
 }
+
+output "rti-info" {
+  value = local.rti-info[0]
+}
+
+# Workaround to create dependency betweeen ../main.tf ansible_execution and module jumpbox
+output "prepare-rti" {
+  value = null_resource.prepare-rti
+}

--- a/deploy/v2/terraform/modules/jumpbox/variables.tf
+++ b/deploy/v2/terraform/modules/jumpbox/variables.tf
@@ -39,7 +39,7 @@ variable "ansible-inventory" {
 }
 
 variable "ssh-timeout" {
-  description = "Timeout for connection that used by provisioner"
+  description = "Timeout for connection that is used by provisioner"
 }
 
 # RTI IP and authentication details

--- a/deploy/v2/terraform/modules/jumpbox/variables.tf
+++ b/deploy/v2/terraform/modules/jumpbox/variables.tf
@@ -40,7 +40,6 @@ variable "ansible-inventory" {
 
 variable "ssh-timeout" {
   description = "Timeout for connection that used by provisioner"
-  default     = "30s"
 }
 
 # RTI IP and authentication details

--- a/deploy/v2/terraform/variables.tf
+++ b/deploy/v2/terraform/variables.tf
@@ -23,6 +23,6 @@ variable "options" {
 }
 
 variable "ssh-timeout" {
-  description = "Timeout for connection that used by provisioner"
+  description = "Timeout for connection that is used by provisioner"
   default     = "30s"
 }

--- a/deploy/v2/terraform/variables.tf
+++ b/deploy/v2/terraform/variables.tf
@@ -21,3 +21,8 @@ variable "sshkey" {
 variable "options" {
   description = "Configuration options"
 }
+
+variable "ssh-timeout" {
+  description = "Timeout for connection that used by provisioner"
+  default     = "30s"
+}

--- a/templates/tempGen/template.json
+++ b/templates/tempGen/template.json
@@ -210,6 +210,7 @@
     "path_to_private_key": "/tmp/sshkey"
   },
   "options": {
-    "enable_secure_transfer": true
+    "enable_secure_transfer": true,
+    "ansible_execution": true
   }
 }

--- a/templates/tempGen/template.json
+++ b/templates/tempGen/template.json
@@ -211,6 +211,6 @@
   },
   "options": {
     "enable_secure_transfer": true,
-    "ansible_execution": true
+    "ansible_execution": false
   }
 }


### PR DESCRIPTION
Introduced flag `ansible_execution`:

- If set to `true`, terraform apply will execute Ansible playbook from jumpbox
- If set to `false`, terraform will not execute Ansible playbook, only show the Ansible version on jumpbox

In the v2 pipeline testing, this flag is set to `false`, because we want to checkout the updated playbook from PR and execute that one instead.