### PR TITLE
[HOTFIX] Pin to larger release for Ansible installation

### DIFF
--- a/deploy/v2/terraform/modules/jumpbox/main.tf
+++ b/deploy/v2/terraform/modules/jumpbox/main.tf
@@ -241,8 +241,8 @@ resource "null_resource" "prepare-rti" {
       "sudo apt-get install git=1:2.7.4-0ubuntu1.6",
       # Installs Ansible
       "sudo apt install software-properties-common",
-      "sudo apt-add-repository --yes --update ppa:ansible/ansible",
-      "sudo apt -y install ansible=2.8.6-1ppa~xenial",
+      "sudo apt-add-repository --yes --update ppa:ansible/ansible-2.8",
+      "sudo apt -y install ansible=2.8*",
       # Clones project repository
       "git clone https://github.com/Azure/sap-hana.git"
     ]


### PR DESCRIPTION
**Error:**
```
E: Version '2.8.6-1ppa~xenial' for 'ansible' was not found
error executing "/tmp/terraform_2114420622.sh": Process exited with status 127
```
**Root Cause:**
Currently the Ansible installed on Jumpbox is pinned to `2.8.6-1ppa~xenial` which no longer exists.

**Solution:**
Pin to larger release (e.g. 2.8.x) instead.

**Impact:** 
All v2 pipeline test will fail since Ansible can't not be installed due to the above error.