### PR TITLE
Track terraform deployment with IMDS

### DIFF
--- a/deploy/v2/terraform/main.tf
+++ b/deploy/v2/terraform/main.tf
@@ -72,6 +72,8 @@ resource "null_resource" "ansible_playbook" {
   # Run Ansible Playbook on jumpbox if ansible_execution set to true
   provisioner "remote-exec" {
     inline = [
+      # Registers the current deployment state with Azure's Metadata Service (IMDS)
+      "curl -i -H \"Metadata: \"true\"\" -H \"user-agent: SAP AutoDeploy/${var.auto-deploy-version}; scenario=${var.scenario}; deploy-status=Terraform_finished\" http://169.254.169.254/metadata/instance?api-version=${var.api-version}",
       "export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES",
       "export ANSIBLE_HOST_KEY_CHECKING=False",
       var.options.ansible_execution ? "ansible-playbook -i hosts ~/sap-hana/deploy/v2/ansible/sap_playbook.yml" : "ansible-playbook --version"

--- a/deploy/v2/terraform/variables.tf
+++ b/deploy/v2/terraform/variables.tf
@@ -26,3 +26,18 @@ variable "ssh-timeout" {
   description = "Timeout for connection that is used by provisioner"
   default     = "30s"
 }
+
+variable "api-version" {
+  description = "IMDS API Version"
+  default     = "2019-04-30"
+}
+
+variable "auto-deploy-version" {
+  description = "Version for automated deployment"
+  default     = "v2"
+}
+
+variable "scenario" {
+  description = "Deployment Scenario"
+  default     = "HANA Database"
+}


### PR DESCRIPTION
Since the Ansible playbook is not final, I only add tracking of deployemnt for Terraform execution.
Below filter can be used to check the statistic<sup>[1](#myfootnote1)</sup>:

```sql
| where TimeStamp > ago(3d)
| where UserAgent contains"SAP AutoDeploy/v2" and message contains"Terraform_finished"
```

<a name="myfootnote1">1</a>:There is normally a couple of hours delay until the data show up.