### PR TITLE
Extend the timeout to allow installation of all the components

### DIFF
--- a/templates/job-template-per-os.yaml
+++ b/templates/job-template-per-os.yaml
@@ -4,6 +4,7 @@ parameters:
 
 jobs:
 - job: createAllNew${{parameters.osVersion}}
+  timeoutInMinutes: 180
   variables:
     scenario: v2-allNew
     testcase: $(scenario)-${{parameters.osVersion}}-$(Build.BuildId)
@@ -22,6 +23,7 @@ jobs:
     parameters:
       testCaseName: $(testcase)
 - job: reuseRG${{parameters.osVersion}}
+  timeoutInMinutes: 180
   variables:
     scenario: v2-reuseRG
     testcase: $(scenario)-${{parameters.osVersion}}-$(Build.BuildId)
@@ -51,6 +53,7 @@ jobs:
       testCaseName: $(testcase)
 - job: reuseVnet${{parameters.osVersion}}
   dependsOn: createAllNew${{parameters.osVersion}}
+  timeoutInMinutes: 180
   variables:
     scenario: v2-reuseVNET
     testcase: $(scenario)-${{parameters.osVersion}}-$(Build.BuildId)
@@ -78,6 +81,7 @@ jobs:
     parameters:
       testCaseName: $(testcase)
 - job: reuseNSG${{parameters.osVersion}}
+  timeoutInMinutes: 180
   dependsOn: createAllNew${{parameters.osVersion}}
   variables:
     scenario: v2-reuseNSG


### PR DESCRIPTION
The default timeout of each job in the current pipeline is 60 minutes. This is not enough to install HanaDB, SHINE and XSA related components. So increasing the timeout of each test scenario.