### PR TITLE
Upgrade crmsh to use default IP for ring0_addr

### DIFF
--- a/deploy/vm/ansible/ha_pair_playbook.yml
+++ b/deploy/vm/ansible/ha_pair_playbook.yml
@@ -53,6 +53,14 @@
   roles:
     - ssh-key-distribute
 
+- hosts: hdb0,hdb1
+  tasks:
+    - name: update crmsh
+      zypper:
+        name: crmsh
+        state: latest
+      become: true
+
 - hosts: hdb0
   become: true
   roles:


### PR DESCRIPTION

HA pair deployment scripts have been broken for some time with the following error:
```
[0m[0mmodule.configure_vm.null_resource.mount-disks-and-configure-hana (local-exec): TASK [ha-cluster-join : HA cluster join cluster] *******************************
[0m[0mmodule.configure_vm.null_resource.mount-disks-and-configure-hana (local-exec): fatal: [ha1-hdb1]: FAILED! => {"changed": true, "cmd": "ha-cluster-join -y cluster", "delta": "0:00:05.504106", "end": "2020-01-24 01:24:07.627824", "msg": "non-zero return code", "rc": 1, "start": "2020-01-24 01:24:02.123718", "stderr": "ERROR: cluster.join: No value for ring0", "stderr_lines": ["ERROR: cluster.join: No value for ring0"], "stdout": "  Probing for new partitions...done\n  No existing IP/hostname specified - skipping mountpoint detection/creation", "stdout_lines": ["  Probing for new partitions...done", "  No existing IP/hostname specified - skipping mountpoint detection/creation"]}
[0m[0m
```
After going through the cookbooks I could find and doing several trial and error, I figured out the issue was with a change in crm shell. The crm shell was looking for ring0_addr. However a later version of crm (3.0.4) had a fix to automatically pick up the ring0 addr. https://github.com/ClusterLabs/crmsh/blob/master/ChangeLog

