### PR TITLE
Pin NSG rules for rdp and winrm to vnet

### DIFF
--- a/deploy/vm/modules/common_setup/nsg.tf
+++ b/deploy/vm/modules/common_setup/nsg.tf
@@ -29,36 +29,6 @@ resource "azurerm_network_security_group" "sap_nsg" {
   }
 }
 
-resource "azurerm_network_security_rule" "hana-xsc-rules" {
-  count                       = var.use_existing_nsg ? 0 : var.install_xsa ? 0 : length(local.hana_xsc_rules)
-  name                        = element(split(",", local.hana_xsc_rules[count.index]), 0)
-  priority                    = element(split(",", local.hana_xsc_rules[count.index]), 1)
-  direction                   = "Inbound"
-  access                      = "Allow"
-  protocol                    = "Tcp"
-  source_port_range           = "*"
-  destination_port_range      = element(split(",", local.hana_xsc_rules[count.index]), 2)
-  source_address_prefixes     = local.all_ips
-  destination_address_prefix  = "*"
-  resource_group_name         = azurerm_resource_group.hana-resource-group.name
-  network_security_group_name = azurerm_network_security_group.sap_nsg[0].name
-}
-
-resource "azurerm_network_security_rule" "hana-xsa-rules" {
-  count                       = var.use_existing_nsg ? 0 : var.install_xsa ? length(local.hana_xsa_rules) : 0
-  name                        = element(split(",", local.hana_xsa_rules[count.index]), 0)
-  priority                    = element(split(",", local.hana_xsa_rules[count.index]), 1)
-  direction                   = "Inbound"
-  access                      = "Allow"
-  protocol                    = "Tcp"
-  source_port_range           = "*"
-  destination_port_range      = element(split(",", local.hana_xsa_rules[count.index]), 2)
-  source_address_prefixes     = local.all_ips
-  destination_address_prefix  = "*"
-  resource_group_name         = azurerm_resource_group.hana-resource-group.name
-  network_security_group_name = azurerm_network_security_group.sap_nsg[0].name
-}
-
 # Creates Windows jumpbox RDP network security rule
 resource "azurerm_network_security_rule" "nsr-rdp" {
   count                       = var.windows_bastion ? 1 : 0
@@ -89,6 +59,36 @@ resource "azurerm_network_security_rule" "nsr-winrm" {
   destination_port_ranges     = [5985, 5986]
   source_address_prefixes     = var.allow_ips
   destination_address_prefix  = "*"
+}
+
+resource "azurerm_network_security_rule" "hana-xsc-rules" {
+  count                       = var.use_existing_nsg ? 0 : var.install_xsa ? 0 : length(local.hana_xsc_rules)
+  name                        = element(split(",", local.hana_xsc_rules[count.index]), 0)
+  priority                    = element(split(",", local.hana_xsc_rules[count.index]), 1)
+  direction                   = "Inbound"
+  access                      = "Allow"
+  protocol                    = "Tcp"
+  source_port_range           = "*"
+  destination_port_range      = element(split(",", local.hana_xsc_rules[count.index]), 2)
+  source_address_prefixes     = local.all_ips
+  destination_address_prefix  = "*"
+  resource_group_name         = azurerm_resource_group.hana-resource-group.name
+  network_security_group_name = azurerm_network_security_group.sap_nsg[0].name
+}
+
+resource "azurerm_network_security_rule" "hana-xsa-rules" {
+  count                       = var.use_existing_nsg ? 0 : var.install_xsa ? length(local.hana_xsa_rules) : 0
+  name                        = element(split(",", local.hana_xsa_rules[count.index]), 0)
+  priority                    = element(split(",", local.hana_xsa_rules[count.index]), 1)
+  direction                   = "Inbound"
+  access                      = "Allow"
+  protocol                    = "Tcp"
+  source_port_range           = "*"
+  destination_port_range      = element(split(",", local.hana_xsa_rules[count.index]), 2)
+  source_address_prefixes     = local.all_ips
+  destination_address_prefix  = "*"
+  resource_group_name         = azurerm_resource_group.hana-resource-group.name
+  network_security_group_name = azurerm_network_security_group.sap_nsg[0].name
 }
 
 data "azurerm_network_security_group" "nsg_info" {

--- a/deploy/vm/modules/common_setup/nsg.tf
+++ b/deploy/vm/modules/common_setup/nsg.tf
@@ -59,6 +59,38 @@ resource "azurerm_network_security_rule" "hana-xsa-rules" {
   network_security_group_name = azurerm_network_security_group.sap_nsg[0].name
 }
 
+# Creates Windows jumpbox RDP network security rule
+resource "azurerm_network_security_rule" "nsr-rdp" {
+  count                       = var.windows_bastion ? 1 : 0
+  name                        = "rdp"
+  resource_group_name         = azurerm_resource_group.hana-resource-group.name
+  network_security_group_name = azurerm_network_security_group.sap_nsg[0].name
+  priority                    = 103
+  direction                   = "Inbound"
+  access                      = "allow"
+  protocol                    = "Tcp"
+  source_port_range           = "*"
+  destination_port_range      = 3389
+  source_address_prefixes     = var.allow_ips
+  destination_address_prefix  = "*"
+}
+
+# Creates Windows jumpbox WinRM network security rule
+resource "azurerm_network_security_rule" "nsr-winrm" {
+  count                       = var.windows_bastion ? 1 : 0
+  name                        = "winrm"
+  resource_group_name         = azurerm_resource_group.hana-resource-group.name
+  network_security_group_name = azurerm_network_security_group.sap_nsg[0].name
+  priority                    = 104
+  direction                   = "Inbound"
+  access                      = "allow"
+  protocol                    = "Tcp"
+  source_port_range           = "*"
+  destination_port_ranges     = [5985, 5986]
+  source_address_prefixes     = var.allow_ips
+  destination_address_prefix  = "*"
+}
+
 data "azurerm_network_security_group" "nsg_info" {
   name = element(
     concat(

--- a/deploy/vm/modules/common_setup/variables.tf
+++ b/deploy/vm/modules/common_setup/variables.tf
@@ -50,13 +50,13 @@ locals {
 
   // Structure for the rules will be: "rule_name,priority,destination_port_range"
   hana_xsc_rules = [
-    "XSC-HTTP,103,80${var.sap_instancenum}",
-    "XSC-HTTPS,104,43${var.sap_instancenum}",
+    "XSC-HTTP,105,80${var.sap_instancenum}",
+    "XSC-HTTPS,106,43${var.sap_instancenum}",
   ]
 
   hana_xsa_rules = [
-    "XSA-HTTP,105,4000-4999",
-    "XSA,106,50000-59999",
+    "XSA-HTTP,107,4000-4999",
+    "XSA,108,50000-59999",
   ]
 }
 

--- a/deploy/vm/modules/common_setup/variables.tf
+++ b/deploy/vm/modules/common_setup/variables.tf
@@ -38,6 +38,11 @@ variable "sap_sid" {
   default = "PV1"
 }
 
+variable "windows_bastion" {
+  description = "Whether or not you want a windows bastion host"
+  default     = false
+}
+
 locals {
   all_ips      = ["0.0.0.0/0"]
   empty_string = ""

--- a/deploy/vm/modules/single_node_hana/single-node-hana.tf
+++ b/deploy/vm/modules/single_node_hana/single-node-hana.tf
@@ -14,6 +14,7 @@ module "common_setup" {
   sap_instancenum   = var.sap_instancenum
   sap_sid           = var.sap_sid
   use_existing_nsg  = var.use_existing_nsg
+  windows_bastion   = var.windows_bastion
 }
 
 module "create_hdb" {

--- a/deploy/vm/modules/windows_bastion_host/main.tf
+++ b/deploy/vm/modules/windows_bastion_host/main.tf
@@ -1,38 +1,3 @@
-resource "azurerm_network_security_group" "windows_bastion_nsg" {
-  count               = var.windows_bastion ? 1 : 0
-  name                = "windows_bastion_nsg"
-  location            = var.az_region
-  resource_group_name = var.az_resource_group
-
-  security_rule {
-    name                       = "RDP"
-    priority                   = 100
-    direction                  = "Inbound"
-    access                     = "Allow"
-    protocol                   = "Tcp"
-    source_port_range          = "*"
-    destination_port_range     = local.rdp_port
-    source_address_prefixes    = var.allow_ips
-    destination_address_prefix = "*"
-  }
-
-  security_rule {
-    name                       = "winrm"
-    priority                   = 110
-    direction                  = "Inbound"
-    access                     = "Allow"
-    protocol                   = "Tcp"
-    source_port_range          = "*"
-    destination_port_range     = local.winrm_port
-    source_address_prefixes    = var.allow_ips
-    destination_address_prefix = "*"
-  }
-
-  tags = {
-    environment = "windows_bastion"
-  }
-}
-
 resource "azurerm_public_ip" "pip" {
   count               = var.windows_bastion ? 1 : 0
   name                = "${local.machine_name}-pip"
@@ -50,12 +15,11 @@ resource "azurerm_public_ip" "pip" {
 
 # Create network interface
 resource "azurerm_network_interface" "nic" {
-  count                     = var.windows_bastion ? 1 : 0
-  depends_on                = [azurerm_public_ip.pip]
-  name                      = "${local.machine_name}-nic"
-  location                  = var.az_region
-  resource_group_name       = var.az_resource_group
-  network_security_group_id = var.windows_bastion ? azurerm_network_security_group.windows_bastion_nsg[0].id : local.empty_string
+  count               = var.windows_bastion ? 1 : 0
+  depends_on          = [azurerm_public_ip.pip]
+  name                = "${local.machine_name}-nic"
+  location            = var.az_region
+  resource_group_name = var.az_resource_group
 
   ip_configuration {
     name                          = "${local.machine_name}-nic-configuration"

--- a/deploy/vm/modules/windows_bastion_host/variables.tf
+++ b/deploy/vm/modules/windows_bastion_host/variables.tf
@@ -53,7 +53,5 @@ locals {
 
   machine_name = "${lower(var.sap_sid)}-win-bastion"
   static       = "Static"
-  winrm_port   = 5986
-  rdp_port     = 3389
 }
 


### PR DESCRIPTION
This is to fix [issue #273](https://github.com/Azure/sap-hana/issues/273).

Root cause:
NSG rule, that associate with vnet, denies traffic including rdp/winrm ports.
NSG rule, that associate with windows bastion NIC, allows rdp/winrm traffic.
First rule override the second rule.

Solution:
If windows_bastion is set to true, add rules to allow rdp/winrm traffic to NSG that associate with vnet.