### PR TITLE
Reduce v2 pipeline runtime

### DIFF
--- a/templates/job-template-allReuseCases.yaml
+++ b/templates/job-template-allReuseCases.yaml
@@ -19,9 +19,6 @@ jobs:
     parameters:
       testCaseName: $(testcase)
       osImage: ${{parameters.osImage}}
-  - template: ansible-deployment-steps.yaml
-    parameters:
-      testCaseName: $(testcase)
 - job: reuseRG${{parameters.osVersion}}
   timeoutInMinutes: 180
   variables:
@@ -77,9 +74,6 @@ jobs:
     parameters:
       testCaseName: $(testcase)
       osImage: ${{parameters.osImage}}
-  - template: ansible-deployment-steps.yaml
-    parameters:
-      testCaseName: $(testcase)
 - job: reuseNSG${{parameters.osVersion}}
   timeoutInMinutes: 180
   dependsOn: createAllNew${{parameters.osVersion}}
@@ -106,6 +100,3 @@ jobs:
     parameters:
       testCaseName: $(testcase)
       osImage: ${{parameters.osImage}}
-  - template: ansible-deployment-steps.yaml
-    parameters:
-      testCaseName: $(testcase)


### PR DESCRIPTION
Currently, each PR has to pass a test in v2 pipeline.
With the current deployment code, it deploys infra in Azure, then run ansible to install HANA database with other HANA component (client, XSA, etc...).

Generally, the **terrform** deploy finishes within 10 minutes.
However the **ansible** part for the installation unfortunately takes quite some time, which leads to a 2.5-3 hrs for all test cases to finish.

Therefore I remove the ansible execution from some test cases to reduce the total time for each validation. After testing the new pipeline, I can confirm the runtime can be reduced to 1.5 hrs.

### Test cases before the change:

Job 1 createAllNew on SLES12 with terraform + ansible
Job 1 reuseRG on SLES12 with terraform + ansible
Job 1 createAllNew on RHEL7 with terraform+ ansible
Job 2 reuseVnet on SLES12 with terraform + ansible (depends on createAllNew on SLES12)
Job 2 reuseNSG on SLES12 with terraform + ansible (depends on createAllNew on SLES12)

Total runtime is roughly the runtime of:

(Job 1 createAllNew on SLES12 with terraform + ansible) + (Job 2 reuseVnet on SLES12 with terraform + ansible)

### Test cases after the change:

Job 1 createAllNew with terraform on SLES12
Job 1 reuseRG on SLES12 with terraform + ansible
Job 1 createAllNew on RHEL7 with terraform+ ansible
Job 2 reuseVnet on SLES12 with terraform (depends on createAllNew on SLES12)
Job 2 reuseNSG on SLES12 with terraform (depends on createAllNew on SLES12)

Total runtime is roughly the runtime of:

(Job 1 reuseRG on SLES12 with terraform + ansible)


