### PR TITLE
Use Python 3 interpreter for ansible

### DIFF
--- a/deploy/v2/terraform/modules/jumpbox/main.tf
+++ b/deploy/v2/terraform/modules/jumpbox/main.tf
@@ -285,9 +285,9 @@ resource "null_resource" "prepare-rti" {
       # Install pip3
       "sudo apt -y install python3-pip",
       # Installs Ansible
-      "sudo apt install software-properties-common",
-      "sudo apt-add-repository --yes --update ppa:ansible/ansible-2.8",
-      "sudo apt -y install ansible=2.8*",
+      "sudo -H pip3 install \"ansible>=2.8,<2.9\"",
+      # Install pywinrm
+      "sudo -H pip3 install \"pywinrm>=0.3.0\"",
       # Clones project repository
       "git clone https://github.com/Azure/sap-hana.git"
     ]


### PR DESCRIPTION
Goal is to move away from python2 and use python3.
Ansible supports python3. To have that set as default, pip3 need be used for the installation.

Therefore upgrade component install to pip3.