### PR TITLE
Fix problem with winrm

### DIFF
--- a/deploy/v2/terraform/main.tf
+++ b/deploy/v2/terraform/main.tf
@@ -61,7 +61,7 @@ module "output_files" {
 }
 
 resource "null_resource" "ansible_playbook" {
-  depends_on = [module.hdb_node.dbnodes, module.jumpbox.prepare-rti]
+  depends_on = [module.hdb_node.dbnodes, module.jumpbox.prepare-rti, , module.jumpbox.vm-windows]
   connection {
     type        = "ssh"
     host        = module.jumpbox.rti-info.public_ip_address

--- a/deploy/v2/terraform/main.tf
+++ b/deploy/v2/terraform/main.tf
@@ -61,7 +61,7 @@ module "output_files" {
 }
 
 resource "null_resource" "ansible_playbook" {
-  depends_on = [module.hdb_node.dbnodes, module.jumpbox.prepare-rti, , module.jumpbox.vm-windows]
+  depends_on = [module.hdb_node.dbnodes, module.jumpbox.prepare-rti, module.jumpbox.vm-windows]
   connection {
     type        = "ssh"
     host        = module.jumpbox.rti-info.public_ip_address

--- a/deploy/v2/terraform/modules/jumpbox/main.tf
+++ b/deploy/v2/terraform/modules/jumpbox/main.tf
@@ -229,12 +229,21 @@ resource "azurerm_virtual_machine" "vm-windows" {
   os_profile_windows_config {
     provision_vm_agent = true
 
+    winrm {
+      protocol = "Http"
+    }
+
+    winrm {
+      protocol        = "Https"
+      certificate_url = azurerm_key_vault_certificate.key-vault-cert[count.index].secret_id
+    }
+
     # Auto-Login's required to configure WinRM
     additional_unattend_config {
       pass         = "oobeSystem"
       component    = "Microsoft-Windows-Shell-Setup"
       setting_name = "AutoLogon"
-      content      = "<AutoLogon><Password><Value>${var.jumpboxes.windows[count.index].authentication.password}</Value></Password><Enabled>true</Enabled><LogonCount>1</LogonCount><Username>${var.jumpboxes.windows[count.index].authentication.username}</Username></AutoLogon>"
+      content      = "<AutoLogon><Password><Value>${var.jumpboxes.windows[count.index].authentication.password}</Value></Password><Enabled>true</Enabled><LogonCount>2</LogonCount><Username>${var.jumpboxes.windows[count.index].authentication.username}</Username></AutoLogon>"
     }
 
     # Unattend config is to enable basic auth in WinRM, required for the provisioner stage.

--- a/deploy/v2/terraform/modules/jumpbox/main.tf
+++ b/deploy/v2/terraform/modules/jumpbox/main.tf
@@ -285,9 +285,9 @@ resource "null_resource" "prepare-rti" {
       # Install pip3
       "sudo apt -y install python3-pip",
       # Installs Ansible
-      "sudo apt install software-properties-common",
-      "sudo apt-add-repository --yes --update ppa:ansible/ansible-2.8",
-      "sudo apt -y install ansible=2.8*",
+      "sudo -H pip3 install \"ansible>=2.8,<2.9\"",
+      # Install pywinrm
+      "sudo -H pip3 install \"pywinrm>=0.3.0\"",
       # Clones project repository
       "git clone https://github.com/Azure/sap-hana.git"
     ]

--- a/deploy/v2/terraform/modules/jumpbox/outputs.tf
+++ b/deploy/v2/terraform/modules/jumpbox/outputs.tf
@@ -22,3 +22,7 @@ output "rti-info" {
 output "prepare-rti" {
   value = null_resource.prepare-rti
 }
+
+output "vm-windows" {
+  value = azurerm_virtual_machine.vm-windows
+}

--- a/deploy/v2/terraform/modules/output_files/ansible_inventory.tmpl
+++ b/deploy/v2/terraform/modules/output_files/ansible_inventory.tmpl
@@ -4,10 +4,6 @@ ${ips-jumpboxes-windows[index(jumpboxes-windows, jumpbox-windows)]}  ansible_con
 %{~ endfor }
 
 [jumpboxes_linux]
-
-%{~ endfor }
-
-[jumpboxes_linux]
 %{~ for jumpbox-linux in jumpboxes-linux }
 %{~ if jumpbox-linux.destroy_after_deploy != "true" && jumpbox-linux.authentication.type == "key" }
 ${ips-jumpboxes-linux[index(jumpboxes-linux, jumpbox-linux)]}  ansible_connection=ssh  ansible_user=${jumpbox-linux.authentication.username}

--- a/deploy/v2/terraform/modules/output_files/ansible_inventory.tmpl
+++ b/deploy/v2/terraform/modules/output_files/ansible_inventory.tmpl
@@ -1,6 +1,10 @@
 [jumpboxes_windows]
 %{~ for jumpbox-windows in jumpboxes-windows }
-${ips-jumpboxes-windows[index(jumpboxes-windows, jumpbox-windows)]}  ansible_connection=winrm  ansible_user=${jumpbox-windows.authentication.username} ansible_ssh_pass=${jumpbox-windows.authentication.password}  ansible_ssh_port=5986
+${ips-jumpboxes-windows[index(jumpboxes-windows, jumpbox-windows)]}  ansible_connection=winrm  ansible_user=${jumpbox-windows.authentication.username} ansible_ssh_pass=${jumpbox-windows.authentication.password}  ansible_ssh_port=5986 ansible_winrm_transport=ntlm ansible_winrm_server_cert_validation=ignore
+%{~ endfor }
+
+[jumpboxes_linux]
+
 %{~ endfor }
 
 [jumpboxes_linux]


### PR DESCRIPTION
There are some issues with the previous winrm configuration, that makes the ansible not able to run playbook on windows jumpboxes, especially with the problem below:

_Not able to logon and run playbook on windows jumpbox during the 1st terraform+ansible deployment - we see ansible hanging at [**Gathering facts**] phase. However the 2nd attempt of terraform + ansible would work._

This is the fix based on [the PR for python3](https://github.com/Azure/sap-hana/pull/280), and have tested with [sample playbook](https://github.com/Azure/sap-hana/tree/nancyc-winrm-fix-test) that it works from end to end for windows jumpbox.