### PR TITLE
Use SLES12 SP3 for v2 pipeline test

### DIFF
--- a/azure-pipelines-v2.yaml
+++ b/azure-pipelines-v2.yaml
@@ -52,7 +52,7 @@ stages:
       osVersion: "SLES12"
       osImage: '\"offer\": \"SLES-SAP\", 
                 \"publisher\": \"SUSE\", 
-                \"sku\": \"12-sp2\"'
+                \"sku\": \"12-SP3\"'
   - template: templates/job-template-per-os.yaml
     parameters:
       osVersion: "RHEL7"

--- a/deploy/v2/ansible/vars/packages.yml
+++ b/deploy/v2/ansible/vars/packages.yml
@@ -40,7 +40,7 @@ packages:
       - compat-sap-c++-5
 
     Suse: 
-      - libyui-qt-pkg7
+      - libyui-qt-pkg
       - sapconf
       - saptune
       - glibc


### PR DESCRIPTION
We will use **SLES12 SP3 for SAP Application**<sup>*</sup> as a baseline testing.

<sup>*</sup> SLES12 SP4 image for SAP Application seems to miss certain required packages (including libyui-qt-pkg, saptune, etc...), therefore we go with SP3 for the time being.