### PR TITLE
Add code to enable prometheus on HANA VMs

### DIFF
--- a/azure-pipelines-v2.yaml
+++ b/azure-pipelines-v2.yaml
@@ -52,7 +52,7 @@ stages:
       osVersion: "SLES12"
       osImage: '\"offer\": \"SLES-SAP\", 
                 \"publisher\": \"SUSE\", 
-                \"sku\": \"12-sp2\"'
+                \"sku\": \"12-SP4\"'
   - template: templates/job-template-per-os.yaml
     parameters:
       osVersion: "RHEL7"

--- a/deploy/v2/ansible/roles/enable-prometheus/tasks/main.yml
+++ b/deploy/v2/ansible/roles/enable-prometheus/tasks/main.yml
@@ -1,0 +1,36 @@
+---
+
+# Enable prometheus on HANA servers
+
+- name: Set OS version
+  set_fact:
+    distro: "SLE_{{ ansible_facts['distribution_major_version'] }}_SP{{ ansible_facts['distribution_release'] }}"
+
+- name: Add repository
+  zypper_repository:
+    repo: "https://download.opensuse.org/repositories/server:/monitoring/{{ distro }}/server:monitoring.repo"
+
+- name: Install Prometheus with Node and HA Cluster exporters
+  zypper:
+    name: "{{ item }}"
+    disable_gpg_check: yes
+  loop:
+    - golang-github-prometheus-node_exporter
+    - prometheus-ha_cluster_exporter
+
+- name: Set arguments for Node exporter
+  lineinfile:
+    path: /etc/sysconfig/prometheus-node_exporter
+    regexp: 'ARGS=.*'
+    line: 'ARGS="--collector.systemd"'
+
+- name: Start the Node exporter
+  service:
+    name: prometheus-node_exporter
+    state: started
+
+- name: Start the HA Cluster exporter (HA Clusters only)
+  service:
+    name: prometheus-ha_cluster_exporter
+    state: started
+  when: hana_database.high_availability == True

--- a/deploy/v2/ansible/sap_playbook.yml
+++ b/deploy/v2/ansible/sap_playbook.yml
@@ -1,5 +1,9 @@
 ---
 
+# TODO: 
+# Remove YAML shorthand style for roles (Eg. - { role: os-preparation }) 
+# And replace with newer syntax on https://docs.ansible.com/ansible/latest/user_guide/playbooks_reuse_roles.html
+
 - hosts: localhost
   become: true
   become_user: root
@@ -29,6 +33,10 @@
   roles:
     - { role: os-preparation }
     - { role: os-disk-setup }
+    - role: enable-prometheus
+      when:
+        - output.options.enable_prometheus == True
+        - ansible_facts['distribution_file_variety'] == 'SUSE'
 
 # Mount Azure File share on all linux servers
 - hosts: all_linux_servers

--- a/deploy/v2/ansible/sap_playbook.yml
+++ b/deploy/v2/ansible/sap_playbook.yml
@@ -37,7 +37,7 @@
       when:
         - output.options.enable_prometheus == True
         - ansible_facts['distribution_file_variety'] == 'SUSE'
-        - ansible_facts['distribution_version] is regex("(12.[3-9]|15.\d)")
+        - ansible_facts['distribution_version'] is regex("(12.[3-9]|15.\d)")
 
 # Mount Azure File share on all linux servers
 - hosts: all_linux_servers

--- a/deploy/v2/ansible/sap_playbook.yml
+++ b/deploy/v2/ansible/sap_playbook.yml
@@ -37,6 +37,7 @@
       when:
         - output.options.enable_prometheus == True
         - ansible_facts['distribution_file_variety'] == 'SUSE'
+        - ansible_facts['distribution_version] is regex("(12.[3-9]|15.\d)")
 
 # Mount Azure File share on all linux servers
 - hosts: all_linux_servers

--- a/deploy/v2/ansible/sap_playbook.yml
+++ b/deploy/v2/ansible/sap_playbook.yml
@@ -37,7 +37,7 @@
       when:
         - output.options.enable_prometheus == True
         - ansible_facts['distribution_file_variety'] == 'SUSE'
-        - ansible_facts['distribution_version'] is regex("(12.[3-9]|15.\d)")
+        - ansible_facts['distribution_version'] is regex("(12.[3-4]|15.\d)")
 
 # Mount Azure File share on all linux servers
 - hosts: all_linux_servers

--- a/deploy/v2/input.json
+++ b/deploy/v2/input.json
@@ -223,6 +223,7 @@
   },
   "options": {
     "enable_secure_transfer": true,
-    "ansible_execution": true
+    "ansible_execution": true,
+    "enable_prometheus": false
   }
 }

--- a/deploy/v2/terraform/main.tf
+++ b/deploy/v2/terraform/main.tf
@@ -51,6 +51,7 @@ module "output_files" {
   jumpboxes                    = var.jumpboxes
   databases                    = var.databases
   software                     = var.software
+  options                      = var.options
   storage-sapbits              = module.common_infrastructure.storage-sapbits
   nics-jumpboxes-windows       = module.jumpbox.nics-jumpboxes-windows
   nics-jumpboxes-linux         = module.jumpbox.nics-jumpboxes-linux

--- a/deploy/v2/terraform/modules/output_files/main.tf
+++ b/deploy/v2/terraform/modules/output_files/main.tf
@@ -56,13 +56,14 @@ resource "local_file" "output-json" {
     ],
     "software" = {
       "storage_account_sapbits" = {
-        "name"               = var.storage-sapbits[0].name,
-        "storage_access_key" = var.storage-sapbits[0].primary_access_key,
-        "blob_container_name"     = lookup(var.software.storage_account_sapbits, "blob_container_name", null)
-        "file_share_name"         = lookup(var.software.storage_account_sapbits, "file_share_name", null)
+        "name"                = var.storage-sapbits[0].name,
+        "storage_access_key"  = var.storage-sapbits[0].primary_access_key,
+        "blob_container_name" = lookup(var.software.storage_account_sapbits, "blob_container_name", null)
+        "file_share_name"     = lookup(var.software.storage_account_sapbits, "file_share_name", null)
       },
       "downloader" = var.software.downloader
     }
+    "options" = var.options
     }
   )
   filename = "${path.root}/../ansible_config_files/output.json"

--- a/deploy/v2/terraform/modules/output_files/variables.tf
+++ b/deploy/v2/terraform/modules/output_files/variables.tf
@@ -14,6 +14,10 @@ variable "software" {
   description = "Details of the information required to download SAP installation media"
 }
 
+variable "options" {
+  description = "Configuration options"
+}
+
 variable "nics-jumpboxes-linux" {
   description = "NICs of the Linux jumpboxes"
 }

--- a/templates/tempGen/template.json
+++ b/templates/tempGen/template.json
@@ -215,6 +215,7 @@
   },
   "options": {
     "enable_secure_transfer": true,
-    "ansible_execution": false
+    "ansible_execution": false,
+    "enable_prometheus": true
   }
 }


### PR DESCRIPTION
With this PR, we will be able to enable prometheus on HANA VMs if `"enable_prometheus": true` in `input.json`, in `options`. Related changes:
- `golang-github-prometheus-node_exporter` does not exist for `SLES12 SP2`, therefore we upgrade the pipeline testing to use a newer version `SLES12 SP4` (same code tested with `SLES12 SP3`, also works.)
- Pass information under `options` from Terraform to Ansible with `output.json`.
- Add Ansible code to enable prometheus for HANA servers.