### PR TITLE
Fix problem when depends_on is not defined for the comp

### DIFF
--- a/deploy/v2/ansible/group_vars/all.yml
+++ b/deploy/v2/ansible/group_vars/all.yml
@@ -2,7 +2,7 @@
 disk_dict: {}
 start: 0
 azure_files_mount_path: "/sapmnt"
-components_list: []
+hdb_comp_list: []
 linux_comp_list: []
 windows_comp_list: []
 hana_install_path: "/hana/shared/install"

--- a/deploy/v2/ansible/roles/hdb-server-install/tasks/main.yml
+++ b/deploy/v2/ansible/roles/hdb-server-install/tasks/main.yml
@@ -2,24 +2,26 @@
 
 - name: Create HANA components list from output JSON
   set_fact:
-    components_list: "{{ components_list + [ item.key ] }}"
+    hdb_comp_list: "{{ hdb_comp_list + [ item.key ] }}"
   loop: "{{ hana_database.components|dict2items }}"
 
 - name: Merge HANA Components list with its depends on components
   set_fact:
-    install_comp: "{{  [ item.depends_on ] + components_list }}"
+    hdb_comp_list: "{{  [ item.depends_on ] + hdb_comp_list }}"
   loop: "{{ components }}"
-  when: 'item.component in components_list'
+  when: 
+    - item.component in hdb_comp_list
+    - item.depends_on is defined
 
 - name: Create unique list of HANA Components
   set_fact:
-    hana_components: "{{ install_comp|flatten(levels=1)|unique }}"
+    hdb_comp_list: "{{ hdb_comp_list|flatten(levels=1)|unique }}"
 
 # Install HANA Components
 - name: Install HANA Components
   include_role:
     name: components-install
     tasks_from: "{{ component }}.yml"
-  loop: "{{ hana_components }}"
+  loop: "{{ hdb_comp_list }}"
   loop_control:
     loop_var: component


### PR DESCRIPTION
There is a bug when creating unique list for HANA database component, which will lead to below error when only components without dependency are defined (eg. hana_database, hana_linux_client, hana_linux_studio).

Error:

```
sap-hana/deploy/v2/ansible/roles/hdb-server-install/tasks/main.yml" 40L, 990C written                
        "U",
        "d",
        "f",
        ",",
        " ",
        "'",
        "h",
        "_",
        "t",
        "]"
```

While correcting this wrong behavior, I also address the [comment](https://github.com/Azure/sap-hana/pull/282#discussion_r377801712) in 
PR #282 regarding variable naming so it's clearer.