### PR TITLE
Utility script support for multiple input JSON templates (#297)

### DIFF
--- a/deploy/v2/USAGE.md
+++ b/deploy/v2/USAGE.md
@@ -166,10 +166,10 @@ Configuring your SAP Launchpad credentials for the simplest example JSON input f
    util/terraform_v2.sh init
    ```
 
-1. To easily deploy the system, run the following utility script:
+1. To easily deploy the system, run the following utility script with an input template name (e.g. `single_node_hana`):
 
    ```text
-   util/terraform_v2.sh apply
+   util/terraform_v2.sh apply single_node_hana
    ```
 
    **Note:** This process can take in the region of 90 minutes to complete.
@@ -185,10 +185,10 @@ Configuring your SAP Launchpad credentials for the simplest example JSON input f
 1. To review/inspect the provisioned resources navigate to the `test_rg` resource group of your configured Azure subscription in Azure portal.
    By default, all the provisioned resources (excluding the service principal) are deployed into the same resource group.
 
-1. To easily delete the provisioned resources, run the following utility script:
+1. To easily delete the provisioned resources, run the following utility script with an input template name (e.g. `single_node_hana`):
 
    ```text
-   util/terraform_v2.sh destroy
+   util/terraform_v2.sh destroy single_node_hana
    ```
 
 ## Summary
@@ -217,8 +217,8 @@ util/set_sap_download_credentials.sh S123456789 MySAPpass
 
 # Build/Update Lifecycle: Takes about 90 minutes and is performed once per SAP system build/update
 util/terraform_v2.sh init
-util/terraform_v2.sh apply
+util/terraform_v2.sh apply single_node_hana
 
 # Destroy Lifecycle: Takes about 15 minutes and is performed once per SAP system build
-util/terraform_v2.sh destroy
+util/terraform_v2.sh destroy single_node_hana
 ```

--- a/deploy/v2/template_samples/rti_only.json
+++ b/deploy/v2/template_samples/rti_only.json
@@ -59,7 +59,7 @@
         "os": {
           "publisher": "Canonical",
           "offer": "UbuntuServer",
-          "sku": "16.04-LTS"
+          "sku": "18.04-LTS"
         },
         "authentication": {
           "type": "key",

--- a/deploy/v2/template_samples/rti_only.json
+++ b/deploy/v2/template_samples/rti_only.json
@@ -1,0 +1,92 @@
+{
+  "infrastructure": {
+    "region": "eastus",
+    "resource_group": {
+      "is_existing": "false",
+      "name": "test-rg"
+    },
+    "vnets": {
+      "management": {
+        "is_existing": "false",
+        "name": "vnet-mgmt",
+        "address_space": "10.0.0.0/16",
+        "subnet_mgmt": {
+          "is_existing": "false",
+          "name": "subnet-mgmt",
+          "prefix": "10.0.1.0/24",
+          "nsg": {
+            "is_existing": "false",
+            "name": "nsg-mgmt",
+            "allowed_ips": [
+              "0.0.0.0/0"
+            ]
+          }
+        }
+      },
+      "sap": {
+        "is_existing": "false",
+        "name": "vnet-sap",
+        "address_space": "10.1.0.0/16",
+        "subnet_admin": {
+          "is_existing": "false",
+          "name": "subnet-admin",
+          "prefix": "10.1.1.0/24",
+          "nsg": {
+            "is_existing": "false",
+            "name": "nsg-admin"
+          }
+        },
+        "subnet_db": {
+          "is_existing": "false",
+          "name": "subnet-db",
+          "prefix": "10.1.2.0/24",
+          "nsg": {
+            "is_existing": "false",
+            "name": "nsg-db"
+          }
+        }
+      }
+    }
+  },
+  "jumpboxes": {
+    "windows": [],
+    "linux": [
+      {
+        "name": "rti",
+        "destroy_after_deploy": "true",
+        "size": "Standard_D2s_v3",
+        "disk_type": "StandardSSD_LRS",
+        "os": {
+          "publisher": "Canonical",
+          "offer": "UbuntuServer",
+          "sku": "16.04-LTS"
+        },
+        "authentication": {
+          "type": "key",
+          "username": "azureadm"
+        },
+        "components": [
+          "ansible"
+        ]
+      }
+    ]
+  },
+  "databases": [],
+  "software": {
+    "storage_account_sapbits": {
+      "is_existing": false,
+      "account_tier": "Premium",
+      "account_replication_type": "LRS",
+      "account_kind": "FileStorage",
+      "file_share_name": "bits"
+    },
+    "downloader": {}
+  },
+  "sshkey": {
+    "path_to_public_key": "~/.ssh/id_rsa.pub",
+    "path_to_private_key": "~/.ssh/id_rsa"
+  },
+  "options": {
+    "ansible_execution": false
+  }
+}

--- a/util/common_utils.sh
+++ b/util/common_utils.sh
@@ -20,5 +20,14 @@ function continue_or_error_and_exit()
 	local status_code=$1
 	local error_message="$2"
 
-	((status_code != 0)) && { echo "ERROR: ${error_message}"; exit 1; }
+	((status_code != 0)) && { error_and_exit "${error_message}"; }
+}
+
+
+function error_and_exit()
+{
+	local error_message="$1"
+
+	printf "%s\n" "ERROR: ${error_message}" >&2
+	exit 1
 }

--- a/util/create_service_principal.sh
+++ b/util/create_service_principal.sh
@@ -40,7 +40,7 @@ function check_command_line_arguments()
 
 	# Check there's just a single argument provided
 	if [[ ${args_count} -ne 1 ]]; then
-		continue_or_error_and_exit 1 "You must specify a single command line argument for the service principal name"
+		error_and_exit "You must specify a single command line argument for the service principal name"
 	fi
 }
 

--- a/util/set_sap_download_credentials.sh
+++ b/util/set_sap_download_credentials.sh
@@ -42,7 +42,7 @@ function check_command_line_arguments()
 
 	# Check there're just two arguments provided
 	if [[ ${args_count} -ne 2 ]]; then
-		continue_or_error_and_exit 1 "You must specify 2 command line arguments for the SAP download credentials: a username and a password"
+		error_and_exit "You must specify 2 command line arguments for the SAP download credentials: a username and a password"
 	fi
 }
 

--- a/util/terraform_v2.sh
+++ b/util/terraform_v2.sh
@@ -21,16 +21,22 @@ set -o nounset
 source util/common_utils.sh
 
 
+readonly input_file_term='<JSON template name>'
 readonly target_path="deploy/v2"
 readonly target_code="${target_path}/terraform/"
-readonly target_json="${target_path}/template_samples/single_node_hana.json"
+readonly target_template_dir="${target_path}/template_samples"
 
 
 function main()
 {
-	# handle no command being supplied
+
+	# default to empty string when 0 args supplied
 	local terraform_action=''
 	[ $# -eq 0 ] || terraform_action="$1"
+
+	# default to empty string when 1 or less args supplied
+	local template_name=''
+	[ $# -le 1 ] || template_name="$2"
 
 	# dispatch appropriate command
 	case "${terraform_action}" in
@@ -38,15 +44,33 @@ function main()
 			terraform_init
 			;;
 		'apply')
-			terraform_apply
+			check_command_line_arguments_for_template "$@"
+			terraform_apply "${template_name}"
 			;;
 		'destroy')
-			terraform_destroy
+			check_command_line_arguments_for_template "$@"
+			terraform_destroy "${template_name}"
 			;;
 		*)
-			print_usage_info
+			print_usage_info_and_exit
 			;;
 	esac
+}
+
+
+# This function checks the command line arguments for the case when a template
+# name is required
+function check_command_line_arguments_for_template()
+{
+	local args_count=$#
+	local script_name="$0"
+	local terraform_action="$1"
+
+	# Check there're just two arguments provided
+	if [[ ${args_count} -ne 2 ]]; then
+		print_usage_info
+		error_and_exit "You must specify a ${input_file_term} to run ${script_name} with the '${terraform_action}' option"
+	fi
 }
 
 
@@ -60,6 +84,12 @@ function terraform_init()
 # Apply Terraform target code
 function terraform_apply()
 {
+	local target_json_template="$1"
+
+	check_json_template_exists "${target_json_template}"
+
+	local target_json
+	target_json=$(get_json_template_path "${target_json_template}")
 	run_terraform_command "apply -auto-approve -var-file=${target_json} ${target_code}"
 }
 
@@ -67,11 +97,17 @@ function terraform_apply()
 # Destroy Azure resources using the Terraform target code
 function terraform_destroy()
 {
+	local target_json_template="$1"
+
+	check_json_template_exists "${target_json_template}"
+
+	local target_json
+	target_json=$(get_json_template_path "${target_json_template}")
 	run_terraform_command "destroy -auto-approve -var-file=${target_json} ${target_code}"
 }
 
 
-# Print the correct/expected script usage
+# This function prints the correct/expected script usage but does not exit
 function print_usage_info()
 {
 	local script_path="$0"
@@ -83,9 +119,19 @@ function print_usage_info()
 	echo
 	echo "The commands are:"
 	echo -e "\tinit"
-	echo -e "\tapply"
-	echo -e "\tdestroy"
+	echo -e "\tapply ${input_file_term}"
+	echo -e "\tdestroy ${input_file_term}"
 	echo
+	echo "Where ${input_file_term} is one of the following:"
+	print_allowed_json_template_names
+	echo
+}
+
+
+# This function prints the correct/expected script usage and then exits
+function print_usage_info_and_exit()
+{
+	print_usage_info
 	exit 2
 }
 
@@ -105,6 +151,46 @@ function run_terraform_command()
 
 	${command}
 }
+
+
+# Given a template file name (without file extension)
+# This function returns the full relative path of the template file
+function get_json_template_path()
+{
+	local template_name="$1"
+
+	local json_template_path="${target_template_dir}/${template_name}.json"
+
+	echo "${json_template_path}"
+}
+
+
+# Given a template file name (without file extension)
+# This function determines if the template file exists, and exits with an
+# error and usage info when no template is found
+function check_json_template_exists()
+{
+	local template_name="$1"
+
+	local template_path
+	template_path=$(get_json_template_path "${template_name}")
+
+	if [ ! -f "${template_path}" ]; then
+		print_usage_info
+		error_and_exit "'${template_name}' is not a valid ${input_file_term} to use with the '${terraform_action}' option"
+	fi
+}
+
+
+# This function pretty prints all the currently available template file names
+function print_allowed_json_template_names()
+{
+	# list JSON files in the templates dir
+	# filter the output of 'find' to extract just the filenames without extensions
+	# prefix the results with indents and hyphen bullets
+	find ${target_template_dir} -name '*.json' | sed -e 's/.*\/\(.*\)\.json/  - \1/'
+}
+
 
 # Execute the main program flow with all arguments
 main "$@"


### PR DESCRIPTION
## Problem

Changes introduced in #288 allow terraform to be easily run against a single JSON input template (single node HANA), but as more templates are added the scripts will need to allow for the user to make a choice on which to use (see #292).

The current scripts also write errors to STDOUT rather than STDERR (see #295).

## Description

This PR enables the V2 terraform script to be run using any input JSON template within the example templates directory, and provides the user with appropriate usage details and suggestions in the case when no template is given, or the given template does not exist. The USAGE guide is also updated to cover this interface change, and a new "minimal example" input JSON template is added `rti_only` that can be used to provision/destroy just the RTI instance. This can be used to test RTI-related provisioning, and runs in considerably less time than the SAP `single_node_hana` alternative.

The PR also fixes #295 by ensuring all error output created through the error output function is sent to STDERR.

**Note:** This PR does not cover the changes required to enable the `util/set_sap_download_credentials.sh` script to work with multiple input JSON templates. That feature will be added when more SAP input JSON templates are added.

## Pre-Requisites

1. Have followed the initial parts of [the USAGE guide up to section **Build/Update/Destroy Lifecycle**](https://github.com/Azure/sap-hana/blob/226cc37827333e5b96319f297c85313418f50144/deploy/v2/USAGE.md#buildupdatedestroy-lifecycle).
1. `shellcheck` installed on the workstation you're testing from (for test 3)

## Test Instructions

- [x] 1. Review the [USAGE.md](https://github.com/Azure/sap-hana/pull/297/files#diff-7b2ac2a41f894bd0e6577ab6721d0d9d) guide updates to ensure they are clear.
- [x] 2. Follow the usage guide to ensure the process works and the new utility scripts run successfully:
   - Potential alternative test cases:
      1. `util/terraform_v2.sh apply rti_only`
      1. `util/terraform_v2.sh destroy rti_only`
- [x] 3. Shellcheck review the scripts by running `shellcheck util/*.sh` (no results should be shown and there should be a zero exit status from `echo $?` when run after shellcheck)
- [x] 4. Check some edge cases for reasonable error handling in the `util/terraform_v2.sh` script, such as:
   - Not specifying command line arguments, when they're expected (e.g. `util/terraform_v2.sh`)
   - Specifying only partial command line arguments (e.g. `util/terraform_v2.sh apply`)
   - Specifying template files that don't exist  (e.g. `util/terraform_v2.sh apply test`)
- [x] 5. Check that errors are now going to STDOUT by running through the following:
  - [x] Check the following does not display the error "ERROR: 'test' is not a valid <JSON template name> to use with the 'destroy' option" on the terminal:
    ```bash
    util/terraform_v2.sh destroy test 2>error.log
    ```
  - [x] Check the above error is in the `error.log` file:
    ```bash
    cat error.log
    ```

## References

1. See #297 for original commit history