### PR TITLE
Disable ansible execution and minimize testing scope

### DIFF
--- a/templates/ansible-deployment-steps.yaml
+++ b/templates/ansible-deployment-steps.yaml
@@ -19,8 +19,6 @@ steps:
       git checkout $(System.PullRequest.SourceBranch)      
       EOF
       echo "Ansible Deployment disabled"
-# Disable ansible playbook execution since current milestone is TF only
-#      ssh -i /tmp/sshkey -o StrictHostKeyChecking=no "${rti_user}"@"${rti_public_ip}" 'OBJC_DISABLE_INITIALIZE_FORK_SAFETY="YES" ANSIBLE_HOST_KEY_CHECKING="False" ansible-playbook -i hosts sap-hana/deploy/v2/ansible/sap_playbook.yml'      
     displayName: 'Ansible Deployment'
     env:
       TF_VAR_azure_service_principal_id: $(hana-pipeline-spn-id)

--- a/templates/ansible-deployment-steps.yaml
+++ b/templates/ansible-deployment-steps.yaml
@@ -18,7 +18,9 @@ steps:
       cd sap-hana
       git checkout $(System.PullRequest.SourceBranch)      
       EOF
-      ssh -i /tmp/sshkey -o StrictHostKeyChecking=no "${rti_user}"@"${rti_public_ip}" 'OBJC_DISABLE_INITIALIZE_FORK_SAFETY="YES" ANSIBLE_HOST_KEY_CHECKING="False" ansible-playbook -i hosts sap-hana/deploy/v2/ansible/sap_playbook.yml'
+      echo "Ansible Deployment disabled"
+# Disable ansible playbook execution since current milestone is TF only
+#      ssh -i /tmp/sshkey -o StrictHostKeyChecking=no "${rti_user}"@"${rti_public_ip}" 'OBJC_DISABLE_INITIALIZE_FORK_SAFETY="YES" ANSIBLE_HOST_KEY_CHECKING="False" ansible-playbook -i hosts sap-hana/deploy/v2/ansible/sap_playbook.yml'      
     displayName: 'Ansible Deployment'
     env:
       TF_VAR_azure_service_principal_id: $(hana-pipeline-spn-id)

--- a/templates/tempGen/template.json
+++ b/templates/tempGen/template.json
@@ -50,47 +50,8 @@
   },
   "jumpboxes": {
     "windows": [
-      {
-        "name": "jumpbox-windows",
-        "destroy_after_deploy": "false",
-        "size": "Standard_D2s_v3",
-        "disk_type": "StandardSSD_LRS",
-        "os": {
-          "publisher": "MicrosoftWindowsServer",
-          "offer": "WindowsServer",
-          "sku": "2016-Datacenter"
-        },
-        "authentication": {
-          "type": "password",
-          "username": "azureadm",
-          "password": "Sap@hana2019!"
-        },
-        "components": [
-          "hana_studio_windows",
-          "hana_client_windows"
-        ]
-      }
     ],
     "linux": [
-      {
-        "name": "jumpbox-linux",
-        "destroy_after_deploy": "false",
-        "size": "Standard_D2s_v3",
-        "disk_type": "StandardSSD_LRS",
-        "os": {
-          "publisher": "Canonical",
-          "offer": "UbuntuServer",
-          "sku": "18.04-LTS"
-        },
-        "authentication": {
-          "type": "key",
-          "username": "azureadm"
-        },
-        "components": [
-          "hana_studio_linux",
-          "hana_client_linux"
-        ]
-      },
       {
         "name": "rti",
         "destroy_after_deploy": "true",
@@ -136,17 +97,7 @@
         "cockpit_admin_password": "Manager1"
       },
       "components": {
-        "hana_database": [],
-        "hana_client_linux": [],
-        "xs": [
-          "xsac_alm_pi_ui",
-          "xsac_portal_serv",
-          "xsac_services",
-          "xsac_ui5_fesv5",
-          "xsac_ui5_sb",
-          "xsac_xsa_cockpit"
-        ],
-        "shine": []
+        "hana_database": []
       },
       "xsa": {
         "routing": "ports"


### PR DESCRIPTION
Currently, each pipeline test will takes 1.5 - 2 hrs to finish.
This has become bottle neck for PR to get updated and merged.
Therefore we introduce the below changes, which will reduce the pipeline test to ~15 minutes.

- Disable ansible execution for [milestone 1](https://github.com/Azure/sap-hana/milestone/1) since the this one is terraform only. Will enable ansible execution afterwards.
- Simplify template.json to minimal set (to just deploy single HANA instance)

For the complete scenario, there will be separate PR (#305) to schedule daily job for more coverage, which includes:

- Single HANA instance installation
- XSA installation
- SHINE installation
- HANA Studio/Client installation on Linux/Windows jumpboxes