### PR TITLE
Simplify usage by auto-sourcing Service Principal Auth Credentials File

### DIFF
--- a/util/terraform_v2.sh
+++ b/util/terraform_v2.sh
@@ -20,6 +20,8 @@ set -o nounset
 # import common functions that are reused across scripts
 source util/common_utils.sh
 
+# name of the script where the auth info should be saved
+readonly auth_script='set-sp.sh'
 
 readonly input_file_term='<JSON template name>'
 readonly target_path="deploy/v2"
@@ -143,6 +145,8 @@ function run_terraform_command()
 
 	local command="terraform ${options}"
 
+	load_auth_script_credentials
+
 	# describe the command that will be run (useful for debugging)
 	echo "Running the following Terraform command:"
 	echo
@@ -178,6 +182,20 @@ function check_json_template_exists()
 	if [ ! -f "${template_path}" ]; then
 		print_usage_info
 		error_and_exit "'${template_name}' is not a valid ${input_file_term} to use with the '${terraform_action}' option"
+	fi
+}
+
+
+
+# This functionn checks the auth script exists and loads it, otherwise it exits
+# with an appropriate error
+function load_auth_script_credentials()
+{
+	if [ -f ${auth_script} ]; then
+		# shellcheck source=/dev/null
+		source "${auth_script}"
+	else
+		error_and_exit "Authorization file not found: ${auth_script}. Try running util/create_service_principal.sh to create it."
 	fi
 }
 


### PR DESCRIPTION
## Problem

After following the USAGE guide, if an Engineer opens a new terminal session it's easy to forget you need to re-run the sourcing of the Service Principal authorization info.

## Description

This PR adds V2 functionality to automatically source the credentials file, or report that it's missing when attempting to use terraform.

## Pre-Requisites

1. `shellcheck` installed on the workstation you're testing from
2. Ensure you have followed the scripted setup in the USAGE guide (so you have a `set-sp.sh` file in the expected location)

## Test Instructions

- [ ] 1. Shellcheck review the scripts by running `shellcheck util/*.sh` (no results should be shown and there should be a zero exit status from `echo $?` when run after shellcheck)
- [ ] 2. Open a new terminal session to ensure you have no pre-set environment variables for terraform. Check this with `env | grep "^ARM"` and expect no results.
- [ ] 3. Run: `util/terraform_v2.sh init` (expect it to complete successfully)
- [ ] 4. Move your existing auth file to a new location. E.g.: `mv set-sp.sh set-sp.sh.bak`
- [ ] 5. Re-run `util/terraform_v2.sh init` (expect it to give a sensible error)
- [ ] 6. Either restore or recreate the auth file: `mv set-sp.sh.bak set-sp.sh`
- [ ] 7. Re-run `util/terraform_v2.sh init` (expect it to complete successfully again)
