### PR TITLE
Fixing missing semicolons in terraform_v2.sh

### DIFF
--- a/util/terraform_v2.sh
+++ b/util/terraform_v2.sh
@@ -54,6 +54,7 @@ function main()
 		'destroy')
 			check_command_line_arguments_for_template "$@"
 			terraform_destroy "${template_name}"
+			;;
 		'clean')
 			terraform_clean
 			;;


### PR DESCRIPTION
`util/terraform_v2.sh` clean does not wrong due to syntax error:

```bash
$ util/terraform_v2.sh clean
util/terraform_v2.sh: line 57: syntax error near unexpected token `)'
```