### PR TITLE
[HOTFIX] Update all deployment script to use SLES12 SP5

### DIFF
--- a/azure-pipelines-v2.yaml
+++ b/azure-pipelines-v2.yaml
@@ -50,9 +50,9 @@ stages:
   - template: templates/job-template-allReuseCases.yaml
     parameters:
       osVersion: "SLES12"
-      osImage: '\"offer\": \"SLES-SAP\", 
+      osImage: '\"offer\": \"sles-sap-12-sp5\", 
                 \"publisher\": \"SUSE\", 
-                \"sku\": \"12-SP5\"'
+                \"sku\": \"gen1\"'
   - template: templates/job-template-per-os.yaml
     parameters:
       osVersion: "RHEL7"

--- a/azure-pipelines-v2.yaml
+++ b/azure-pipelines-v2.yaml
@@ -52,7 +52,7 @@ stages:
       osVersion: "SLES12"
       osImage: '\"offer\": \"SLES-SAP\", 
                 \"publisher\": \"SUSE\", 
-                \"sku\": \"12-SP4\"'
+                \"sku\": \"12-SP5\"'
   - template: templates/job-template-per-os.yaml
     parameters:
       osVersion: "RHEL7"

--- a/deploy/vm/ansible/roles/create-azure-vm/defaults/main.yml
+++ b/deploy/vm/ansible/roles/create-azure-vm/defaults/main.yml
@@ -20,9 +20,9 @@ backend_ip_pool_ids: []
 
 # VM specific values
 vm_name:
-source_image_offer: SLES-SAP
+source_image_offer: sles-sap-12-sp5
 source_image_publisher: SUSE
-source_image_sku: 12-SP5
+source_image_sku: gen1
 source_image_version: latest
 managed_disk_type: Premium_LRS
 vm_data_disks: []

--- a/deploy/vm/ansible/roles/create-azure-vm/defaults/main.yml
+++ b/deploy/vm/ansible/roles/create-azure-vm/defaults/main.yml
@@ -22,7 +22,7 @@ backend_ip_pool_ids: []
 vm_name:
 source_image_offer: SLES-SAP
 source_image_publisher: SUSE
-source_image_sku: 12-SP3
+source_image_sku: 12-SP5
 source_image_version: latest
 managed_disk_type: Premium_LRS
 vm_data_disks: []

--- a/deploy/vm/ansible/roles/create-hana-cluster/tasks/main.yml
+++ b/deploy/vm/ansible/roles/create-hana-cluster/tasks/main.yml
@@ -108,7 +108,7 @@
         image:
             offer: SLES
             publisher: SUSE
-            sku: 12-SP3
+            sku: 12-SP5
             version: latest
       with_sequence: start=1 end="{{ n }}"
       async: 1500

--- a/deploy/vm/ansible/roles/create-hana-cluster/tasks/main.yml
+++ b/deploy/vm/ansible/roles/create-hana-cluster/tasks/main.yml
@@ -106,9 +106,9 @@
         started: yes
         state: present
         image:
-            offer: SLES
+            offer: sles-sap-12-sp5
             publisher: SUSE
-            sku: 12-SP5
+            sku: gen1
             version: latest
       with_sequence: start=1 end="{{ n }}"
       async: 1500

--- a/deploy/vm/ansible/roles/disk-setup/tasks/main.yml
+++ b/deploy/vm/ansible/roles/disk-setup/tasks/main.yml
@@ -5,7 +5,7 @@
     name="{{ item }}"
     state=present
   with_items:
-    - gdisk
+    - gptfdisk
     - sg3_utils
     - lvm2
   tags:

--- a/deploy/vm/modules/generic_vm_and_disk_creation/main.tf
+++ b/deploy/vm/modules/generic_vm_and_disk_creation/main.tf
@@ -61,7 +61,7 @@ resource "azurerm_virtual_machine" "vm" {
   storage_image_reference {
     publisher = "SUSE"
     offer     = "SLES-SAP"
-    sku       = "12-SP3"
+    sku       = "12-SP5"
     version   = "latest"
   }
 

--- a/deploy/vm/modules/generic_vm_and_disk_creation/main.tf
+++ b/deploy/vm/modules/generic_vm_and_disk_creation/main.tf
@@ -60,8 +60,8 @@ resource "azurerm_virtual_machine" "vm" {
 
   storage_image_reference {
     publisher = "SUSE"
-    offer     = "SLES-SAP"
-    sku       = "12-SP5"
+    offer     = "sles-sap-12-sp5"
+    sku       = "gen1"
     version   = "latest"
   }
 

--- a/templates/README.MD
+++ b/templates/README.MD
@@ -92,8 +92,8 @@ This is Azure pipeline test created for deploy/v2
     - template: templates/job-template-per-os.yaml
       parameters:
         osVersion: "SLES12"
-        osImage: '\"offer\": \"SLES-SAP\", 
+        osImage: '\"offer\": \"sles-sap-12-sp5\", 
                   \"publisher\": \"SUSE\", 
-                  \"sku\": \"12-SP5\"'
+                  \"sku\": \"gen1\"'
     ```
   - add the new OS into os_list under `stage: DestroyingResources` -> `job: cleanUp` -> varible `os_list`.

--- a/templates/README.MD
+++ b/templates/README.MD
@@ -94,6 +94,6 @@ This is Azure pipeline test created for deploy/v2
         osVersion: "SLES12"
         osImage: '\"offer\": \"SLES-SAP\", 
                   \"publisher\": \"SUSE\", 
-                  \"sku\": \"12-sp2\"'
+                  \"sku\": \"12-SP5\"'
     ```
   - add the new OS into os_list under `stage: DestroyingResources` -> `job: cleanUp` -> varible `os_list`.


### PR DESCRIPTION
**Issue description:**

Due to [bug](https://bugzilla.suse.com/show_bug.cgi?id=1165732) in cloud-regionsrv-client prior to 9.0.7, the automated deployment script will break while installing packages on deployed VMs.

The bug has been fixed in 9.0.8, which comes only in the active images maintained by SUSE.
 
**Impact:**

- runner keeps failing.
- customer who deploy with our script facing the same problem.

**Solution:**

There is no more support for SLES 12 SP2/3/4, therefore no active images on those SPs. 
Therefore the only way to get the latest cloud-regionsrv-client is to deploy VMs with images that are on SLES12 SP5.