### PR TITLE
[DRAFT] Use symlink to share common variables across modules

### DIFF
--- a/deploy/v2/terraform/main.tf
+++ b/deploy/v2/terraform/main.tf
@@ -8,9 +8,12 @@ module "common_infrastructure" {
   source              = "./modules/common_infrastructure"
   is_single_node_hana = "true"
   infrastructure      = var.infrastructure
+  jumpboxes           = var.jumpboxes
+  databases           = var.databases
+  sshkey              = var.sshkey
   software            = var.software
   options             = var.options
-  databases           = var.databases
+
 }
 
 # Create Jumpboxes and RTI box
@@ -21,6 +24,8 @@ module "jumpbox" {
   databases         = var.databases
   sshkey            = var.sshkey
   ssh-timeout       = var.ssh-timeout
+  software          = var.software
+  options           = var.options
   resource-group    = module.common_infrastructure.resource-group
   subnet-mgmt       = module.common_infrastructure.subnet-mgmt
   nsg-mgmt          = module.common_infrastructure.nsg-mgmt
@@ -34,8 +39,11 @@ module "jumpbox" {
 module "hdb_node" {
   source           = "./modules/hdb_node"
   infrastructure   = var.infrastructure
+  jumpboxes        = var.jumpboxes
   databases        = var.databases
   sshkey           = var.sshkey
+  software         = var.software
+  options          = var.options
   resource-group   = module.common_infrastructure.resource-group
   subnet-sap-admin = module.common_infrastructure.subnet-sap-admin
   nsg-admin        = module.common_infrastructure.nsg-admin
@@ -50,6 +58,7 @@ module "output_files" {
   infrastructure               = var.infrastructure
   jumpboxes                    = var.jumpboxes
   databases                    = var.databases
+  sshkey                       = var.sshkey
   software                     = var.software
   options                      = var.options
   storage-sapbits              = module.common_infrastructure.storage-sapbits

--- a/deploy/v2/terraform/modules/common_infrastructure/variables.tf
+++ b/deploy/v2/terraform/modules/common_infrastructure/variables.tf
@@ -1,20 +1,4 @@
-variable "infrastructure" {
-  description = "Details of the Azure infrastructure to deploy the SAP landscape into"
-}
-
 variable "is_single_node_hana" {
   description = "Checks if single node hana architecture scenario is being deployed"
   default     = false
-}
-
-variable "software" {
-  description = "Details of the infrastructure components required for SAP installation"
-}
-
-variable "options" {
-  description = "Configuration options"
-}
-
-variable "databases" {
-  description = "Details of the databases"
 }

--- a/deploy/v2/terraform/modules/common_infrastructure/variables_shared_ln.tf
+++ b/deploy/v2/terraform/modules/common_infrastructure/variables_shared_ln.tf
@@ -1,0 +1,1 @@
+../../variables.tf

--- a/deploy/v2/terraform/modules/hdb_node/variables.tf
+++ b/deploy/v2/terraform/modules/hdb_node/variables.tf
@@ -1,11 +1,3 @@
-variable "databases" {
-  description = "Details of the HANA database nodes"
-}
-
-variable "infrastructure" {
-  description = "Details of the Azure infrastructure to deploy the SAP landscape into"
-}
-
 variable "resource-group" {
   description = "Details of the resource group"
 }
@@ -28,10 +20,6 @@ variable "nsg-db" {
 
 variable "storage-bootdiag" {
   description = "Details of the boot diagnostics storage account"
-}
-
-variable "sshkey" {
-  description = "Details of ssh key pair"
 }
 
 # Imports HANA database sizing information

--- a/deploy/v2/terraform/modules/hdb_node/variables_shared_ln.tf
+++ b/deploy/v2/terraform/modules/hdb_node/variables_shared_ln.tf
@@ -1,0 +1,1 @@
+../../variables.tf

--- a/deploy/v2/terraform/modules/jumpbox/variables.tf
+++ b/deploy/v2/terraform/modules/jumpbox/variables.tf
@@ -1,15 +1,3 @@
-variable "jumpboxes" {
-  description = "Details of the jumpboxes"
-}
-
-variable "databases" {
-  description = "Details of the databases"
-}
-
-variable "infrastructure" {
-  description = "Details of the Azure infrastructure to deploy the SAP landscape into"
-}
-
 variable "resource-group" {
   description = "Details of the resource group"
 }
@@ -26,20 +14,12 @@ variable "storage-bootdiag" {
   description = "Details of the boot diagnostics storage account"
 }
 
-variable "sshkey" {
-  description = "Details of ssh key pair"
-}
-
 variable "output-json" {
   description = "Details of the output JSON"
 }
 
 variable "ansible-inventory" {
   description = "Details of the Ansible inventory"
-}
-
-variable "ssh-timeout" {
-  description = "Timeout for connection that is used by provisioner"
 }
 
 variable "random-id" {

--- a/deploy/v2/terraform/modules/jumpbox/variables_shared_ln.tf
+++ b/deploy/v2/terraform/modules/jumpbox/variables_shared_ln.tf
@@ -1,0 +1,1 @@
+../../variables.tf

--- a/deploy/v2/terraform/modules/output_files/variables.tf
+++ b/deploy/v2/terraform/modules/output_files/variables.tf
@@ -1,23 +1,3 @@
-variable "infrastructure" {
-  description = "Details of the Azure infrastructure to deploy the SAP landscape into"
-}
-
-variable "jumpboxes" {
-  description = "Details of the jumpboxes"
-}
-
-variable "databases" {
-  description = "Details of the HANA database nodes"
-}
-
-variable "software" {
-  description = "Details of the information required to download SAP installation media"
-}
-
-variable "options" {
-  description = "Configuration options"
-}
-
 variable "nics-jumpboxes-linux" {
   description = "NICs of the Linux jumpboxes"
 }

--- a/deploy/v2/terraform/modules/output_files/variables_shared_ln.tf
+++ b/deploy/v2/terraform/modules/output_files/variables_shared_ln.tf
@@ -1,0 +1,1 @@
+../../variables.tf


### PR DESCRIPTION
There are several variables shared across different modules.
This PR will change to use symlink to share the `terraform/variable.tf` among all modules.

As a follow up item, there will be a separate PR to extend the content of the shared `terraform/variable.tf` with better descriptions as well as default values if not assigned.