### PR TITLE
[HOTFIX] Fix broken saplandscaperunner

### DIFF
--- a/deploy/vm/ansible/delete_bastion_linux.yml
+++ b/deploy/vm/ansible/delete_bastion_linux.yml
@@ -2,4 +2,4 @@
 - name: delete vm
   hosts: localhost
   roles:
-          - {role: delete-azure-vm, az_resource_group: "{{ az_resource_group}}", az_vm_name: "{{ az_vm_name }}"}
+          - {role: delete-azure-vm, when: linux_bastion == true, az_resource_group: "{{ az_resource_group }}", az_vm_name: "{{ az_vm_name }}"}

--- a/deploy/vm/ansible/linux_bastion_host.yml
+++ b/deploy/vm/ansible/linux_bastion_host.yml
@@ -37,7 +37,7 @@
 - hosts: localhost
   tasks:
     - name: Retrieve the public IP of the new linux bastion vm
-      azure_rm_publicipaddress_facts:
+      azure_rm_publicipaddress_info:
         resource_group: "{{ az_json.az_resource_group }}"
         name:  "{{ az_json.az_vm_name }}-pip"
       register: lbh_metadata

--- a/deploy/vm/ansible/roles/disk-setup/tasks/main.yml
+++ b/deploy/vm/ansible/roles/disk-setup/tasks/main.yml
@@ -8,6 +8,10 @@
     - gptfdisk
     - sg3_utils
     - lvm2
+  register: result
+  retries: "{{ package_retries_cnt }}"
+  until: result.rc == 0
+  delay: "{{ package_retries_delay }}"
   tags:
   - disk_setup
 

--- a/deploy/vm/ansible/roles/iscsi-setup/tasks/main.yml
+++ b/deploy/vm/ansible/roles/iscsi-setup/tasks/main.yml
@@ -24,10 +24,6 @@
     name: targetcli
     state: absent
 
-# HOTFIX for issue 220
-- name: Re-register the SLE instance against its respective cloud repository
-  command: /usr/sbin/registercloudguest --force-new
-
 - name: Install iSCSI target packages
   package:
     name: targetcli-fb

--- a/deploy/vm/modules/playbook-execution/main.tf
+++ b/deploy/vm/modules/playbook-execution/main.tf
@@ -35,6 +35,8 @@ resource null_resource "mount-disks-and-configure-hana" {
      \"url_timeout\": \"${var.url_timeout}\", \
      \"url_retries_cnt\": \"${var.url_retries_cnt}\", \
      \"url_retries_delay\": \"${var.url_retries_delay}\",\
+     \"package_retries_cnt\": \"${var.package_retries_cnt}\", \
+     \"package_retries_delay\": \"${var.package_retries_delay}\", \
      \"pwd_db_xsaadmin\": \"${var.pwd_db_xsaadmin}\", \
      \"pw_bastion_windows\": \"${var.pw_bastion_windows}\", \
      \"bastion_username_windows\": \"${var.bastion_username_windows}\", \

--- a/deploy/vm/modules/playbook-execution/variables.tf
+++ b/deploy/vm/modules/playbook-execution/variables.tf
@@ -178,7 +178,7 @@ variable "url_retries_cnt" {
 }
 
 variable "url_retries_delay" {
-  description = "The time between each attempt to download the installation bits from the URLs"
+  description = "The time (in seconds) between each attempt to download the installation bits from the URLs"
   default     = 10
 }
 
@@ -188,7 +188,7 @@ variable "package_retries_cnt" {
 }
 
 variable "package_retries_delay" {
-  description = "The time between each attempt to install packages"
+  description = "The time (in seconds) between each attempt to install packages"
   default     = 10
 }
 

--- a/deploy/vm/modules/playbook-execution/variables.tf
+++ b/deploy/vm/modules/playbook-execution/variables.tf
@@ -37,17 +37,17 @@ variable "install_webide" {
 
 variable "private_ip_address_hdb0" {
   description = "Private ip address of hdb0 in HA pair"
-  default     = ""                                      # not needed in single node case
+  default     = "" # not needed in single node case
 }
 
 variable "private_ip_address_hdb1" {
   description = "Private ip address of hdb1 in HA pair"
-  default     = ""                                      # not needed in single node case
+  default     = "" # not needed in single node case
 }
 
 variable "private_ip_address_lb_frontend" {
   description = "Private ip address of the load balancer front end in HA pair"
-  default     = ""                                                             # not needed in single node case
+  default     = "" # not needed in single node case
 }
 
 variable "pw_bastion_windows" {
@@ -61,7 +61,7 @@ variable "pw_db_system" {
 variable "pw_hacluster" {
   type        = "string"
   description = "Password for the HA cluster nodes"
-  default     = ""                                  #single node case doesn't need one
+  default     = "" #single node case doesn't need one
 }
 
 variable "pw_os_sapadm" {
@@ -179,6 +179,16 @@ variable "url_retries_cnt" {
 
 variable "url_retries_delay" {
   description = "The time between each attempt to download the installation bits from the URLs"
+  default     = 10
+}
+
+variable "package_retries_cnt" {
+  description = "The number of attempts to install packages"
+  default     = 10
+}
+
+variable "package_retries_delay" {
+  description = "The time between each attempt to install packages"
   default     = 10
 }
 

--- a/deploy/vm/modules/single_node_hana/single-node-hana.tf
+++ b/deploy/vm/modules/single_node_hana/single-node-hana.tf
@@ -106,7 +106,7 @@ resource "null_resource" "destroy-vm" {
                ANSIBLE_HOST_KEY_CHECKING="False" \
                ansible-playbook -u '${var.vm_user}' \
                --private-key '${var.sshkey_path_private}' \
-               --extra-vars="{az_resource_group: \"${module.common_setup.resource_group_name}\", az_vm_name: \"${local.linux_vm_name}\"}" ../../ansible/delete_bastion_linux.yml
+               --extra-vars="{az_resource_group: \"${module.common_setup.resource_group_name}\", az_vm_name: \"${local.linux_vm_name}\", linux_bastion: \"${var.linux_bastion}\"}" ../../ansible/delete_bastion_linux.yml
 EOT
 
   }


### PR DESCRIPTION
**Background:**
saplandscaperunner keeps failing for two major reasons:
- Install package intermittent fails for the first package being installed after VM created
- Resource creation/deletion fails when ansible is used to create/delete azure resources

**Fix includes:**
- Remove workaround for issue #220. 
  - By updating all supported image to SLES12 SP5, [SUSE bug](https://bugzilla.suse.com/show_bug.cgi?id=1150395) is away 
(fixed with `cloud-regionsrv-client 9.0.3` and now we always get `cloud-regionsrv-client 9.0.8`)
  - Workround for issue #220 has side effect that sometimes make the repo not available
- Add retry logic for the first (not all) package install
  - There is no easy way to add retry logic to all package installs
  - We only need to retry for the fist package since afterwards the first success installing package, the repo should be avaible for the following package installation
- Add logic to only remove `linux_bastion` VM if it is installed
  - There is a compatibility issue between `azure-cli` and `azure-cli-core` when installing them on the same machine ([link](https://github.com/ansible/ansible/pull/61238#issuecomment-527998744))
  - There is a bug in the current logic where we try to delete a linux bastion although it is not created - it worked with `azure-cli-core 2.0.35` which is questionable. However by adding azure-cli to the same docker image, `azure-cli-core` will be on a higher version (currently pin to `2.0.71` to resolve most of the compatibility issue), and hits the compatibility issue.
- Rename  [azure_rm_publicipaddress_facts](https://docs.ansible.com/ansible/latest/modules/azure_rm_publicipaddress_facts_module.html) to azure_rm_publicipaddress_info since azure_rm_publicipaddress_facts is outdated.