### PR TITLE
Staging PR: Adding Availability Set to HDB Node module

### DIFF
--- a/deploy/v2/terraform/modules/hdb_node/main.tf
+++ b/deploy/v2/terraform/modules/hdb_node/main.tf
@@ -133,11 +133,13 @@ resource "azurerm_lb_rule" "hana-lb-rules" {
 # AVAILABILITY SET ================================================================================================
 
 resource "azurerm_availability_set" "hana-as" {
-  for_each            = local.loadbalancers
-  name                = "${each.value.sid}-as"
-  location            = var.resource-group[0].location
-  resource_group_name = var.resource-group[0].name
-  managed             = true
+  for_each                     = local.loadbalancers
+  name                         = "${each.value.sid}-as"
+  location                     = var.resource-group[0].location
+  resource_group_name          = var.resource-group[0].name
+  platform_update_domain_count = 20
+  platform_fault_domain_count  = 2
+  managed                      = true
 }
 
 # VIRTUAL MACHINES ================================================================================================

--- a/deploy/v2/terraform/modules/hdb_node/main.tf
+++ b/deploy/v2/terraform/modules/hdb_node/main.tf
@@ -130,6 +130,16 @@ resource "azurerm_lb_rule" "hana-lb-rules" {
   probe_id                       = azurerm_lb_probe.hana-lb-health-probe[0].id
 }
 
+# AVAILABILITY SET ================================================================================================
+
+resource "azurerm_availability_set" "hana-as" {
+  for_each            = local.loadbalancers
+  name                = "${each.value.sid}-as"
+  location            = var.resource-group[0].location
+  resource_group_name = var.resource-group[0].name
+  managed             = true
+}
+
 # VIRTUAL MACHINES ================================================================================================
 
 # Creates database VM
@@ -138,6 +148,7 @@ resource "azurerm_virtual_machine" "vm-dbnode" {
   name                          = each.value.name
   location                      = var.resource-group[0].location
   resource_group_name           = var.resource-group[0].name
+  availability_set_id           = azurerm_availability_set.hana-as[0].id
   primary_network_interface_id  = azurerm_network_interface.nics-dbnodes-db[each.key].id
   network_interface_ids         = [azurerm_network_interface.nics-dbnodes-admin[each.key].id, azurerm_network_interface.nics-dbnodes-db[each.key].id]
   vm_size                       = lookup(local.sizes, each.value.size).compute.vm_size

--- a/deploy/v2/terraform/modules/hdb_node/outputs.tf
+++ b/deploy/v2/terraform/modules/hdb_node/outputs.tf
@@ -10,3 +10,7 @@ output "nics-dbnodes-db" {
 output "dbnodes" {
   value = azurerm_virtual_machine.vm-dbnode
 }
+
+output "loadbalancers" {
+  value = azurerm_lb.hana-lb
+}

--- a/deploy/v2/terraform/modules/hdb_node/variables.tf
+++ b/deploy/v2/terraform/modules/hdb_node/variables.tf
@@ -39,7 +39,70 @@ locals {
   sizes = jsondecode(file("${path.root}/../hdb_sizes.json"))
 }
 
-# List of HANA DB nodes to be created
 locals {
-  dbnodes = zipmap(range(length(flatten([for database in var.databases : [for dbnode in database.dbnodes : dbnode.name]]))), flatten([for database in var.databases : [for dbnode in database.dbnodes : { platform = database.platform, name = dbnode.name, admin_nic_ip = lookup(dbnode, "admin_nic_ip", false), db_nic_ip = lookup(dbnode, "db_nic_ip", false), size = database.size, os = database.os, authentication = database.authentication }]]))
+  # Numerically indexed Hash of HANA DB nodes to be created
+  dbnodes = zipmap(
+    range(
+      length(
+        flatten([
+          for database in var.databases : [
+            for dbnode in database.dbnodes : dbnode.name
+          ]
+          if database.platform == "HANA"
+        ])
+      )
+    ),
+    flatten([
+      for database in var.databases : [
+        for dbnode in database.dbnodes : {
+          platform       = database.platform,
+          name           = dbnode.name,
+          admin_nic_ip   = lookup(dbnode, "admin_nic_ip", false),
+          db_nic_ip      = lookup(dbnode, "db_nic_ip", false),
+          size           = database.size,
+          os             = database.os,
+          authentication = database.authentication
+          sid            = database.instance.sid
+        }
+      ]
+      if database.platform == "HANA"
+    ])
+  )
+
+  # Ports used for specific HANA Versions
+  lb_ports = {
+    "1" = [
+      "30015",
+      "30017",
+    ]
+
+    "2" = [
+      "30013",
+      "30015",
+      "30040",
+      "30041",
+      "30042",
+    ]
+  }
+
+  # Hash of Load Balancers to create for HANA instances
+  loadbalancers = zipmap(
+    range(
+      length([
+        for database in var.databases : database.instance.sid
+        if database.platform == "HANA"
+      ])
+    ),
+    [
+      for database in var.databases : {
+        sid             = database.instance.sid
+        instance_number = database.instance.instance_number
+        ports           = [
+          for port in local.lb_ports[split(".", database.db_version)[0]] : tonumber(port) + (tonumber(database.instance.instance_number) * 100)
+        ]
+        lb_fe_ip        = lookup(database, "lb_fe_ip", false),
+      }
+      if database.platform == "HANA"
+    ]
+  )
 }

--- a/util/terraform_v2.sh
+++ b/util/terraform_v2.sh
@@ -239,8 +239,7 @@ function check_json_template_exists()
 }
 
 
-
-# This functionn checks the auth script exists and loads it, otherwise it exits
+# This function checks the auth script exists and loads it, otherwise it exits
 # with an appropriate error
 function load_auth_script_credentials()
 {


### PR DESCRIPTION
This PR adds an availability set in, and associates any VMs deployed within the module with it.

Some observations I have about this code:

1. The source data used is the same `local.loadbalancers` hash created - should this be renamed? If so, to what?
1. As this is using the same dataset as the Load Balancer, it will have the same issue about future work with multiple nodes/databases.
1. The [comment added to the Load Balancer PR](https://github.com/Azure/sap-hana/pull/318/files#diff-07f5118af64e7689be637b6e2fa43b29R110-R112) suggests that there may be nodes added by this module which are not part of the backend pool/availability set
