### PR TITLE
Ability to script the resource group name (#358)

### DIFF
--- a/deploy/v2/USAGE.md
+++ b/deploy/v2/USAGE.md
@@ -154,6 +154,14 @@ Configuring your SAP Launchpad credentials for a JSON template requires you to p
 
    **Note:** The current templates are located in `deploy/v2/template_samples/` and you do not need to specify the `.json` extension.
 
+You can programatically set the deployment's resource group name in Azure using another utility script.  This needs to be done for each template you intend to deploy.
+
+1. Run the following utility script to configure your deployment resource group name:
+
+   ```text
+   util/set_resource_group.sh <resource_group_name> <template_name>
+   ```
+
 ## Build/Update/Destroy Lifecycle
 
 In the following steps you will need to substitute a `<template_name>` for the template. To see the currently available tempaltes, run:\

--- a/util/common_utils.sh
+++ b/util/common_utils.sh
@@ -10,6 +10,11 @@
 ###############################################################################
 
 
+readonly target_path="deploy/v2"
+# location of the input JSON templates
+readonly target_template_dir="${target_path}/template_samples"
+
+
 # Given a return/exit status code (numeric argument)
 #   and an error message (string argument)
 # This function returns immediately if the status code is zero.
@@ -21,6 +26,8 @@ function continue_or_error_and_exit()
 	local error_message="$2"
 
 	((status_code != 0)) && { error_and_exit "${error_message}"; }
+
+	return "${status_code}"
 }
 
 
@@ -52,4 +59,57 @@ function print_allowed_json_template_names()
 	# filter the output of 'find' to extract just the filenames without extensions
 	# prefix the results with indents and hyphen bullets
 	find "${target_dir}" -name '*.json' | sed -e 's/.*\/\(.*\)\.json/  - \1/'
+}
+
+
+# This function will check to see if the given command line tool is installed
+# If the command is not installed, then it will exit with an appropriate error and the given advice
+function check_command_installed()
+{
+	local cmd="$1"
+	local advice="$2"
+
+	# disable exit on error throughout this section as it's designed to fail
+	# when cmd is not installed
+	set +e
+	local is_cmd_installed
+	command -v "${cmd}" > /dev/null
+	is_cmd_installed=$?
+	set -e
+
+	local error="This script depends on the '${cmd}' command being installed"
+	# append advice if any was provided
+	if [[ "${advice}" != "" ]]; then
+		error="${error} (${advice})"
+	fi
+
+	continue_or_error_and_exit ${is_cmd_installed} "${error}"
+}
+
+
+# This function sets the JSON value at the given JSON path to the given value in the given JSON template file
+# Note: It uses the `jq` command line tool, and will fail with a helpful error if the tool is not installed.
+function edit_json_template_for_path()
+{
+	local json_path="$1"
+	local json_value="$2"
+	local json_template_name="$3"
+	local target_json="${target_template_dir}/${json_template_name}.json"
+	local temp_template_json="${target_json}.tmp"
+
+	check_file_exists "${target_json}"
+
+	check_command_installed 'jq' 'Try: https://stedolan.github.io/jq/download/'
+
+	# this is the JSON path in jq format
+	# in the future we could call a function here to translate simple dot-based paths into jq format paths
+	# For example: Translate 'infrastructure.resource_group.name' to '"infrastructure", "resource_group", "name"'
+	local jq_json_path="${json_path}"
+	local jq_command="jq --arg value ${json_value} 'setpath([${jq_json_path}]; \$value)' ${target_json}"
+
+	# edit JSON template file contents and write to temp file
+	eval "${jq_command}" > "${temp_template_json}"
+
+	# replace original JSON template file with temporary edited one
+	mv "${temp_template_json}" "${target_json}"
 }

--- a/util/set_resource_group.sh
+++ b/util/set_resource_group.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+###############################################################################
+#
+# Purpose:
+# This script simplifies the user interaction with the JSON input templates so
+# the user does not need to manually edit JSON files when configuring their SAP
+# Launchpad access credentials for downloading SAP install media.
+#
+###############################################################################
+
+# exit immediately if a command fails
+set -o errexit
+
+# exit immediately if an unset variable is used
+set -o nounset
+
+# import common functions that are reused across scripts
+source util/common_utils.sh
+
+
+function main()
+{
+	check_command_line_arguments "$@"
+
+	local resource_group="$1"
+	local template_name="$2"
+
+	edit_json_template_for_resource_group "${resource_group}" "${template_name}"
+}
+
+
+function check_command_line_arguments()
+{
+	local args_count=$#
+
+	# Check there're just two arguments provided
+	if [[ ${args_count} -ne 2 ]]; then
+		echo "Available Templates:"
+		list_available_templates
+		error_and_exit "You must specify 2 command line arguments for the resource group: a resource group name, and the template name"
+	fi
+}
+
+
+function list_available_templates()
+{
+	print_allowed_json_template_names "${target_template_dir}"
+}
+
+
+function edit_json_template_for_resource_group()
+{
+	local rg_name="$1"
+	local json_template_name="$2"
+
+	# this is the JSON path in jq format
+	local rg_name_json_path='"infrastructure", "resource_group", "name"'
+
+	# Only attempt to set for non-empty resource groups
+	if [[ "${rg_name}" != "" ]]; then
+		edit_json_template_for_path "${rg_name_json_path}" "${rg_name}" "${json_template_name}"
+	else
+		error_and_exit "The resource group name cannot be empty"
+	fi
+}
+
+
+# Execute the main program flow with all arguments
+main "$@"

--- a/util/set_sap_download_credentials.sh
+++ b/util/set_sap_download_credentials.sh
@@ -19,12 +19,6 @@ set -o nounset
 source util/common_utils.sh
 
 
-# location of the input JSON template
-readonly target_path="deploy/v2"
-# readonly target_code="${target_path}/terraform/"
-readonly target_template_dir="${target_path}/template_samples"
-
-
 function main()
 {
 	check_command_line_arguments "$@"
@@ -60,22 +54,21 @@ function edit_json_template_for_sap_credentials()
 {
 	local sap_username="$1"
 	local sap_password="$2"
-	local template_name="$3"
+	local json_template_name="$3"
 
-	# use temp file method to avoid BSD sed issues on Mac/OSX
-	# See: https://stackoverflow.com/questions/5694228/sed-in-place-flag-that-works-both-on-mac-bsd-and-linux/5694430#5694430
-	local target_json="${target_template_dir}/${template_name}.json"
-	local temp_template_json="${target_json}.tmp"
+	# these are the JSON path in jq format
+	local sap_username_json_path='"software", "downloader", "credentials", "sap_user"'
+	local sap_password_json_path='"software", "downloader", "credentials", "sap_password"'
 
-	check_file_exists "${target_json}"
+	# Only attempt to set for non-empty usernames
+	if [[ "${sap_username}" != "" ]]; then
+		edit_json_template_for_path "${sap_username_json_path}" "${sap_username}" "${json_template_name}"
+	fi
 
-	# filter JSON template file contents and write to temp file
-	sed -e "s/\(.*\"sap_user\": \)\".*\(\"\)/\1\2${sap_username}\"/" \
-		-e "s/\(.*\"sap_password\": \)\".*\(\"\)/\1\2${sap_password}\"/" \
-		"${target_json}" > "${temp_template_json}"
-
-    # replace original JSON template file with temporary filtered one
-    mv "${temp_template_json}" "${target_json}"
+	# Only attempt to set for non-empty passwords
+	if [[ "${sap_password}" != "" ]]; then
+		edit_json_template_for_path "${sap_password_json_path}" "${sap_password}" "${json_template_name}"
+	fi
 }
 
 

--- a/util/terraform_v2.sh
+++ b/util/terraform_v2.sh
@@ -24,14 +24,12 @@ source util/common_utils.sh
 readonly auth_script='set-sp.sh'
 
 readonly input_file_term='<JSON template name>'
-readonly target_path="deploy/v2"
+
 readonly target_code="${target_path}/terraform/"
-readonly target_template_dir="${target_path}/template_samples"
 
 
 function main()
 {
-
 	# default to empty string when 0 args supplied
 	local terraform_action=''
 	[ $# -eq 0 ] || terraform_action="$1"


### PR DESCRIPTION
## Problem

Initial phase of solving #348 

## Description

This PR adds a new util script for V2 that can be used to programatically set the resource group in an input JSON template. This PR also refactors some existing scripts to extract and share the same underlying ability to set the value of a key-value pair in a given JSON template file, which opens some doors for more repeatable/scriptable testing across Engineers working with the codebase.

**Note:** Due to the way that `jq` works and how its being wrapped in bash, there is a minor change to previously documented behaviour in that the user can no longer pass in empty strings as input values, or rather, empty strings are ignored. This may change in the future, but it's a simple solution to handling an issue where passing in an empty string can empty the entire JSON template file.

## Pre-Requisites

1. `shellcheck` installed on the workstation you're testing from
1. `jq` installed on the workstation you're testing from

## Test Instructions

### Standards Testing

- Shellcheck review the scripts by running `shellcheck util/*.sh` (no results should be shown and there should be a zero exit status from `echo $?` when run after shellcheck)

### Feature Tests

```text
# Scenario 1
# Running the script with no args...
util/set_resource_group.sh

# ... provides the following usage info and an error:
# Available Templates:
#   - rti_only
#   - single_node_hana
#   - clustered_hana
# ERROR: You must specify 2 command line arguments for the resource group: a resource group name, and the template name


# Scenario 2
# Running the script with incorrect args...
util/set_resource_group.sh "my-rg"

# ... provides the following usage info and an error:
# Available Templates:
#   - rti_only
#   - single_node_hana
#   - clustered_hana
# ERROR: You must specify 2 command line arguments for the resource group: a resource group name, and the template name


# Scenario 3
# Attempting to set no resource group in a template and looking for changes...
util/set_resource_group.sh "" single_node_hana

# ... provides the following error:
# ERROR: The resource group name cannot be empty

git diff

# ... and shows nothing has changed


# Scenario 4
# Attempting to set the resource group in a template and looking for changes...
util/set_resource_group.sh "my-rg" single_node_hana
git diff

# ... shows the deploy/v2/template_samples/single_node_hana.json file has changed...
# --- a/deploy/v2/template_samples/single_node_hana.json
# +++ b/deploy/v2/template_samples/single_node_hana.json

# ... and the resource group is now set correctly
# -      "name": "test-rg"
# +      "name": "my-rg"

# Scenario 5
# Attempting to set the resource group when jq is not installed...
# This can be faked by temporarily moving the binary: sudo mv $(command -v jq) $(command -v jq).old 
util/set_resource_group.sh "my-rg" single_node_hana

# ... provides the following error:
# ERROR: This script depends on the 'jq' command being installed (Try: https://stedolan.github.io/jq/download/)

# Make sure to restore afterwards with: sudo mv $(command -v jq.old) $(command -v jq)
```

### Regression Tests

For the SAP Download Credentials Utility Script...

```text
# Scenario 1
# Running the script with no args...
util/set_sap_download_credentials.sh

# ... provides the following usage info and an error (note RTI_only is filtered out):
# Available Templates:
#   - single_node_hana
#   - clustered_hana
# ERROR: You must specify 3 command line arguments for the SAP download credentials: a username, a password, and the template name


# Scenario 2
# Running the script with incorrect args...
util/set_sap_download_credentials.sh "rti"

# ... provides the following usage info and an error (note RTI_only is filtered out):
# Available Templates:
#   - single_node_hana
#   - clustered_hana
# ERROR: You must specify 3 command line arguments for the SAP download credentials: a username, a password, and the template name


# Scenario 3
# Attempting to set the crednetials in a template and looking for changes...
util/set_sap_download_credentials.sh "test_user" "test_pass" single_node_hana
git diff

# ... shows the deploy/v2/template_samples/single_node_hana.json file has changed...
# --- a/deploy/v2/template_samples/single_node_hana.json
# +++ b/deploy/v2/template_samples/single_node_hana.json

# ... and the credentials are now set correctly
# -        "sap_user": "",
# -        "sap_password": ""
# +        "sap_user": "test_user",
# +        "sap_password": "test_pass"


# Scenario 4
# Attempting to set no credentials in a template and looking for changes...
util/set_sap_download_credentials.sh "" "" single_node_hana
git diff

# ... and shows nothing has changed (since scenario 3)
# --- a/deploy/v2/template_samples/single_node_hana.json
# +++ b/deploy/v2/template_samples/single_node_hana.json

# ... and the credentials are still set (as in scenario 3)
# -        "sap_user": "",
# -        "sap_password": ""
# +        "sap_user": "test_user",
# +        "sap_password": "test_pass"


# Scenario 5
# Attempting to set the credentials when jq is not installed...
# This can be faked by temporarily moving the binary: sudo mv $(command -v jq) $(command -v jq).old 
util/set_sap_download_credentials.sh "test_user" "test_pass" single_node_hana

# ... provides the following error:
# ERROR: This script depends on the 'jq' command being installed (Try: https://stedolan.github.io/jq/download/)

# Make sure to restore afterwards with: sudo mv $(command -v jq.old) $(command -v jq)
```

## Acceptance Criteria

**Note:** The following acceptance testing has been completed in preparation of this PR. See https://github.com/Centiq/sap-hana/pull/13

### Standards

- [x] Shellcheck tests pass

### Features

- [x] Scenario 1 passes
- [x] Scenario 2 passes
- [x] Scenario 3 passes
- [x] Scenario 4 passes
- [x] Scenario 5 passes

### Regression

- [x] Scenario 1 passes
- [x] Scenario 2 passes
- [x] Scenario 3 passes
- [x] Scenario 4 passes
- [x] Scenario 5 passes
