### PR TITLE
Enable Static IPs for HA deploments

### DIFF
--- a/deploy/v2/input.json
+++ b/deploy/v2/input.json
@@ -159,8 +159,8 @@
       "dbnodes": [
         {
           "name": "",
-          "admin_nic_ip": "",
-          "db_nic_ip": "",
+          "admin_nic_ips": [],
+          "db_nic_ips": [],
           "role": ""
         }
       ]

--- a/deploy/v2/terraform/modules/hdb_node/variables_local.tf
+++ b/deploy/v2/terraform/modules/hdb_node/variables_local.tf
@@ -41,8 +41,8 @@ locals {
         for dbnode in database.dbnodes : {
           platform       = database.platform,
           name           = "${dbnode.name}-0",
-          admin_nic_ip   = length(lookup(dbnode, "admin_nic_ips", [])) >= 1 ? lookup(dbnode, "admin_nic_ips", [])[0] : false,
-          db_nic_ip      = length(lookup(dbnode, "db_nic_ips", [])) >= 1 ? lookup(dbnode, "db_nic_ips", [])[0] : false,
+          admin_nic_ip   = lookup(dbnode, "admin_nic_ips", [false, false])[0],
+          db_nic_ip      = lookup(dbnode, "db_nic_ips", [false, false])[0],
           size           = database.size,
           os             = database.os,
           authentication = database.authentication
@@ -55,8 +55,8 @@ locals {
         for dbnode in database.dbnodes : {
           platform       = database.platform,
           name           = "${dbnode.name}-1",
-          admin_nic_ip   = length(lookup(dbnode, "admin_nic_ips", [])) >= 2 ? lookup(dbnode, "admin_nic_ips", [])[1] : false,
-          db_nic_ip      = length(lookup(dbnode, "db_nic_ips", [])) >= 2 ? lookup(dbnode, "db_nic_ips", [])[1] : false,
+          admin_nic_ip   = lookup(dbnode, "admin_nic_ips", [false, false])[1],
+          db_nic_ip      = lookup(dbnode, "db_nic_ips", [false, false])[1],
           size           = database.size,
           os             = database.os,
           authentication = database.authentication

--- a/deploy/v2/terraform/modules/hdb_node/variables_local.tf
+++ b/deploy/v2/terraform/modules/hdb_node/variables_local.tf
@@ -41,8 +41,8 @@ locals {
         for dbnode in database.dbnodes : {
           platform       = database.platform,
           name           = "${dbnode.name}-0",
-          admin_nic_ip   = lookup(dbnode, "admin_nic_ip", false),
-          db_nic_ip      = lookup(dbnode, "db_nic_ip", false),
+          admin_nic_ip   = length(lookup(dbnode, "admin_nic_ips", [])) >= 1 ? lookup(dbnode, "admin_nic_ips", [])[0] : false,
+          db_nic_ip      = length(lookup(dbnode, "db_nic_ips", [])) >= 1 ? lookup(dbnode, "db_nic_ips", [])[0] : false,
           size           = database.size,
           os             = database.os,
           authentication = database.authentication
@@ -55,8 +55,8 @@ locals {
         for dbnode in database.dbnodes : {
           platform       = database.platform,
           name           = "${dbnode.name}-1",
-          admin_nic_ip   = lookup(dbnode, "admin_nic_ip", false),
-          db_nic_ip      = lookup(dbnode, "db_nic_ip", false),
+          admin_nic_ip   = length(lookup(dbnode, "admin_nic_ips", [])) >= 2 ? lookup(dbnode, "admin_nic_ips", [])[1] : false,
+          db_nic_ip      = length(lookup(dbnode, "db_nic_ips", [])) >= 2 ? lookup(dbnode, "db_nic_ips", [])[1] : false,
           size           = database.size,
           os             = database.os,
           authentication = database.authentication


### PR DESCRIPTION
## Problem

Issue #356 describes a bug created in #345 where the static IP assignments would cause an issue when a clustered HA system is deployed.  The IP would be given to both HA nodes generated based off of the `database.dbnodes` list.

## Description

This PR fixes #356 by updating the `input.json` to provide a list of IPs for the `admin_nic_ips` and `db_nic_ips`.  The local variable `dbnodes` computation checks for the existence of a list by these keys, and for non-HA nodes (`-0`) assigns the `admin_nic_ip` or `db_nic_ip` the first entry if it is present. If it is not present, `false` is provided and the existing behaviour in the `hdb_node/main.tf` module for assigning an IP works as before.

For HA nodes (`-1`) the second IP is used if it is present.

## Test Instructions/Acceptance Criteria

Note: Centiq have tested this PR [on the fork here](https://github.com/Centiq/sap-hana/pull/16).

1. Review the change to the [blank `input.json` template](https://github.com/Centiq/sap-hana/pull/16/files#diff-8dfe51c2bf2c1da29f7ec0982ed22827R162-R163)
   - [x] Key names and default values updated
1. Review the [not-necessarily HA changes](https://github.com/Centiq/sap-hana/pull/16/files#diff-681009318dcfcd7367ecd293fb4002fcR44-R45)
   - [x] First value is used if provided
   - [x] `false` is used if no values available
   - [x] Key name on the resulting object is singular and matches existing code
1. Review the [HA changes](https://github.com/Centiq/sap-hana/pull/16/files#diff-681009318dcfcd7367ecd293fb4002fcR58-R59)
   - [x] Second value is used if provided
   - [x] `false` is used if one or no values available
   - [x] Key name on the resulting object is singular and matches existing code
1. Check existing sequential IP address allocation has not been changed, run the Terraform plan command, selecting the IP allocations:\
   `util/terraform_v2.sh plan clustered_hana | grep -A 24 resource.*nics-dbnodes |grep -A3 -- -nic-ip`
   - [x] The `hdb1-0-admin-nic-ip` IP is `10.1.1.4`
   - [x] The `hdb1-1-admin-nic-ip` IP is `10.1.1.5`
   - [x] The `hdb1-0-db-nic-ip` IP  is `10.1.2.4`
   - [x] The `hdb1-1-db-nic-ip` IP is `10.1.2.5`
1. Update `dbnodes` entry in the `deploy/v2/template_samples/clustered_hana.json` template to contain some IPs:
   ```
         "dbnodes": [
           {
             "name": "hdb1",
             "role": "worker",
             "admin_nic_ips": [
               "10.1.1.20",
               "10.1.1.30"
             ],
             "db_nic_ips": [
               "10.1.2.40",
               "10.1.2.50"
             ]
           }
         ]
   ```
1. Run the Terraform plan command, selecting the IP allocations:\
   `util/terraform_v2.sh plan clustered_hana | grep -A 24 resource.*nics-dbnodes |grep -A3 -- -nic-ip`
   - [x] The `hdb1-0-admin-nic-ip` IP matches the first IP in the `admin_nic_ips` list
   - [x] The `hdb1-1-admin-nic-ip` IP matches the second IP in the `admin_nic_ips` list
   - [x] The `hdb1-0-db-nic-ip` IP matches the first IP in the `db_nic_ips` list
   - [x] The `hdb1-1-db-nic-ip` IP matches the second IP in the `db_nic_ips` list

## Notes

I have checked the generated inventory on the RTI instance and it contains the provided IPs.

I have assumed that if someone is providing any IPs for their VMs, that they will be providing all of them.  There is presently no checking that the IPs provided are within the scope of the subnets provided.