### PR TITLE
Fixes #348 by allowing RG names to be set via env var for util scripts

### DIFF
--- a/deploy/v2/USAGE.md
+++ b/deploy/v2/USAGE.md
@@ -162,6 +162,15 @@ You can programatically set the deployment's resource group name in Azure using 
    util/set_resource_group.sh <resource_group_name> <template_name>
    ```
 
+   **Note:** You can avoid this step by setting the environment variable `SAP_HANA_RESOURCE_GROUP` to your desired resource group name.
+   This can be done in any of the standard ways, such as:
+
+     - Setting in your current terminal session (e.g. `export SAP_HANA_RESOURCE_GROUP="rg-sap-hana-dev"`)
+     - Setting as a prefix of your script command (e.g. `SAP_HANA_RESOURCE_GROUP="rg-sap-hana-dev" util/terraform_v2.sh plan single_node_hana`)
+     - Setting in your dot files (e.g. in `.bash_profile`)
+
+   In any case, this opens up scope for programatically setting the HANA deployment resource group using something personal to your user (e.g. $USER variable), which helps to avoid clashes with others that might be sharing the same Azure subscription.
+
 ## Build/Update/Destroy Lifecycle
 
 In the following steps you will need to substitute a `<template_name>` for the template. To see the currently available tempaltes, run:\

--- a/util/terraform_v2.sh
+++ b/util/terraform_v2.sh
@@ -34,26 +34,13 @@ function main()
 	local terraform_action=''
 	[ $# -eq 0 ] || terraform_action="$1"
 
-	# default to empty string when 1 or less args supplied
-	local template_name=''
-	[ $# -le 1 ] || template_name="$2"
-
 	# dispatch appropriate command
 	case "${terraform_action}" in
 		'init')
 			terraform_init
 			;;
-		'plan')
-			check_command_line_arguments_for_template "$@"
-			terraform_plan "${template_name}"
-			;;
-		'apply')
-			check_command_line_arguments_for_template "$@"
-			terraform_apply "${template_name}"
-			;;
-		'destroy')
-			check_command_line_arguments_for_template "$@"
-			terraform_destroy "${template_name}"
+		'plan'|'apply'|'destroy')
+			dispatch_terraform_template_action "$@"
 			;;
 		'clean')
 			terraform_clean
@@ -62,6 +49,49 @@ function main()
 			print_usage_info_and_exit
 			;;
 	esac
+}
+
+
+function dispatch_terraform_template_action()
+{
+	# default to empty string when 0 args supplied
+	local terraform_action=''
+	[ $# -eq 0 ] || terraform_action="$1"
+
+	# default to empty string when 1 or less args supplied
+	local template_name=''
+	[ $# -le 1 ] || template_name="$2"
+
+	check_command_line_arguments_for_template "$@"
+
+	configure_resource_group_for_template "${template_name}"
+
+	case "${terraform_action}" in
+		'plan')
+			terraform_plan "${template_name}"
+			;;
+		'apply')
+			terraform_apply "${template_name}"
+			;;
+		'destroy')
+			terraform_destroy "${template_name}"
+			;;
+	esac
+}
+
+
+# This function sets the given template's resource group name from an environment variable
+# If the environment variable is empty/undefined, then it leaves the resource group name unchanged
+function configure_resource_group_for_template()
+{
+	local template_name="$1"
+
+	# default environment variable to empty string if not set
+	local rg_name_from_env="${SAP_HANA_RESOURCE_GROUP-}"
+
+	if [[ "${rg_name_from_env}" != "" ]]; then
+		util/set_resource_group.sh "${rg_name_from_env}" "${template_name}"
+	fi
 }
 
 

--- a/util/terraform_v2.sh
+++ b/util/terraform_v2.sh
@@ -91,6 +91,11 @@ function configure_resource_group_for_template()
 
 	if [[ "${rg_name_from_env}" != "" ]]; then
 		util/set_resource_group.sh "${rg_name_from_env}" "${template_name}"
+
+		echo "********************************************************************************"
+		echo "The resource group in ${template_name} has been set to '${rg_name_from_env}'"
+		echo "This is based on the content of the environment variable SAP_HANA_RESOURCE_GROUP"
+		echo "********************************************************************************"
 	fi
 }
 


### PR DESCRIPTION
## Problem

See #348

## Description

This PR allows the util scripts to automatically set the input JSON's resource group name to the value set in the environment variable `SAP_HANA_RESOURCE_GROUP`.

## Pre-Requisites

`jq` installed

## Test Instructions

1. Start with a clean PR branch checkout, and test with `git status` showing no changes.
1. Unset any potential previous env var `unset SAP_HANA_RESOURCE_GROUP`
1. Run `util/terraform_v2.sh plan rti_only`
1. Check the RTI template hasn't changed with `git diff deploy/v2/template_samples/rti_only.json` (AC1)
1. Run `SAP_HANA_RESOURCE_GROUP="rg-rti-only" util/terraform_v2.sh plan rti_only`
1. Check the RTI template has changed as expected with `git diff deploy/v2/template_samples/rti_only.json` (AC2)

## Acceptance Criteria

Note: The following acceptance testing has been completed in preparation of this PR. See https://github.com/Centiq/sap-hana/pull/17

- [x] AC1: Resourse group name not set in the template if the env var is not set
- [x] AC2: Resource group name is set in the template if the env var is set
