### PR TITLE
Updating comments of set_resource_group.sh

### DIFF
--- a/util/set_resource_group.sh
+++ b/util/set_resource_group.sh
@@ -3,9 +3,11 @@
 ###############################################################################
 #
 # Purpose:
-# This script simplifies the user interaction with the JSON input templates so
-# the user does not need to manually edit JSON files when configuring their SAP
-# Launchpad access credentials for downloading SAP install media.
+# This script is for configuring deployment resource group name which helps 
+# to avoid clashes with others that might be sharing the same Azure subscription.
+# It also simplifies the user interaction with the JSON input templates so
+# the user does not need to manually edit JSON files when configuring their 
+# resource group.
 #
 ###############################################################################
 


### PR DESCRIPTION
Old comment belongs to set_sap_download_credentials.sh, correcting it by explaining the purpose of setting resource group.