### PR TITLE
[HOTFIX] Fix test case name in pipeline cleanup job

### DIFF
--- a/azure-pipelines-v2-daily.yaml
+++ b/azure-pipelines-v2-daily.yaml
@@ -86,10 +86,11 @@ stages:
             RHEL7
           )
           scenario_list=(
-            v2-allNew
-            v2-reuseRG
-            v2-reuseVNET
-            v2-reuseNSG
+            v2-allNew-SN
+            v2-allNew-HA
+            v2-reuseRG-SN
+            v2-reuseVNET-SN
+            v2-reuseNSG-SN
           )
           for scenario in "${scenario_list[@]}"
           do

--- a/azure-pipelines-v2.yaml
+++ b/azure-pipelines-v2.yaml
@@ -80,10 +80,11 @@ stages:
             RHEL7
           )
           scenario_list=(
-            v2-allNew
-            v2-reuseRG
-            v2-reuseVNET
-            v2-reuseNSG
+            v2-allNew-SN
+            v2-allNew-HA
+            v2-reuseRG-SN
+            v2-reuseVNET-SN
+            v2-reuseNSG-SN
           )
           for scenario in "${scenario_list[@]}"
           do


### PR DESCRIPTION
### Symptons:
Quota in azure pipeline has been used up.

### Rootcause:
Cleanup job does not function properly since case name was not extended after #370 .

### Impact:
All PR can't be tested.

### Fix:
Extend the case name properly.
