### PR TITLE
[DRAFT] Ensure correct hostnames are set on HANA VMs

### DIFF
--- a/deploy/v2/ansible/roles/hdb-server-install/tasks/hana_server_installation.yml
+++ b/deploy/v2/ansible/roles/hdb-server-install/tasks/hana_server_installation.yml
@@ -1,0 +1,27 @@
+---
+
+- name: Create HANA components list from output JSON
+  set_fact:
+    hdb_comp_list: "{{ hdb_comp_list + [ item.key ] }}"
+  loop: "{{ hana_database.components|dict2items }}"
+
+- name: Merge HANA Components list with its depends on components
+  set_fact:
+    hdb_comp_list: "{{  [ item.depends_on ] + hdb_comp_list }}"
+  loop: "{{ components }}"
+  when: 
+    - item.component in hdb_comp_list
+    - item.depends_on is defined
+
+- name: Create unique list of HANA Components
+  set_fact:
+    hdb_comp_list: "{{ hdb_comp_list|flatten(levels=1)|unique }}"
+
+# Install HANA Components
+- name: Install HANA Components
+  include_role:
+    name: components-install
+    tasks_from: "{{ component }}.yml"
+  loop: "{{ hdb_comp_list }}"
+  loop_control:
+    loop_var: component

--- a/deploy/v2/ansible/roles/hdb-server-install/tasks/main.yml
+++ b/deploy/v2/ansible/roles/hdb-server-install/tasks/main.yml
@@ -1,27 +1,4 @@
 ---
 
-- name: Create HANA components list from output JSON
-  set_fact:
-    hdb_comp_list: "{{ hdb_comp_list + [ item.key ] }}"
-  loop: "{{ hana_database.components|dict2items }}"
-
-- name: Merge HANA Components list with its depends on components
-  set_fact:
-    hdb_comp_list: "{{  [ item.depends_on ] + hdb_comp_list }}"
-  loop: "{{ components }}"
-  when: 
-    - item.component in hdb_comp_list
-    - item.depends_on is defined
-
-- name: Create unique list of HANA Components
-  set_fact:
-    hdb_comp_list: "{{ hdb_comp_list|flatten(levels=1)|unique }}"
-
-# Install HANA Components
-- name: Install HANA Components
-  include_role:
-    name: components-install
-    tasks_from: "{{ component }}.yml"
-  loop: "{{ hdb_comp_list }}"
-  loop_control:
-    loop_var: component
+- import_tasks: pre_checks.yml
+- import_tasks: hana_server_installation.yml

--- a/deploy/v2/ansible/roles/hdb-server-install/tasks/pre_checks.yml
+++ b/deploy/v2/ansible/roles/hdb-server-install/tasks/pre_checks.yml
@@ -17,4 +17,3 @@
     name: "{{ item.dbname }}"
   when: item.ip_admin_nic == ansible_default_ipv4.address
   loop: "{{ hana_database.nodes }}"
-  

--- a/deploy/v2/ansible/roles/hdb-server-install/tasks/pre_checks.yml
+++ b/deploy/v2/ansible/roles/hdb-server-install/tasks/pre_checks.yml
@@ -1,0 +1,10 @@
+---
+
+# This is workaround for https://github.com/Azure/WALinuxAgent/pull/1832
+- name: Ensure the correct hostname are set on HANA VMs
+  become: true
+  become_user: root
+  hostname:
+    name: "{{ item.dbname }}"
+  when: item.ip_admin_nic == ansible_default_ipv4.address
+  loop: "{{ hana_database.nodes }}"

--- a/deploy/v2/ansible/roles/hdb-server-install/tasks/pre_checks.yml
+++ b/deploy/v2/ansible/roles/hdb-server-install/tasks/pre_checks.yml
@@ -17,3 +17,4 @@
     name: "{{ item.dbname }}"
   when: item.ip_admin_nic == ansible_default_ipv4.address
   loop: "{{ hana_database.nodes }}"
+  

--- a/deploy/v2/ansible/roles/hdb-server-install/tasks/pre_checks.yml
+++ b/deploy/v2/ansible/roles/hdb-server-install/tasks/pre_checks.yml
@@ -2,7 +2,7 @@
 
 - name: Ensure correct hostname are set and not changed for SLES
   when:
-    - "{{ ansible_os_family|upper }}" == 'SUSE'
+    - ansible_os_family|upper == 'SUSE'
   block:
 
   #SUSE bug 1167134

--- a/deploy/v2/ansible/roles/hdb-server-install/tasks/pre_checks.yml
+++ b/deploy/v2/ansible/roles/hdb-server-install/tasks/pre_checks.yml
@@ -2,7 +2,7 @@
 
 - name: Ensure correct hostname are set and not changed for SLES
   when:
-    - ansible_facts['distribution_file_variety'] == 'SUSE'
+    - ansible_os_family == 'Suse'
   block:
 
   #SUSE bug 1167134

--- a/deploy/v2/ansible/roles/hdb-server-install/tasks/pre_checks.yml
+++ b/deploy/v2/ansible/roles/hdb-server-install/tasks/pre_checks.yml
@@ -1,19 +1,24 @@
 ---
 
-#SUSE bug 1167134
-- name: Ensure DHCLIENT_SET_HOSTNAME is set to no
-  become: true
-  become_user: root
-  lineinfile:
-    path: /etc/sysconfig/network/dhcp
-    regexp: '^DHCLIENT_SET_HOSTNAME='
-    line: DHCLIENT_SET_HOSTNAME="no"
+- name: Ensure correct hostname are set and not changed for SLES
+  when:
+    - ansible_facts['distribution_file_variety'] == 'SUSE'
+  block:
 
-# This is workaround for https://github.com/Azure/WALinuxAgent/pull/1832
-- name: Ensure the correct hostname are set on HANA VMs
-  become: true
-  become_user: root
-  hostname:
-    name: "{{ item.dbname }}"
-  when: item.ip_admin_nic == ansible_default_ipv4.address
-  loop: "{{ hana_database.nodes }}"
+  #SUSE bug 1167134
+  - name: Ensure DHCLIENT_SET_HOSTNAME is set to no
+    become: true
+    become_user: root
+    lineinfile:
+      path: /etc/sysconfig/network/dhcp
+      regexp: '^DHCLIENT_SET_HOSTNAME='
+      line: DHCLIENT_SET_HOSTNAME="no"
+
+  # This is workaround for https://github.com/Azure/WALinuxAgent/pull/1832
+  - name: Ensure the correct hostname are set on HANA VMs
+    become: true
+    become_user: root
+    hostname:
+      name: "{{ item.dbname }}"
+    when: item.ip_admin_nic == ansible_default_ipv4.address
+    loop: "{{ hana_database.nodes }}"

--- a/deploy/v2/ansible/roles/hdb-server-install/tasks/pre_checks.yml
+++ b/deploy/v2/ansible/roles/hdb-server-install/tasks/pre_checks.yml
@@ -2,7 +2,7 @@
 
 - name: Ensure correct hostname are set and not changed for SLES
   when:
-    - ansible_os_family == 'Suse'
+    - "{{ ansible_os_family|upper }}" == 'SUSE'
   block:
 
   #SUSE bug 1167134

--- a/deploy/v2/ansible/roles/hdb-server-install/tasks/pre_checks.yml
+++ b/deploy/v2/ansible/roles/hdb-server-install/tasks/pre_checks.yml
@@ -1,5 +1,14 @@
 ---
 
+#SUSE bug 1167134
+- name: Ensure DHCLIENT_SET_HOSTNAME is set to no
+  become: true
+  become_user: root
+  lineinfile:
+    path: /etc/sysconfig/network/dhcp
+    regexp: '^DHCLIENT_SET_HOSTNAME='
+    line: DHCLIENT_SET_HOSTNAME="no"
+
 # This is workaround for https://github.com/Azure/WALinuxAgent/pull/1832
 - name: Ensure the correct hostname are set on HANA VMs
   become: true


### PR DESCRIPTION
Sporadically, hostname of HANA VMs are not set properly due to some issues with SLES image.
Therefore implement pre-check task to make sure the hostname is setup properly and will remain the same.