### PR TITLE
Ensure correct hostnames are set on HANA VMs

### DIFF
--- a/deploy/v2/ansible/roles/hdb-server-install/tasks/hana_server_installation.yml
+++ b/deploy/v2/ansible/roles/hdb-server-install/tasks/hana_server_installation.yml
@@ -1,0 +1,27 @@
+---
+
+- name: Create HANA components list from output JSON
+  set_fact:
+    hdb_comp_list: "{{ hdb_comp_list + [ item.key ] }}"
+  loop: "{{ hana_database.components|dict2items }}"
+
+- name: Merge HANA Components list with its depends on components
+  set_fact:
+    hdb_comp_list: "{{  [ item.depends_on ] + hdb_comp_list }}"
+  loop: "{{ components }}"
+  when: 
+    - item.component in hdb_comp_list
+    - item.depends_on is defined
+
+- name: Create unique list of HANA Components
+  set_fact:
+    hdb_comp_list: "{{ hdb_comp_list|flatten(levels=1)|unique }}"
+
+# Install HANA Components
+- name: Install HANA Components
+  include_role:
+    name: components-install
+    tasks_from: "{{ component }}.yml"
+  loop: "{{ hdb_comp_list }}"
+  loop_control:
+    loop_var: component

--- a/deploy/v2/ansible/roles/hdb-server-install/tasks/hana_server_installation.yml
+++ b/deploy/v2/ansible/roles/hdb-server-install/tasks/hana_server_installation.yml
@@ -5,20 +5,20 @@
     hdb_comp_list: "{{ hdb_comp_list + [ item.key ] }}"
   loop: "{{ hana_database.components|dict2items }}"
 
-- name: Merge HANA Components list with its depends on components
+- name: Merge HANA components list with its depends on components
   set_fact:
-    hdb_comp_list: "{{  [ item.depends_on ] + hdb_comp_list }}"
+    hdb_comp_list: "{{ [ item.depends_on ] + hdb_comp_list }}"
   loop: "{{ components }}"
   when: 
     - item.component in hdb_comp_list
     - item.depends_on is defined
 
-- name: Create unique list of HANA Components
+- name: Create unique list of HANA components
   set_fact:
     hdb_comp_list: "{{ hdb_comp_list|flatten(levels=1)|unique }}"
 
 # Install HANA Components
-- name: Install HANA Components
+- name: Install HANA components
   include_role:
     name: components-install
     tasks_from: "{{ component }}.yml"

--- a/deploy/v2/ansible/roles/hdb-server-install/tasks/hdb_pre_checks.yml
+++ b/deploy/v2/ansible/roles/hdb-server-install/tasks/hdb_pre_checks.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Ensure correct hostname are set and not changed for SLES
+- name: Ensure correct hostnames are set and not changed for SLES
   become: true
   become_user: root
   when:
@@ -15,7 +15,7 @@
       line: DHCLIENT_SET_HOSTNAME="no"
 
   # This is workaround for https://github.com/Azure/WALinuxAgent/pull/1832
-  - name: Ensure the correct hostname are set on HANA VMs
+  - name: Ensure the correct hostnames are set on HANA VMs
     hostname:
       name: "{{ item.dbname }}"
     when: item.ip_admin_nic == ansible_default_ipv4.address

--- a/deploy/v2/ansible/roles/hdb-server-install/tasks/main.yml
+++ b/deploy/v2/ansible/roles/hdb-server-install/tasks/main.yml
@@ -1,27 +1,4 @@
 ---
 
-- name: Create HANA components list from output JSON
-  set_fact:
-    hdb_comp_list: "{{ hdb_comp_list + [ item.key ] }}"
-  loop: "{{ hana_database.components|dict2items }}"
-
-- name: Merge HANA Components list with its depends on components
-  set_fact:
-    hdb_comp_list: "{{  [ item.depends_on ] + hdb_comp_list }}"
-  loop: "{{ components }}"
-  when: 
-    - item.component in hdb_comp_list
-    - item.depends_on is defined
-
-- name: Create unique list of HANA Components
-  set_fact:
-    hdb_comp_list: "{{ hdb_comp_list|flatten(levels=1)|unique }}"
-
-# Install HANA Components
-- name: Install HANA Components
-  include_role:
-    name: components-install
-    tasks_from: "{{ component }}.yml"
-  loop: "{{ hdb_comp_list }}"
-  loop_control:
-    loop_var: component
+- import_tasks: pre_checks.yml
+- import_tasks: hana_server_installation.yml

--- a/deploy/v2/ansible/roles/hdb-server-install/tasks/main.yml
+++ b/deploy/v2/ansible/roles/hdb-server-install/tasks/main.yml
@@ -1,4 +1,4 @@
 ---
 
-- import_tasks: pre_checks.yml
+- import_tasks: hdb_pre_checks.yml
 - import_tasks: hana_server_installation.yml

--- a/deploy/v2/ansible/roles/hdb-server-install/tasks/pre_checks.yml
+++ b/deploy/v2/ansible/roles/hdb-server-install/tasks/pre_checks.yml
@@ -1,14 +1,14 @@
 ---
 
 - name: Ensure correct hostname are set and not changed for SLES
+  become: true
+  become_user: root
   when:
     - ansible_os_family|upper == 'SUSE'
   block:
 
   #SUSE bug 1167134
   - name: Ensure DHCLIENT_SET_HOSTNAME is set to no
-    become: true
-    become_user: root
     lineinfile:
       path: /etc/sysconfig/network/dhcp
       regexp: '^DHCLIENT_SET_HOSTNAME='
@@ -16,8 +16,6 @@
 
   # This is workaround for https://github.com/Azure/WALinuxAgent/pull/1832
   - name: Ensure the correct hostname are set on HANA VMs
-    become: true
-    become_user: root
     hostname:
       name: "{{ item.dbname }}"
     when: item.ip_admin_nic == ansible_default_ipv4.address

--- a/deploy/v2/ansible/roles/hdb-server-install/tasks/pre_checks.yml
+++ b/deploy/v2/ansible/roles/hdb-server-install/tasks/pre_checks.yml
@@ -1,0 +1,24 @@
+---
+
+- name: Ensure correct hostname are set and not changed for SLES
+  when:
+    - ansible_os_family|upper == 'SUSE'
+  block:
+
+  #SUSE bug 1167134
+  - name: Ensure DHCLIENT_SET_HOSTNAME is set to no
+    become: true
+    become_user: root
+    lineinfile:
+      path: /etc/sysconfig/network/dhcp
+      regexp: '^DHCLIENT_SET_HOSTNAME='
+      line: DHCLIENT_SET_HOSTNAME="no"
+
+  # This is workaround for https://github.com/Azure/WALinuxAgent/pull/1832
+  - name: Ensure the correct hostname are set on HANA VMs
+    become: true
+    become_user: root
+    hostname:
+      name: "{{ item.dbname }}"
+    when: item.ip_admin_nic == ansible_default_ipv4.address
+    loop: "{{ hana_database.nodes }}"


### PR DESCRIPTION
Sporadically, hostname of HANA VMs are not set properly due to some issues with SLES image.
Therefore implement pre-check task to make sure the hostname is setup properly and will remain the same.