### PR TITLE
add pre-check of os-disk-setup

### DIFF
--- a/deploy/v2/ansible/roles/os-disk-setup/tasks/installation_path_prechecks.yml
+++ b/deploy/v2/ansible/roles/os-disk-setup/tasks/installation_path_prechecks.yml
@@ -1,0 +1,15 @@
+---
+
+# Check if installation paths are correct. 
+- name: Pre-check installation path
+  stat:
+    path: "{{ item.value.mount_point }}"
+  loop: "{{ disk_dict|dict2items }}"
+  register: path_status
+
+# If any one of paths is incorrect, path_status_flag will be defined.
+- name: Get intallation path status
+  set_fact:
+     path_status_flag: "{{ item.stat.exists }}"
+  loop: "{{ path_status.results }}"
+  when: item.stat.exists == False

--- a/deploy/v2/ansible/roles/os-disk-setup/tasks/lvm_mount.yml
+++ b/deploy/v2/ansible/roles/os-disk-setup/tasks/lvm_mount.yml
@@ -1,0 +1,44 @@
+---
+
+- name: Create physical volume group
+  lvg: 
+    vg: "vg_{{ item.key }}"
+    pvs: "{{ item.value.devices }}"
+  with_dict: "{{ disk_dict }}"
+  register: physical_vg
+  failed_when: physical_vg is failed
+  ignore_errors: true
+
+- name: Create logical volume group
+  lvol:
+    state: present
+    vg: "vg_{{ item.key }}"
+    lv: "lv_hana_{{ item.key }}"
+    size: 100%VG
+  with_dict: "{{ disk_dict }}"
+  register: logical_vg
+  failed_when: logical_vg is failed
+  ignore_errors: true
+ 
+- name: Create mount points
+  file:
+    path: "{{ item.value.mount_point }}"
+    state: directory
+  with_dict: "{{ disk_dict }}"
+
+- name: Create file systems
+  filesystem:
+     fstype: "{{ hana_database.filesystem | default('xfs') }}"
+     dev: "/dev/vg_{{ item.key }}/lv_hana_{{ item.key }}"
+  with_dict: "{{ disk_dict }}"
+  register: file_system
+
+- name: Mount volumes
+  mount:
+    path: "{{ item.value.mount_point }}"
+    fstype: "{{ hana_database.filesystem | default('xfs') }}"
+    opts: "defaults,nofail"
+    src: "/dev/vg_{{ item.key }}/lv_hana_{{ item.key }}"
+    state: mounted
+  with_dict: "{{ disk_dict }}"
+  register: vol_mount

--- a/deploy/v2/ansible/roles/os-disk-setup/tasks/main.yml
+++ b/deploy/v2/ansible/roles/os-disk-setup/tasks/main.yml
@@ -13,47 +13,8 @@
   loop: "{{ hdb_sizes[hana_database.size].storage }}"
   when: item.name != 'os'
 
-- name: Create physical volume group
-  lvg: 
-    vg: "vg_{{ item.key }}"
-    pvs: "{{ item.value.devices }}"
-  with_dict: "{{ disk_dict }}"
-  register: physical_vg
-  failed_when: physical_vg is failed
-  ignore_errors: true
+# Check if installation paths are ready. If paths are unready, path_status_flag will be set. Then subsequent tasks will be executed.
+- import_tasks: installation_path_prechecks.yml
 
-- name: Create logical volume group
-  lvol:
-    state: present
-    vg: "vg_{{ item.key }}"
-    lv: "lv_hana_{{ item.key }}"
-    size: 100%FREE
-  with_dict: "{{ disk_dict }}"
-  register: logical_vg
-  failed_when: logical_vg is failed
-  ignore_errors: true 
- 
-- name: Create mount points
-  file:
-    path: "{{ item.value.mount_point }}"
-    state: directory
-  with_dict: "{{ disk_dict }}"
-
-- name: Create file systems
-  filesystem:
-     fstype: "{{ hana_database.filesystem | default('xfs') }}"
-     dev: "/dev/vg_{{ item.key }}/lv_hana_{{ item.key }}"
-  with_dict: "{{ disk_dict }}"
-  register: file_system
-  failed_when: file_system is failed
-
-- name: Mount volumes
-  mount:
-    path: "{{ item.value.mount_point }}"
-    fstype: "{{ hana_database.filesystem | default('xfs') }}"
-    opts: "defaults,nofail"
-    src: "/dev/vg_{{ item.key }}/lv_hana_{{ item.key }}"
-    state: mounted
-  with_dict: "{{ disk_dict }}"
-  register: vol_mount
-  failed_when: vol_mount is failed
+- include_tasks: lvm_mount.yml
+  when: path_status_flag is defined

--- a/deploy/v2/ansible/roles/os-preparation/tasks/common/os_config.yml
+++ b/deploy/v2/ansible/roles/os-preparation/tasks/common/os_config.yml
@@ -19,17 +19,22 @@
 - name: Task Disable Transparent Hugepages & Configure Processor C-States 3
   command: grub2-mkconfig -o /boot/grub2/grub.cfg
 
-- name: Create SWAP space
-  lineinfile:
-    dest: /etc/waagent.conf
-    regexp: "^{{ item.prop }}="
-    line: "{{ item.prop }}={{ item.value }}"
-  with_items:
-    - { prop: "ResourceDisk.Format", value: "y" }
-    - { prop: "ResourceDisk.EnableSwap", value: "y" }
-    - { prop: "ResourceDisk.SwapSizeMB", value: "{{ (hdb_sizes[hana_database.size].compute.swap_size_gb) * 1024|int }}" }
+# If current host is LargeInstance, creating swap will be skipped. 
+- name: Prepare SWAP
+  when: hana_database.size != "LargeInstance"
+  block:
+  
+  - name: Configure SWAP space
+    lineinfile:
+      dest: /etc/waagent.conf
+      regexp: "^{{ item.prop }}="
+      line: "{{ item.prop }}={{ item.value }}"
+    with_items:
+      - { prop: "ResourceDisk.Format", value: "y" }
+      - { prop: "ResourceDisk.EnableSwap", value: "y" }
+      - { prop: "ResourceDisk.SwapSizeMB", value: "{{ (hdb_sizes[hana_database.size].compute.swap_size_gb) * 1024|int }}" }
 
-- name: Restart waagent
-  service:
-     name: waagent 
-     state: restarted
+  - name: Restart waagent
+    service:
+      name: waagent 
+      state: restarted

--- a/deploy/v2/ansible/roles/sap-media-download/tasks/main.yml
+++ b/deploy/v2/ansible/roles/sap-media-download/tasks/main.yml
@@ -15,7 +15,7 @@
     pip3 install beautifulsoup4
   become: true
 
-- name: Check whether the installation media already exists and been extracted
+- name: Check whether the installation media already exists and has been extracted
   stat: path={{ hana_software_loc }}
   register: extract_path_status
 


### PR DESCRIPTION
1. restructure os-disk-setup role
2. add precheck to os-disk-setup role, if installation paths all exist, volume group, LVG, mount disk will be skipped.
3. If the scenario is bare metal, creating SWAP is skipped.
4. When creating Logical volume group, every time LVG will occupy the whole volume group.