### PR TITLE
HANA VM OS Clustering on SLES

### DIFF
--- a/deploy/v2/ansible/roles/hana-os-clustering/defaults/main.yml
+++ b/deploy/v2/ansible/roles/hana-os-clustering/defaults/main.yml
@@ -1,0 +1,15 @@
+---
+
+clustering_service:
+  Suse: "corosync"
+
+crm_totem:
+  token: 30000
+  retransmits: 10
+  join: 60
+  consensus: 36000
+  max_messages: 20
+
+crm_quorum:
+  expected_votes: 2
+  two_node: 1

--- a/deploy/v2/ansible/roles/hana-os-clustering/tasks/main.yml
+++ b/deploy/v2/ansible/roles/hana-os-clustering/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+
+- import_tasks: pre_checks.yml
+- import_tasks: provision.yml
+  when: cluster_existence_check_result.rc != 0

--- a/deploy/v2/ansible/roles/hana-os-clustering/tasks/pre_checks.yml
+++ b/deploy/v2/ansible/roles/hana-os-clustering/tasks/pre_checks.yml
@@ -6,14 +6,14 @@
     that:
       - "ha_cluster_password is defined"
       - "ha_cluster_password | trim | length > 0"
-      - "subscription_id is defined"
-      - "subscription_id | trim | length > 0"
-      - "tenant_id is defined"
-      - "tenant_id | trim | length > 0"
-      - "stonith_service_principal_application_id is defined"
-      - "stonith_service_principal_application_id | trim | length > 0"
-      - "stonith_service_principal_application_password is defined"
-      - "stonith_service_principal_application_password | trim | length > 0"
+      - "sap_hana_fencing_agent_subscription_id is defined"
+      - "sap_hana_fencing_agent_subscription_id | trim | length > 0"
+      - "sap_hana_fencing_agent_tenant_id is defined"
+      - "sap_hana_fencing_agent_tenant_id | trim | length > 0"
+      - "sap_hana_fencing_agent_client_id is defined"
+      - "sap_hana_fencing_agent_client_id | trim | length > 0"
+      - "sap_hana_fencing_agent_client_password is defined"
+      - "sap_hana_fencing_agent_client_password | trim | length > 0"
 
 - name: Check the required Clustering scripts are available
   when: ansible_os_family == 'Suse'

--- a/deploy/v2/ansible/roles/hana-os-clustering/tasks/pre_checks.yml
+++ b/deploy/v2/ansible/roles/hana-os-clustering/tasks/pre_checks.yml
@@ -1,0 +1,32 @@
+---
+
+
+- name: Check the required Clustering configuration variables are set
+  assert:
+    that:
+      - "ha_cluster_password is defined"
+      - "ha_cluster_password | trim | length > 0"
+      - "subscription_id is defined"
+      - "subscription_id | trim | length > 0"
+      - "tenant_id is defined"
+      - "tenant_id | trim | length > 0"
+      - "stonith_service_principal_application_id is defined"
+      - "stonith_service_principal_application_id | trim | length > 0"
+      - "stonith_service_principal_application_password is defined"
+      - "stonith_service_principal_application_password | trim | length > 0"
+
+- name: Check the required Clustering scripts are available
+  when: ansible_os_family == 'Suse'
+  stat:
+    path: "{{ item }}"
+  with_items:
+    - "/usr/sbin/ha-cluster-init"
+    - "/usr/sbin/ha-cluster-join"
+  register: cluster_scripts_status_results
+  failed_when: not cluster_scripts_status_results.stat.exists
+
+- name: Check if a cluster has already been prepared
+  shell: crm status
+  register: cluster_existence_check_result
+  changed_when: false
+  failed_when: false

--- a/deploy/v2/ansible/roles/hana-os-clustering/tasks/provision.yml
+++ b/deploy/v2/ansible/roles/hana-os-clustering/tasks/provision.yml
@@ -1,0 +1,238 @@
+---
+
+# Pre-provisioning tasks
+- name: Ensure clustering software is installed
+  package:
+    name: "{{ item }}"
+    state: present
+  with_items: "{{ ha_packages[ansible_os_family] }}"
+
+# Pacemaker can create a large number of processes
+- name: Ensure Process limit is raised
+  lineinfile:
+    path: /etc/systemd/system.conf
+    state: present
+    regexp: "^#?\\s*DefaultTasksMax="
+    line: "DefaultTasksMax=4096"
+  register: raise_process_limit
+
+- name: Ensure systemctl daemon is reloaded
+  systemd:
+    daemon_reload: True
+
+# eth1 is the "db" NIC
+- name: Ensure clustering can manage Virtual IPs on the Database Interface
+  lineinfile:
+    path: /etc/sysconfig/network/ifcfg-eth1
+    state: present
+    regexp: "^#?\\s*CLOUD_NETCONFIG_MANAGE="
+    line: "CLOUD_NETCONFIG_MANAGE='no'"
+
+# Configure SSH Keys for inter-node communication as root
+- name: Ensure there are SSH keys for the root user to communicate between nodes
+  shell: crm cluster init -y ssh
+  args:
+    creates: /root/.ssh/id_rsa
+
+- name: Ensure the Public SSH keys are available for exchanging SSH key trust between nodes
+  shell: cat /root/.ssh/id_rsa.pub
+  register: cluster_public_ssh_key
+
+- name: Ensure the Primary Node public key is authorized on all nodes, required for crm_clustering
+  authorized_key:
+    user: root
+    key: "{{ hostvars[hana_database.nodes[0].ip_admin_nic].cluster_public_ssh_key.stdout }}"
+
+- name: Ensure the Secondary Node public key is authorized on all nodes, required for crm_clustering
+  authorized_key:
+    user: root
+    key: "{{ hostvars[hana_database.nodes[1].ip_admin_nic].cluster_public_ssh_key.stdout }}"
+
+# SLES Clustering
+# Ref: https://documentation.suse.com/sle-ha/12-SP4/html/SLE-HA-install-quick/index.html
+
+# @TODO NTP server for datetime sync?
+
+# Set up Hosts entries for the cluster nodes
+- name: Ensure the Primary node hosts entry exists
+  lineinfile:
+    path: /etc/hosts
+    state: present
+    insertafter: EOF
+    regexp: "{{ hana_database.nodes[0].dbname }}"
+    line: "{{ hana_database.nodes[0].ip_db_nic }} {{ hana_database.nodes[0].dbname }}"
+
+- name: Ensure the Secondary node hosts entry exists
+  lineinfile:
+    path: /etc/hosts
+    state: present
+    insertafter: EOF
+    regexp: "{{ hana_database.nodes[1].dbname }}"
+    line: "{{ hana_database.nodes[1].ip_db_nic }} {{ hana_database.nodes[1].dbname }}"
+
+# https://rpm.pbone.net/index.php3/stat/45/idpl/27916721/numer/8/nazwa/ha-cluster-init
+- name: Ensure Primary node initiates the Cluster
+  when: ansible_hostname == hana_database.nodes[0].dbname
+  block:
+    - name: Ensure csync2 is configured
+      shell: crm cluster init -y csync2 --interface eth1
+
+    - name: Ensure corosync is configured
+      shell: crm cluster init -y -u corosync --interface eth1
+
+    - name: Ensure cluster (hdb_{{ hana_database.instance.sid | upper }}) is configured
+      shell: "crm cluster init -y cluster --name 'hdb_{{ hana_database.instance.sid | upper }}' --interface eth1"
+
+- name: Ensure Secondary node joins the Cluster
+  when: ansible_hostname == hana_database.nodes[1].dbname
+  block:
+    - name: Ensure the configuration files are synchronised
+      shell: "crm cluster join -y -c {{ hana_database.nodes[0].ip_db_nic }} csync2 --interface eth1"
+
+    - name: Ensure the cluster is joined
+      shell: "crm cluster join -y -c {{ hana_database.nodes[0].ip_db_nic }} cluster --interface eth1"
+
+- name: Ensure HA Cluster password is set to something secure
+  user:
+    name: hacluster
+    password: "{{ ha_cluster_password | password_hash('sha512') }}" # @TODO Process for creating/storing ha cluster password needs to be defined
+
+- name: Ensure cluster configuration contains correct details
+  template:
+    src: corosync.conf.j2
+    dest: /etc/corosync/corosync.conf
+    mode: 0600
+
+- name: Ensure the Corosync service is restarted
+  systemd:
+    name: "{{ clustering_service[ansible_os_family] }}"
+    state: restarted
+
+- name: Ensure the Cluster STONITH is configured
+  when: ansible_hostname == hana_database.nodes[0].dbname
+  block:
+    - name: Ensure maintenance mode is enabled
+      shell: "crm configure property maintenance-mode=true"
+
+    - name: Ensure CIB Bootstrap Options are set
+      shell: >
+        crm configure property \$id="cib-bootstrap-options"
+        no-quorum-policy="ignore"
+        stonith-enabled="true"
+        stonith-action="reboot"
+        stonith-timeout="150s"
+
+    - name: Ensure the Resource Defaults are configured
+      shell: >
+        crm configure rsc_defaults \$id="rsc-options"
+        resource-stickiness="1000"
+        migration-threshold="5000"
+
+    - name: Ensure the Operation Defaults are configured
+      shell: >
+        crm configure op_defaults \$id="op-options"
+        timeout="600"
+
+    - name: Ensure the Primary STONITH fencing device is created
+      shell: >
+        crm configure primitive rsc_st_azure_1 stonith:fence_azure_arm params
+        subscriptionId="{{ subscription_id }}"
+        resourceGroup="{{ output.infrastructure.resource_group.name }}"
+        tenantId="{{ tenant_id }}"
+        login="{{ stonith_service_principal_application_id }}"
+        passwd="{{ stonith_service_principal_application_password }}"
+        action="off"
+
+    - name: Ensure the Secondary STONITH fencing device is created
+      shell: >
+        crm configure primitive rsc_st_azure_2 stonith:fence_azure_arm params
+        subscriptionId="{{ subscription_id }}"
+        resourceGroup="{{ output.infrastructure.resource_group.name }}"
+        tenantId="{{ tenant_id }}"
+        login="{{ stonith_service_principal_application_id }}"
+        passwd="{{ stonith_service_principal_application_password }}"
+        action="off"
+
+    - name: Ensure STONITH fencing device colocation is configured
+      shell: >
+        crm configure colocation col_st_azure -2000: rsc_st_azure_1:Started rsc_st_azure_2:Started
+
+    - name: Ensure SAP HANA Topology resource is configured
+      shell: >
+        crm configure primitive rsc_SAPHanaTopology_{{ hana_database.instance.sid | upper }}_HDB{{ hana_database.instance.instance_number }}
+        ocf:suse:SAPHanaTopology
+        operations \$id="rsc_sap2_{{ hana_database.instance.sid | upper }}_HDB{{ hana_database.instance.instance_number }}-operations"
+        op monitor interval="10" timeout="600"
+        op start interval="0" timeout="600"
+        op stop interval="0" timeout="300"
+        params SID="{{ hana_database.instance.sid | upper }}" InstanceNumber="{{ hana_database.instance.instance_number }}"
+
+    - name: Ensure SAP HANA Topology clone set resource is configured
+      shell: >
+        crm configure clone cln_SAPHanaTopology_{{ hana_database.instance.sid | upper }}_HDB{{ hana_database.instance.instance_number }}
+        rsc_SAPHanaTopology_{{ hana_database.instance.sid | upper }}_HDB{{ hana_database.instance.instance_number }}
+        meta clone-node-max="1" interleave="true"
+
+    - name: Ensure SAP HANA primitive resource is configured
+      shell: >
+        crm configure primitive rsc_SAPHana_{{ hana_database.instance.sid | upper }}_HDB{{ hana_database.instance.instance_number }}
+        ocf:suse:SAPHana
+        operations \$id="rsc_sap_{{ hana_database.instance.sid | upper }}_HDB{{ hana_database.instance.instance_number }}-operations"
+        op start interval="0" timeout="3600"
+        op stop interval="0" timeout="3600"
+        op promote interval="0" timeout="3600"
+        op monitor interval="60" role="Master" timeout="700"
+        op monitor interval="61" role="Slave" timeout="700"
+        params
+        SID="{{ hana_database.instance.sid | upper }}"
+        InstanceNumber="{{ hana_database.instance.instance_number }}"
+        PREFER_SITE_TAKEOVER="true"
+        DUPLICATE_PRIMARY_TIMEOUT="7200"
+        AUTOMATED_REGISTER="false"
+
+    - name: Ensure SAP HANA master-slave resource is configured
+      shell: >
+        crm configure ms msl_SAPHana_{{ hana_database.instance.sid | upper }}_HDB{{ hana_database.instance.instance_number }}
+        rsc_SAPHana_{{ hana_database.instance.sid | upper }}_HDB{{ hana_database.instance.instance_number }}
+        meta notify="true" clone-max="2" clone-node-max="1"
+        interleave="true"
+
+    - name: Ensure SAP HANA Virtual IP resource is configured
+      shell: >
+        crm configure primitive rsc_ip_{{ hana_database.instance.sid | upper }}_HDB{{ hana_database.instance.instance_number }} ocf:heartbeat:IPaddr2
+        operations \$id="rsc_ip_{{ hana_database.instance.sid | upper }}_HDB{{ hana_database.instance.instance_number }}-operations"
+        op monitor interval="10s" timeout="20s"
+        params ip="{{ hana_database.loadbalancer.frontend_ip }}"
+
+    # socat is recommended in place of netcat on Azure: https://www.suse.com/support/kb/doc/?id=000019536
+    - name: Ensure SAP HANA Heartbeat socat resource is configured
+      shell: >
+        crm configure primitive rsc_nc_{{ hana_database.instance.sid | upper }}_HDB{{ hana_database.instance.instance_number }} anything
+        params binfile="/usr/bin/socat" cmdline_options="-U TCP-LISTEN:625{{ hana_database.instance.instance_number }},backlog=10,fork,reuseaddr /dev/null"
+        op monitor timeout=20s interval=10 depth=0
+
+    - name: Ensure Group IP Address resource is configured
+      shell: >
+        crm configure group g_ip_{{ hana_database.instance.sid | upper }}_HDB{{ hana_database.instance.instance_number }}
+        rsc_ip_{{ hana_database.instance.sid | upper }}_HDB{{ hana_database.instance.instance_number }}
+        rsc_nc_{{ hana_database.instance.sid | upper }}_HDB{{ hana_database.instance.instance_number }}
+
+    - name: Ensure Co-Location constraint is configured
+      shell: >
+        crm configure colocation col_saphana_ip_{{ hana_database.instance.sid | upper }}_HDB{{ hana_database.instance.instance_number }}
+        2000:
+        g_ip_{{ hana_database.instance.sid | upper }}_HDB{{ hana_database.instance.instance_number }}:Started
+        msl_SAPHana_{{ hana_database.instance.sid | upper }}_HDB{{ hana_database.instance.instance_number }}:Master
+
+    - name: Ensure Resource order is configured
+      shell: >
+        crm configure order ord_SAPHana_{{ hana_database.instance.sid | upper }}_HDB{{ hana_database.instance.instance_number }}
+        2000:
+        cln_SAPHanaTopology_{{ hana_database.instance.sid | upper }}_HDB{{ hana_database.instance.instance_number }}
+        msl_SAPHana_{{ hana_database.instance.sid | upper }}_HDB{{ hana_database.instance.instance_number }}
+
+    - name: Ensure any required cluster resources are cleaned up
+      shell: "crm resource cleanup rsc_SAPHana_{{ hana_database.instance.sid | upper }}_HDB{{ hana_database.instance.instance_number }}"
+
+    - name: Ensure maintenance mode is disabled
+      shell: "crm configure property maintenance-mode=false"

--- a/deploy/v2/ansible/roles/hana-os-clustering/tasks/provision.yml
+++ b/deploy/v2/ansible/roles/hana-os-clustering/tasks/provision.yml
@@ -120,7 +120,7 @@
         no-quorum-policy="ignore"
         stonith-enabled="true"
         stonith-action="reboot"
-        stonith-timeout="150s"
+        stonith-timeout="900s"
 
     - name: Ensure the Resource Defaults are configured
       shell: >

--- a/deploy/v2/ansible/roles/hana-os-clustering/tasks/provision.yml
+++ b/deploy/v2/ansible/roles/hana-os-clustering/tasks/provision.yml
@@ -133,29 +133,15 @@
         crm configure op_defaults \$id="op-options"
         timeout="600"
 
-    - name: Ensure the Primary STONITH fencing device is created
+    - name: Ensure the STONITH fencing device is created
       shell: >
-        crm configure primitive rsc_st_azure_1 stonith:fence_azure_arm params
+        crm configure primitive rsc_st_azure stonith:fence_azure_arm params
         subscriptionId="{{ sap_hana_fencing_agent_subscription_id }}"
         resourceGroup="{{ output.infrastructure.resource_group.name }}"
         tenantId="{{ sap_hana_fencing_agent_tenant_id }}"
         login="{{ sap_hana_fencing_agent_client_id }}"
         passwd="{{ sap_hana_fencing_agent_client_password }}"
         action="off"
-
-    - name: Ensure the Secondary STONITH fencing device is created
-      shell: >
-        crm configure primitive rsc_st_azure_2 stonith:fence_azure_arm params
-        subscriptionId="{{ sap_hana_fencing_agent_subscription_id }}"
-        resourceGroup="{{ output.infrastructure.resource_group.name }}"
-        tenantId="{{ sap_hana_fencing_agent_tenant_id }}"
-        login="{{ sap_hana_fencing_agent_client_id }}"
-        passwd="{{ sap_hana_fencing_agent_client_password }}"
-        action="off"
-
-    - name: Ensure STONITH fencing device colocation is configured
-      shell: >
-        crm configure colocation col_st_azure -2000: rsc_st_azure_1:Started rsc_st_azure_2:Started
 
     - name: Ensure SAP HANA Topology resource is configured
       shell: >

--- a/deploy/v2/ansible/roles/hana-os-clustering/tasks/provision.yml
+++ b/deploy/v2/ansible/roles/hana-os-clustering/tasks/provision.yml
@@ -136,21 +136,21 @@
     - name: Ensure the Primary STONITH fencing device is created
       shell: >
         crm configure primitive rsc_st_azure_1 stonith:fence_azure_arm params
-        subscriptionId="{{ subscription_id }}"
+        subscriptionId="{{ sap_hana_fencing_agent_subscription_id }}"
         resourceGroup="{{ output.infrastructure.resource_group.name }}"
-        tenantId="{{ tenant_id }}"
-        login="{{ stonith_service_principal_application_id }}"
-        passwd="{{ stonith_service_principal_application_password }}"
+        tenantId="{{ sap_hana_fencing_agent_tenant_id }}"
+        login="{{ sap_hana_fencing_agent_client_id }}"
+        passwd="{{ sap_hana_fencing_agent_client_password }}"
         action="off"
 
     - name: Ensure the Secondary STONITH fencing device is created
       shell: >
         crm configure primitive rsc_st_azure_2 stonith:fence_azure_arm params
-        subscriptionId="{{ subscription_id }}"
+        subscriptionId="{{ sap_hana_fencing_agent_subscription_id }}"
         resourceGroup="{{ output.infrastructure.resource_group.name }}"
-        tenantId="{{ tenant_id }}"
-        login="{{ stonith_service_principal_application_id }}"
-        passwd="{{ stonith_service_principal_application_password }}"
+        tenantId="{{ sap_hana_fencing_agent_tenant_id }}"
+        login="{{ sap_hana_fencing_agent_client_id }}"
+        passwd="{{ sap_hana_fencing_agent_client_password }}"
         action="off"
 
     - name: Ensure STONITH fencing device colocation is configured

--- a/deploy/v2/ansible/roles/hana-os-clustering/tasks/provision.yml
+++ b/deploy/v2/ansible/roles/hana-os-clustering/tasks/provision.yml
@@ -128,6 +128,7 @@
         resource-stickiness="1000"
         migration-threshold="5000"
 
+    # Operation Default recommendation from section 6.3.1 in https://www.suse.com/media/white-paper/suse_linux_enterprise_server_for_sap_applications_12_sp1.pdf#page=32
     - name: Ensure the Operation Defaults are configured
       shell: >
         crm configure op_defaults \$id="op-options"

--- a/deploy/v2/ansible/roles/hana-os-clustering/tasks/provision.yml
+++ b/deploy/v2/ansible/roles/hana-os-clustering/tasks/provision.yml
@@ -128,7 +128,7 @@
         resource-stickiness="1000"
         migration-threshold="5000"
 
-    # Operation Default recommendation from section 6.3.1 in https://www.suse.com/media/white-paper/suse_linux_enterprise_server_for_sap_applications_12_sp1.pdf#page=32
+    # Operation Default recommendation from section 5.3.1 in https://www.suse.com/media/white-paper/suse_linux_enterprise_server_for_sap_applications_12_sp1.pdf#page=26
     - name: Ensure the Operation Defaults are configured
       shell: >
         crm configure op_defaults \$id="op-options"

--- a/deploy/v2/ansible/roles/hana-os-clustering/templates/corosync.conf.j2
+++ b/deploy/v2/ansible/roles/hana-os-clustering/templates/corosync.conf.j2
@@ -1,0 +1,61 @@
+# Please read the corosync.conf.5 manual page
+
+totem {
+    version:             2
+    secauth:             on
+    crypto_hash:         sha1
+    crypto_cipher:       aes256
+    cluster_name:        hacluster
+    clear_node_high_bit: yes
+
+    token:                               {{ crm_totem.token }}
+    token_retransmits_before_loss_const: {{ crm_totem.retransmits }}
+    join:                                {{ crm_totem.join }}
+    consensus:                           {{ crm_totem.consensus }}
+    max_messages:                        {{ crm_totem.max_messages }}
+
+    interface {
+        ringnumber: 0
+        mcastport:  5405
+        ttl:        1
+    }
+
+
+    transport: udpu
+
+
+
+}
+
+logging {
+    fileline:   off
+    to_stderr:  no
+    to_logfile: no
+    logfile:    /var/log/cluster/corosync.log
+    to_syslog:  yes
+    debug:      off
+    timestamp:  on
+    logger_subsys {
+        subsys: QUORUM
+        debug:  off
+    }
+}
+
+nodelist {
+    node {
+        ring0_addr: {{ hana_database.nodes[0].ip_db_nic }}
+        nodeid:     1
+    }
+    node {
+        ring0_addr: {{ hana_database.nodes[1].ip_db_nic }}
+        nodeid:     2
+    }
+}
+
+quorum {
+    # Enable and configure quorum subsystem (default: off)
+    # see also corosync.conf.5 and votequorum.5
+    provider: corosync_votequorum
+    expected_votes: {{ crm_quorum.expected_votes }}
+    two_node: {{ crm_quorum.two_node }}
+}

--- a/deploy/v2/ansible/sap_playbook.yml
+++ b/deploy/v2/ansible/sap_playbook.yml
@@ -55,6 +55,8 @@
 - hosts: hanadbnodes
   become: true
   become_user: root
+  vars_files:
+    - "vars/ha-packages.yml"
   roles:
     - role: hdb-server-install
     - role: hana-system-replication
@@ -63,6 +65,14 @@
         sid: "{{ hana_database.instance.sid }}"
         instance_number: "{{ hana_database.instance.instance_number }}"
         hana_system_user_password: "{{ hana_database.credentials.db_systemdb_password }}"
+    - role: hana-os-clustering
+      when: hana_database.high_availability
+      vars:
+        ha_cluster_password: "ASecurePa55w0rd"   # @TODO Determine source of truth for this value
+        subscription_id: "{{ lookup('env', 'SAP_HANA_FENCING_AGENT_SUBSCRIPTION_ID') }}"
+        tenant_id: "{{ lookup('env', 'SAP_HANA_FENCING_AGENT_TENANT_ID') }}"
+        stonith_service_principal_application_id: "{{ lookup('env', 'SAP_HANA_FENCING_AGENT_CLIENT_ID') }}"
+        stonith_service_principal_application_password: "{{ lookup('env', 'SAP_HANA_FENCING_AGENT_CLIENT_SECRET') }}"
 
 # Linux jumpboxes components install
 - hosts: jumpboxes_linux

--- a/deploy/v2/ansible/sap_playbook.yml
+++ b/deploy/v2/ansible/sap_playbook.yml
@@ -69,10 +69,10 @@
       when: hana_database.high_availability
       vars:
         ha_cluster_password: "ASecurePa55w0rd"   # @TODO Determine source of truth for this value
-        subscription_id: "{{ lookup('env', 'SAP_HANA_FENCING_AGENT_SUBSCRIPTION_ID') }}"
-        tenant_id: "{{ lookup('env', 'SAP_HANA_FENCING_AGENT_TENANT_ID') }}"
-        stonith_service_principal_application_id: "{{ lookup('env', 'SAP_HANA_FENCING_AGENT_CLIENT_ID') }}"
-        stonith_service_principal_application_password: "{{ lookup('env', 'SAP_HANA_FENCING_AGENT_CLIENT_SECRET') }}"
+        sap_hana_fencing_agent_subscription_id: "{{ lookup('env', 'SAP_HANA_FENCING_AGENT_SUBSCRIPTION_ID') }}"
+        sap_hana_fencing_agent_tenant_id: "{{ lookup('env', 'SAP_HANA_FENCING_AGENT_TENANT_ID') }}"
+        sap_hana_fencing_agent_client_id: "{{ lookup('env', 'SAP_HANA_FENCING_AGENT_CLIENT_ID') }}"
+        sap_hana_fencing_agent_client_password: "{{ lookup('env', 'SAP_HANA_FENCING_AGENT_CLIENT_SECRET') }}"
 
 # Linux jumpboxes components install
 - hosts: jumpboxes_linux

--- a/deploy/v2/ansible/vars/ha-packages.yml
+++ b/deploy/v2/ansible/vars/ha-packages.yml
@@ -1,0 +1,8 @@
+---
+
+ha_packages:
+  Suse:
+    - socat
+    - corosync
+    - resource-agents
+    - fence-agents


### PR DESCRIPTION
## Problem

As described in https://github.com/Azure/sap-hana/issues/338 - the Ansible code base does not have any code to configure the OS clustering and STONITH resources for SLES based systems.

## Description

This PR adds a `hana-os-clustering` role which configures the corosync/pacemaker clustering via `crm`. The cluster has been configured to *not* automatically restart/re-register a node after it has failed.  This is to allow the failure to be investigated.

The assumption that #421 will be used for creating the STONITH Service Principal, and that the role assignment will allow active control over the VMs created through this process. The test instructions below include manual steps for creating a Service Principal and assigning permissions for controlling the VMs.

### Future Work

1. This PR hard codes the `hacluster` password, as the mechanism for generating/storing this has not yet been determined.
1. The `AUTOMATED_REGISTER` value is configured to `False` for the cluster, allowing investigation into failure cause.  This means manual action to recover the cluster is required.
1. Integrate secrets management with Azure KeyVault and `input.json`

### TODO List

- [x] Add Load Balancer to the `output.json` file so it can be used by the Ansible
  - see #399
- [x] Update the source of the Service Principal details to use the output from #421
- [x] Resolve issue of how to get Subscription and Tenant IDs
  - See #421
- [x] Resolve failed resource actions

## Pre-Requisites

None

## Commitment to Test

- Testing takes 2 hours (mostly waiting)
- Reviewing 8 files

## Test Instructions

:hand: The following testing has been performed on [PR#18 on the Centiq Fork](https://github.com/Centiq/sap-hana/pull/18)

### Scenario: Cluster Provisioning

Assuming all pre-requisite steps have been performed in the [Usage guide](https://github.com/Centiq/sap-hana/blob/master/deploy/v2/USAGE.md).

1. Update the resource group for the `clustered_hana` template (use a unique and un-used RG):\
   `util/set_resource_group.sh "pc-test-rg" "clustered_hana"`
1. Ensure a clustering service principal has been created.
   1. Navigate to the [Azure Portal App Registrations page](https://portal.azure.com/#blade/Microsoft_AAD_IAM/ActiveDirectoryMenuBlade/RegisteredApps)
   1. Click `+ New registration`
   1. Enter a name, e.g. `<initials>-stonith-sp-<sid>-<instance_number>`
   1. Enter the Redirect URI as `https://localhost`
   1. Click `Register`
   1. Note the `Application (client) ID` as the `client_id`
   1. Note the `Directory (tenant) ID` as the `tenant_id`
   1. In the left menu pane, click `Certificates & secrets`
   1. Click `+ New client secret`
   1. Enter the description `STONITH client secret`
   1. Select the expiry `Never`
   1. Click `Add`
   1. Note the `Value` generated as the `client_secret`
      :hand: This must be done before navigating away form this page, otherwise the value will be obfuscated and no longer retrievable.
1. Navigate to the [Azure Portal Subscriptions page](https://portal.azure.com/#blade/Microsoft_Azure_Billing/SubscriptionsBlade)
   1. Note the `Subscription ID` for the correct subscription as `subscription_id`
1. Ensure your working directory is clean:\
   `util/terraform_v2.sh clean`
   `y`
1. Ensure your working directory has Terraform initialised:\
   `util/terraform_v2.sh init`
1. Build the `clustered_hana` template:\
   `util/terraform_v2.sh apply clustered_hana`
1. In the [Azure Portal Resource Groups page](https://portal.azure.com/#blade/HubsExtension/BrowseResourceGroups), associate the SP we created with both of the HANA DB VMs:
   1. Navigate to the resource group you have deployed
   1. Click on the `hdb1-0` VM
   1. In the left menu pane click `Access control (IAM)`
   1. In the `Add a role assignment` box, click `Add`
   1. Select the Role `Owner` (overkill, but sufficient for this test)
   1. In the search box, enter the name of the SP created above in step 2, iii
   1. Click on the SP name
   1. Click Save
   1. Repeat for VM `hdb1-1`
1. Use the information from the output to SSH to the RTI instance (e.g.):\
   `ssh azureadm@<ipaddress>`
1. Remove the existing repository:\
   `rm -rf sap-hana`
1. Clone the Centiq Fork:\
   `git clone https://github.com/Centiq/sap-hana.git`
1. Checkout this branch:\
   `cd sap-hana ; git checkout hana-os-cluster ; cd -`
1. Export the following values (using the values you noted earlier):\
   ```
   export SAP_HANA_FENCING_AGENT_SUBSCRIPTION_ID=<subscription_id>
   export SAP_HANA_FENCING_AGENT_TENANT_ID=<tenant_id>
   export SAP_HANA_FENCING_AGENT_CLIENT_ID=<client_id>
   export SAP_HANA_FENCING_AGENT_CLIENT_SECRET=<client_secret>
   export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
   export ANSIBLE_HOST_KEY_CHECKING=False
   ```
1. Run the Ansible to build the system:\
   `ansible-playbook -i hosts ~/sap-hana/deploy/v2/ansible/sap_playbook.yml`

### Scenario: Failover Testing

1. On the primary node (`hdb1-0`) as root, fence the primary node:\
   `crm node fence hdb1-0`
1. On the secondary node (`hdb1-1`), monitor the failover process:\
   `crm_mon`
   This process will take about 5 minutes, and end up with `hdb1-0` stopped, and `hdb1-1` as the Primary.

### Recovery Process

1. Start `hdb1-0` in the Azure portal
1. On `hdb1-1`, monitor the cluster status for stability (approx 1 minute):\
   `crm_mon`
1. Clear the failure message:\
   `stonith_admin --cleanup --history=hdb1-0`

## Acceptance Criteria

1. The Ansible code runs:
   - [x] Process completes without error
1. From the RTI, connect to the primary node:\
   `ssh 10.1.1.4`
1. Escalate to root:\
   `sudo -i`
1. Check the cluster status:\
   `crm status`
   - [x] The output shows a healthy cluster with no failed resource actions

## References

Sample successful `crm status` output:

```
Stack: corosync
Current DC: hdb1-0 (version 1.1.21+20191108.0e5203148-3.3.1-1.1.21+20191108.0e5203148) - partition with quorum
Last updated: Wed Apr 15 17:22:23 2020
Last change: Wed Apr 15 17:21:36 2020 by root via crm_attribute on hdb1-0

2 nodes configured
8 resource instances configured

Online: [ hdb1-0 hdb1-1 ]

Full list of resources:

 rsc_st_azure_1	(stonith:fence_azure_arm):	Started hdb1-1
 rsc_st_azure_2	(stonith:fence_azure_arm):	Started hdb1-0
 Clone Set: cln_SAPHanaTopology_HN1_HDB00 [rsc_SAPHanaTopology_HN1_HDB00]
     Started: [ hdb1-0 hdb1-1 ]
 Master/Slave Set: msl_SAPHana_HN1_HDB00 [rsc_SAPHana_HN1_HDB00]
     Masters: [ hdb1-0 ]
     Slaves: [ hdb1-1 ]
 Resource Group: g_ip_HN1_HDB00
     rsc_ip_HN1_HDB00	(ocf::heartbeat:IPaddr2):	Started hdb1-0
     rsc_nc_HN1_HDB00	(ocf::heartbeat:anything):	Started hdb1-0

```