### PR TITLE
[BUG] Setup SP on RTI env for pipeline

### DIFF
--- a/templates/ansible-deployment-steps-daily.yaml
+++ b/templates/ansible-deployment-steps-daily.yaml
@@ -19,7 +19,12 @@ steps:
       rti_user=$(cat output.json | jq -r '.jumpboxes.linux[] | select(.destroy_after_deploy == "true") | .authentication.username')
       rti_public_ip=$(cat output.json | jq -r '.jumpboxes.linux[] | select(.destroy_after_deploy == "true") | .public_ip_address')     
       ssh -i /tmp/sshkey -o StrictHostKeyChecking=no "${rti_user}"@"${rti_public_ip}" ansible-playbook --version
-      ssh -i /tmp/sshkey -o StrictHostKeyChecking=no "${rti_user}"@"${rti_public_ip}" 'OBJC_DISABLE_INITIALIZE_FORK_SAFETY="YES" ANSIBLE_HOST_KEY_CHECKING="False" ansible-playbook -i hosts sap-hana/deploy/v2/ansible/sap_playbook.yml'
+      ssh -i /tmp/sshkey -o StrictHostKeyChecking=no "${rti_user}"@"${rti_public_ip}" '
+      export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
+      export ANSIBLE_HOST_KEY_CHECKING=False
+      source export-clustering-sp-details.sh
+      ansible-playbook -i hosts sap-hana/deploy/v2/ansible/sap_playbook.yml
+      '
     displayName: 'Ansible Deployment'
     env:
       TF_VAR_azure_service_principal_id: $(hana-pipeline-spn-id)

--- a/templates/ansible-deployment-steps.yaml
+++ b/templates/ansible-deployment-steps.yaml
@@ -21,6 +21,7 @@ steps:
       ssh -i /tmp/sshkey -o StrictHostKeyChecking=no "${rti_user}"@"${rti_public_ip}" '
       export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
       export ANSIBLE_HOST_KEY_CHECKING=False
+      source export-clustering-sp-details.sh
       ansible-playbook -i hosts sap-hana/deploy/v2/ansible/sap_playbook.yml
       '
     displayName: 'Ansible Deployment'


### PR DESCRIPTION
## Problem
Pipeline fails with HA clustering for SLES (PR #425).

## Description
In pipeline, ansible execution is switched off in TF.
It is triggered separately and env needs to be set again with `export-clustering-sp-details.sh`.

## Solution
Setup env with `export-clustering-sp-details.sh` for v2 pipelines.

## Tests
With draft PR #436 based on PR #425 , azure pipeline successfully completed with HA cluster setup ([link](https://dev.azure.com/azuresaphana/Azure-SAP-HANA/_build/results?buildId=3252&view=logs&j=fd5f4be9-95c2-54e4-5cd9-897a049f9ee1&t=0693f71d-5f8c-5be9-89c4-3450bc904366))
