### PR TITLE
Transfer sap installation media to hanadbnodes when scenario is Large instance

### DIFF
--- a/deploy/v2/ansible/roles/sap-media-download/tasks/main.yml
+++ b/deploy/v2/ansible/roles/sap-media-download/tasks/main.yml
@@ -19,9 +19,24 @@
   stat: path={{ hana_software_loc }}
   register: extract_path_status
 
+- debug:
+    var=inventory_hostname
+
 - name: Download installation media
   shell: "python3 {{ playbook_dir }}/../python/downloader/basket.py --config /home/{{ ansible_user}}/output.json --dir {{ azure_files_mount_path }}"
-  when: extract_path_status.stat.exists == false
+  when: 
+    - extract_path_status.stat.exists == false
+    - inventory_hostname not in hanadbnodes
+
+- name: Copy installation media to hanadbnodes
+  become: true
+  become_user: root
+  copy:
+    src: "{{ item }}"
+    dest: "{{ azure_files_mount_path }}/DB/"
+    with_fileglob:
+      - "{{ azure_files_mount_path }}/DB/*.ZIP" 
+      - inventory_hostname in hanadbnodes
 
 - name: Identify media archive
   shell: "ls {{ azure_files_mount_path }}/DB|grep ZIP"

--- a/deploy/v2/ansible/roles/sap-media-transfer/tasks/media_hanadbnode_copy.yml
+++ b/deploy/v2/ansible/roles/sap-media-transfer/tasks/media_hanadbnode_copy.yml
@@ -1,25 +1,20 @@
 ---
 
-# This is temperary solution to get bits from SMP
-
-# Due to the file permission limitation with blob (always 770), we currently only support using azure files.
 - name: Install unzip
-  package: 
+  package:
     name: unzip
     state: latest
-
-# Explicitly install bs4 with python3
-- name: Install beautifulsoup4
-  command: |
-    pip3 install beautifulsoup4
-  become: true
 
 - name: Check whether the installation media already exists and has been extracted
   stat: path={{ hana_software_loc }}
   register: extract_path_status
 
-- name: Download installation media
-  shell: "python3 {{ playbook_dir }}/../python/downloader/basket.py --config {{ inventory_dir }}/output.json --dir {{ azure_files_mount_path }}"
+- name: transfer installation media to hanadbnodes
+  copy:
+    src: "{{ item }}"
+    dest: "{{ azure_files_mount_path }}/DB/"
+  with_fileglob:
+    - "{{ azure_files_mount_path }}/DB/*.ZIP" 
   when: extract_path_status.stat.exists == false
 
 - name: Identify media archive

--- a/deploy/v2/ansible/sap_playbook.yml
+++ b/deploy/v2/ansible/sap_playbook.yml
@@ -60,6 +60,14 @@
   roles:
     - role: sap-media-download
 
+# When scenario is Large Instance, sap bits will be copied to hanadbnodes
+- hosts: hanadbnodes
+  become: true
+  become_user: root
+  roles:
+    - role: sap-media-download
+      when: hana_database.size == "LargeInstance"
+
 # Hana DB components install
 - hosts: hanadbnodes
   become: true

--- a/deploy/v2/ansible/sap_playbook.yml
+++ b/deploy/v2/ansible/sap_playbook.yml
@@ -60,13 +60,15 @@
   roles:
     - role: sap-media-download
 
-# When scenario is Large Instance, sap bits will be copied to hanadbnodes
+# When scenario is Large Instance, sap bits will be transferred to hanadbnodes
 - hosts: hanadbnodes
   become: true
   become_user: root
-  roles:
-    - role: sap-media-download
-      when: hana_database.size == "LargeInstance"
+  tasks:
+  - include_role:
+      name: sap-media-transfer
+      tasks_from: media_hanadbnode_copy.yml
+    when: hana_database.size == "LargeInstance"
 
 # Hana DB components install
 - hosts: hanadbnodes

--- a/deploy/v2/hdb_sizes.json
+++ b/deploy/v2/hdb_sizes.json
@@ -1,60 +1,31 @@
 {   
     "LargeInstance" : {
         "compute" : {
-            "vm_size" : "Standard_D8s_v3",
-            "swap_size_gb" : 2
         },
         "storage" : [
             {
-                "name" : "os",
-                "count" : 1,
-                "disk_type" : "StandardSSD_LRS",
-                "size_gb" : 64,
-                "caching" : "ReadWrite"
-            },
-            {
                 "name" : "data",
                 "count" : 1,
-                "disk_type" : "Premium_LRS",
-                "size_gb" : 512,
-                "caching" : "None",
-                "write_accelerator" : false,
                 "mount_point" : "/hana/data"
             },
             {
                 "name" : "log",
                 "count" : 1,
-                "disk_type" : "Premium_LRS",
-                "size_gb" : 512,
-                "caching" : "None",
-                "write_accelerator" : false,
                 "mount_point" : "/hana/log"
             },
             {
                 "name" : "shared",
                 "count" : 1,
-                "disk_type" : "StandardSSD_LRS",
-                "size_gb" : 512,
-                "caching" : "ReadOnly",
-                "write_accelerator" : false,
                 "mount_point" : "/hana/shared"
             },
             {
                 "name" : "sap",
                 "count" : 1,
-                "disk_type" : "StandardSSD_LRS",
-                "size_gb" : 64,
-                "caching" : "ReadOnly",
-                "write_accelerator" : false,
                 "mount_point" : "/usr/sap"
             },
             {
                 "name" : "backup",
                 "count" : 1,
-                "disk_type" : "StandardSSD_LRS",
-                "size_gb" : 512,
-                "caching" : "ReadOnly",
-                "write_accelerator" : false,
                 "mount_point" : "/hana/backup"
             }
         ]

--- a/deploy/v2/hdb_sizes.json
+++ b/deploy/v2/hdb_sizes.json
@@ -1,4 +1,64 @@
-{
+{   
+    "LargeInstance" : {
+        "compute" : {
+            "vm_size" : "Standard_D8s_v3",
+            "swap_size_gb" : 2
+        },
+        "storage" : [
+            {
+                "name" : "os",
+                "count" : 1,
+                "disk_type" : "StandardSSD_LRS",
+                "size_gb" : 64,
+                "caching" : "ReadWrite"
+            },
+            {
+                "name" : "data",
+                "count" : 1,
+                "disk_type" : "Premium_LRS",
+                "size_gb" : 512,
+                "caching" : "None",
+                "write_accelerator" : false,
+                "mount_point" : "/hana/data"
+            },
+            {
+                "name" : "log",
+                "count" : 1,
+                "disk_type" : "Premium_LRS",
+                "size_gb" : 512,
+                "caching" : "None",
+                "write_accelerator" : false,
+                "mount_point" : "/hana/log"
+            },
+            {
+                "name" : "shared",
+                "count" : 1,
+                "disk_type" : "StandardSSD_LRS",
+                "size_gb" : 512,
+                "caching" : "ReadOnly",
+                "write_accelerator" : false,
+                "mount_point" : "/hana/shared"
+            },
+            {
+                "name" : "sap",
+                "count" : 1,
+                "disk_type" : "StandardSSD_LRS",
+                "size_gb" : 64,
+                "caching" : "ReadOnly",
+                "write_accelerator" : false,
+                "mount_point" : "/usr/sap"
+            },
+            {
+                "name" : "backup",
+                "count" : 1,
+                "disk_type" : "StandardSSD_LRS",
+                "size_gb" : 512,
+                "caching" : "ReadOnly",
+                "write_accelerator" : false,
+                "mount_point" : "/hana/backup"
+            }
+        ]
+    },
     "Demo" : {
         "compute" : {
             "vm_size" : "Standard_D8s_v3",


### PR DESCRIPTION
1. Transfer sap bits from rti to hanadbnodes when it is large instance
2. unzip is needed to unzip *.ZIP, apt-get doesn't exist on Redhat, so change it to use os package manager
3. Add LargeInstance configuration in hdb_size.json. os-disk-setup role uses this file to get the mount point, etc.