### PR TITLE
Revert #398 - Remove subscription/tenant IDs from output.json

### DIFF
--- a/deploy/v2/terraform/modules/output_files/main.tf
+++ b/deploy/v2/terraform/modules/output_files/main.tf
@@ -2,17 +2,9 @@
 # OUTPUT Files
 ##################################################################################################################
 
-# Get the Azure Target Subscription and Tenant IDs
-data "azurerm_client_config" "azure_config" {
-}
-
 # Generates the output JSON with IP address and disk details
 resource "local_file" "output-json" {
   content = jsonencode({
-    "azure_config" = {
-      subscription_id = data.azurerm_client_config.azure_config.subscription_id
-      tenant_id       = data.azurerm_client_config.azure_config.tenant_id
-    },
     "infrastructure" = var.infrastructure,
     "jumpboxes" = {
       "windows" = [for jumpbox-windows in var.jumpboxes.windows : {


### PR DESCRIPTION
## Problem

#398 introduced a method for passing the Subscription and Tenant IDs to the RTI via Terraform.  This method is no longer required as the information is passed via #421.

## Description

This PR reverts the changes made in #398 and closes #441