### PR TITLE
[BUG] windows_bastion not passed to common_setup module

### DIFF
--- a/deploy/vm/modules/ha_pair/main.tf
+++ b/deploy/vm/modules/ha_pair/main.tf
@@ -15,6 +15,7 @@ module "common_setup" {
   sap_instancenum   = var.sap_instancenum
   sap_sid           = var.sap_sid
   use_existing_nsg  = var.use_existing_nsg
+  windows_bastion   = var.windows_bastion
 }
 
 resource "azurerm_availability_set" "ha-pair-availset" {
@@ -238,9 +239,9 @@ resource "null_resource" "destroy-vm" {
                OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES \
                AZURE_RESOURCE_GROUPS="${var.az_resource_group}" \
                ANSIBLE_HOST_KEY_CHECKING="False" \
-	       ansible-playbook -u '${var.vm_user}' \
-	       --private-key '${var.sshkey_path_private}' \
-	       --extra-vars="{az_resource_group: \"${module.common_setup.resource_group_name}\", az_vm_name:  \"${local.linux_vm_name}\"}" ../../ansible/delete_bastion_linux.yml
+         ansible-playbook -u '${var.vm_user}' \
+         --private-key '${var.sshkey_path_private}' \
+         --extra-vars="{az_resource_group: \"${module.common_setup.resource_group_name}\", az_vm_name:  \"${local.linux_vm_name}\"}" ../../ansible/delete_bastion_linux.yml
 EOT
 
   }
@@ -254,11 +255,11 @@ resource "null_resource" "delete-iscsi-public-ip" {
                OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES \
                AZURE_RESOURCE_GROUPS="${var.az_resource_group}" \
                ANSIBLE_HOST_KEY_CHECKING="False" \
-	       ansible-playbook -u '${var.vm_user}' \
-	       --private-key '${var.sshkey_path_private}' \
-	       --extra-vars="{ ip_config_name: \"iscsi-nic-configuration\",azure_nic: \"${module.nic_and_pip_setup_iscsi.nic_name}\", azure_vnet:  \"${module.common_setup.vnet_name}\", azure_subnet: \"hdb-subnet\", azure_nsg: \"${module.common_setup.nsg_id}\", azure_private_ip: \"${var.private_ip_address_iscsi}\", azure_resource_group: \"${module.common_setup.resource_group_name}\", azure_public_ip:  \"${module.nic_and_pip_setup_iscsi.pip_name}\"}" ../../ansible/delete_iscsi_public_ip.yml
+         ansible-playbook -u '${var.vm_user}' \
+         --private-key '${var.sshkey_path_private}' \
+         --extra-vars="{ ip_config_name: \"iscsi-nic-configuration\",azure_nic: \"${module.nic_and_pip_setup_iscsi.nic_name}\", azure_vnet:  \"${module.common_setup.vnet_name}\", azure_subnet: \"hdb-subnet\", azure_nsg: \"${module.common_setup.nsg_id}\", azure_private_ip: \"${var.private_ip_address_iscsi}\", azure_resource_group: \"${module.common_setup.resource_group_name}\", azure_public_ip:  \"${module.nic_and_pip_setup_iscsi.pip_name}\"}" ../../ansible/delete_iscsi_public_ip.yml
 EOT
 
-}
+  }
 }
 


### PR DESCRIPTION
## Problem
As described in #394, NSG for windows bastion host was not created.

## Description
The root cause is variable windows_bastion was not passed to module common_setup.

## Test
```
ESC[0mESC[1mESC[32m
Apply complete! Resources: 57 added, 0 changed, 0 destroyed.ESC[0m
ESC[0mESC[1mESC[32m
Outputs:

hdb0_ip = ha1-hdb0-nancycwin-bastion-0.westus2.cloudapp.azure.com
hdb1_ip = ha1-hdb1-nancycwin-bastion-0.westus2.cloudapp.azure.com
hdb_vm_user = labuser
primary_hdb = ha1-hdb0
secondary_hdb = ha1-hdb1
windows_bastion_ip = [
  "ha1-win-bastion-nancycwin-bastion-0.westus2.cloudapp.azure.com",
]
windows_bastion_user = bastion_userESC[0m
```