### PR TITLE
Allow SAP HANA OS to be set with a util script

### DIFF
--- a/deploy/v2/USAGE.md
+++ b/deploy/v2/USAGE.md
@@ -210,6 +210,20 @@ In the following steps you will need to substitute a `<template_name>` for the t
    util/terraform_v2.sh plan <template_name>
    ```
 
+1. To easily discover which operating systems can be used to build HANA VMs, run the following utility script withput parameters:
+
+   ```text
+   util/set_sap_os.sh
+   ```
+
+   :information_source: The specific versions of operating systems which are tied to the "convenience names" are defined in the `util/sap_os_offers.json` file. The names "SLES" and "RHEL" are preset to match the more specific `sles12sp5` (`offer: sles-sap-12-sp5`, `sku: gen1`) and `redhat76` (`offer: RHEL-SAP-HA`, `sku: 7.6`) respectively.
+
+1. To easily choose which operating system will be used to build HANA VMs, run the following utility script with the required SAP OS chosen from the above list:
+
+   ```text
+   util/set_sap_os.sh <SAP OS> <template name>
+   ```
+
 1. To easily deploy the system, run the following utility script with an input template name (e.g. `single_node_hana`):
 
    ```text

--- a/deploy/v2/template_samples/single_node_hana.json
+++ b/deploy/v2/template_samples/single_node_hana.json
@@ -115,9 +115,9 @@
       "platform": "HANA",
       "db_version": "2.00.043",
       "os": {
-        "publisher": "Redhat",
-        "offer": "RHEL-SAP-HANA",
-        "sku": "7.3"
+        "publisher": "suse",
+        "offer": "sles-sap-12-sp5",
+        "sku": "gen1"
       },
       "size": "Demo",
       "filesystem": "xfs",

--- a/deploy/v2/terraform/modules/common_infrastructure/infrastructure.tf
+++ b/deploy/v2/terraform/modules/common_infrastructure/infrastructure.tf
@@ -192,7 +192,7 @@ resource "azurerm_storage_account" "storage-sapbits" {
   account_replication_type  = "LRS"
   account_tier              = var.software.storage_account_sapbits.account_tier
   account_kind              = var.software.storage_account_sapbits.account_kind
-  enable_https_traffic_only = true
+  enable_https_traffic_only = var.options.enable_secure_transfer == "" ? true : var.options.enable_secure_transfer
 }
 
 # Creates the storage container inside the storage account for SAP bits

--- a/deploy/v2/terraform/modules/common_infrastructure/infrastructure.tf
+++ b/deploy/v2/terraform/modules/common_infrastructure/infrastructure.tf
@@ -224,5 +224,5 @@ resource "azurerm_storage_account" "storage-bootdiag" {
   location                  = var.infrastructure.region
   account_replication_type  = "LRS"
   account_tier              = "Standard"
-  enable_https_traffic_only = true
+enable_https_traffic_only = var.options.enable_secure_transfer == "" ? true : var.options.enable_secure_transfer
 }

--- a/deploy/v2/terraform/modules/common_infrastructure/infrastructure.tf
+++ b/deploy/v2/terraform/modules/common_infrastructure/infrastructure.tf
@@ -192,7 +192,7 @@ resource "azurerm_storage_account" "storage-sapbits" {
   account_replication_type  = "LRS"
   account_tier              = var.software.storage_account_sapbits.account_tier
   account_kind              = var.software.storage_account_sapbits.account_kind
-  enable_https_traffic_only = [for sku in distinct([for database in var.databases : tonumber(database.os.sku) if lower(database.os.publisher) == "redhat"]) : sku if sku < 7.5] == [] ? true : false
+  enable_https_traffic_only = true
 }
 
 # Creates the storage container inside the storage account for SAP bits
@@ -224,5 +224,5 @@ resource "azurerm_storage_account" "storage-bootdiag" {
   location                  = var.infrastructure.region
   account_replication_type  = "LRS"
   account_tier              = "Standard"
-  enable_https_traffic_only = [for sku in distinct([for database in var.databases : tonumber(database.os.sku) if lower(database.os.publisher) == "redhat"]) : sku if sku < 7.5] == [] ? true : false
+  enable_https_traffic_only = true
 }

--- a/util/common_utils.sh
+++ b/util/common_utils.sh
@@ -113,3 +113,30 @@ function edit_json_template_for_path()
 	# replace original JSON template file with temporary edited one
 	mv "${temp_template_json}" "${target_json}"
 }
+
+# This function is used to compare semver strings
+# It takes two parameters, each a semver string /\d+(\.\d+(\.\d+)?)?/
+# For example, 1, 1.2, 1.2.3 and compares them
+# It echos ">" if string1 > string2, "=" if string1 == string2 and "<" if string1 < string2
+function test_semver()
+{
+  local actual_semver="$1"
+  local required_semver="$2"
+
+  IFS=. read -r -a actual_semver_parts <<< "${actual_semver}"
+  IFS=. read -r -a required_semver_parts <<< "${required_semver}"
+
+  (( major=${actual_semver_parts[0]:-0} - ${required_semver_parts[0]:-0} ))
+  if [[ ${major} -ne 0 ]]; then
+    [[ ${major} -gt 0 ]] && echo -n ">" || echo -n "<"
+  else
+    (( minor=${actual_semver_parts[1]:-0} - ${required_semver_parts[1]:-0} ))
+    if [[ ${minor} -ne 0 ]]; then
+      [[ ${minor} -gt 0 ]] && echo -n ">" || echo -n "<"
+    else
+      (( patch=${actual_semver_parts[2]:-0} - ${required_semver_parts[2]:-0} ))
+			# shellcheck disable=SC2015
+      [[ ${patch} -gt 0 ]] && echo -n ">" || ( [[ ${patch} -eq 0 ]] && echo -n "=" || echo -n "<" )
+    fi
+  fi
+}

--- a/util/common_utils.sh
+++ b/util/common_utils.sh
@@ -22,43 +22,43 @@ readonly target_template_dir="${target_path}/template_samples"
 # Note: The error is prefixed with "ERROR: " and is sent to STDOUT, not STDERR
 function continue_or_error_and_exit()
 {
-  local status_code=$1
-  local error_message="$2"
+	local status_code=$1
+	local error_message="$2"
 
-  ((status_code != 0)) && { error_and_exit "${error_message}"; }
+	((status_code != 0)) && { error_and_exit "${error_message}"; }
 
-  return "${status_code}"
+	return "${status_code}"
 }
 
 
 function error_and_exit()
 {
-  local error_message="$1"
+	local error_message="$1"
 
-  printf "%s\n" "ERROR: ${error_message}" >&2
-  exit 1
+	printf "%s\n" "ERROR: ${error_message}" >&2
+	exit 1
 }
 
 
 function check_file_exists()
 {
-  local file_path="$1"
+	local file_path="$1"
 
-  if [ ! -f "${file_path}" ]; then
-    error_and_exit "File ${file_path} does not exist"
-  fi
+	if [ ! -f "${file_path}" ]; then
+		error_and_exit "File ${file_path} does not exist"
+	fi
 }
 
 
 # This function pretty prints all the currently available template file names
 function print_allowed_json_template_names()
 {
-  local target_dir="$1"
+	local target_dir="$1"
 
-  # list JSON files in the templates dir
-  # filter the output of 'find' to extract just the filenames without extensions
-  # prefix the results with indents and hyphen bullets
-  find "${target_dir}" -name '*.json' | sed -e 's/.*\/\(.*\)\.json/  - \1/'
+	# list JSON files in the templates dir
+	# filter the output of 'find' to extract just the filenames without extensions
+	# prefix the results with indents and hyphen bullets
+	find "${target_dir}" -name '*.json' | sed -e 's/.*\/\(.*\)\.json/  - \1/'
 }
 
 
@@ -66,24 +66,24 @@ function print_allowed_json_template_names()
 # If the command is not installed, then it will exit with an appropriate error and the given advice
 function check_command_installed()
 {
-  local cmd="$1"
-  local advice="$2"
+	local cmd="$1"
+	local advice="$2"
 
-  # disable exit on error throughout this section as it's designed to fail
-  # when cmd is not installed
-  set +e
-  local is_cmd_installed
-  command -v "${cmd}" > /dev/null
-  is_cmd_installed=$?
-  set -e
+	# disable exit on error throughout this section as it's designed to fail
+	# when cmd is not installed
+	set +e
+	local is_cmd_installed
+	command -v "${cmd}" > /dev/null
+	is_cmd_installed=$?
+	set -e
 
-  local error="This script depends on the '${cmd}' command being installed"
-  # append advice if any was provided
-  if [[ "${advice}" != "" ]]; then
-    error="${error} (${advice})"
-  fi
+	local error="This script depends on the '${cmd}' command being installed"
+	# append advice if any was provided
+	if [[ "${advice}" != "" ]]; then
+		error="${error} (${advice})"
+	fi
 
-  continue_or_error_and_exit ${is_cmd_installed} "${error}"
+	continue_or_error_and_exit ${is_cmd_installed} "${error}"
 }
 
 
@@ -91,27 +91,27 @@ function check_command_installed()
 # Note: It uses the `jq` command line tool, and will fail with a helpful error if the tool is not installed.
 function edit_json_template_for_path()
 {
-  local json_path="$1"
-  local json_value="$2"
-  local json_template_name="$3"
-  local target_json="${target_template_dir}/${json_template_name}.json"
-  local temp_template_json="${target_json}.tmp"
+	local json_path="$1"
+	local json_value="$2"
+	local json_template_name="$3"
+	local target_json="${target_template_dir}/${json_template_name}.json"
+	local temp_template_json="${target_json}.tmp"
 
-  check_file_exists "${target_json}"
+	check_file_exists "${target_json}"
 
-  check_command_installed 'jq' 'Try: https://stedolan.github.io/jq/download/'
+	check_command_installed 'jq' 'Try: https://stedolan.github.io/jq/download/'
 
-  # this is the JSON path in jq format
-  # in the future we could call a function here to translate simple dot-based paths into jq format paths
-  # For example: Translate 'infrastructure.resource_group.name' to '"infrastructure", "resource_group", "name"'
-  local jq_json_path="${json_path}"
-  local jq_command="jq --arg value ${json_value} 'setpath([${jq_json_path}]; \$value)' ${target_json}"
+	# this is the JSON path in jq format
+	# in the future we could call a function here to translate simple dot-based paths into jq format paths
+	# For example: Translate 'infrastructure.resource_group.name' to '"infrastructure", "resource_group", "name"'
+	local jq_json_path="${json_path}"
+	local jq_command="jq --arg value ${json_value} 'setpath([${jq_json_path}]; \$value)' ${target_json}"
 
-  # edit JSON template file contents and write to temp file
-  eval "${jq_command}" > "${temp_template_json}"
+	# edit JSON template file contents and write to temp file
+	eval "${jq_command}" > "${temp_template_json}"
 
-  # replace original JSON template file with temporary edited one
-  mv "${temp_template_json}" "${target_json}"
+	# replace original JSON template file with temporary edited one
+	mv "${temp_template_json}" "${target_json}"
 }
 
 # This function is used to compare semver strings
@@ -120,23 +120,23 @@ function edit_json_template_for_path()
 # It echos ">" if string1 > string2, "=" if string1 == string2 and "<" if string1 < string2
 function test_semver()
 {
-  local actual_semver="$1"
-  local required_semver="$2"
+	local actual_semver="$1"
+	local required_semver="$2"
 
-  IFS=. read -r -a actual_semver_parts <<< "${actual_semver}"
-  IFS=. read -r -a required_semver_parts <<< "${required_semver}"
+	IFS=. read -r -a actual_semver_parts <<< "${actual_semver}"
+	IFS=. read -r -a required_semver_parts <<< "${required_semver}"
 
-  (( major=${actual_semver_parts[0]:-0} - ${required_semver_parts[0]:-0} ))
-  if [[ ${major} -ne 0 ]]; then
-    [[ ${major} -gt 0 ]] && echo -n ">" || echo -n "<"
-  else
-    (( minor=${actual_semver_parts[1]:-0} - ${required_semver_parts[1]:-0} ))
-    if [[ ${minor} -ne 0 ]]; then
-      [[ ${minor} -gt 0 ]] && echo -n ">" || echo -n "<"
-    else
-      (( patch=${actual_semver_parts[2]:-0} - ${required_semver_parts[2]:-0} ))
-      # shellcheck disable=SC2015
-      [[ ${patch} -gt 0 ]] && echo -n ">" || ( [[ ${patch} -eq 0 ]] && echo -n "=" || echo -n "<" )
-    fi
-  fi
+	(( major=${actual_semver_parts[0]:-0} - ${required_semver_parts[0]:-0} ))
+	if [[ ${major} -ne 0 ]]; then
+		[[ ${major} -gt 0 ]] && echo -n ">" || echo -n "<"
+	else
+		(( minor=${actual_semver_parts[1]:-0} - ${required_semver_parts[1]:-0} ))
+		if [[ ${minor} -ne 0 ]]; then
+			[[ ${minor} -gt 0 ]] && echo -n ">" || echo -n "<"
+		else
+			(( patch=${actual_semver_parts[2]:-0} - ${required_semver_parts[2]:-0} ))
+			# shellcheck disable=SC2015
+			[[ ${patch} -gt 0 ]] && echo -n ">" || ( [[ ${patch} -eq 0 ]] && echo -n "=" || echo -n "<" )
+		fi
+	fi
 }

--- a/util/common_utils.sh
+++ b/util/common_utils.sh
@@ -22,43 +22,43 @@ readonly target_template_dir="${target_path}/template_samples"
 # Note: The error is prefixed with "ERROR: " and is sent to STDOUT, not STDERR
 function continue_or_error_and_exit()
 {
-	local status_code=$1
-	local error_message="$2"
+  local status_code=$1
+  local error_message="$2"
 
-	((status_code != 0)) && { error_and_exit "${error_message}"; }
+  ((status_code != 0)) && { error_and_exit "${error_message}"; }
 
-	return "${status_code}"
+  return "${status_code}"
 }
 
 
 function error_and_exit()
 {
-	local error_message="$1"
+  local error_message="$1"
 
-	printf "%s\n" "ERROR: ${error_message}" >&2
-	exit 1
+  printf "%s\n" "ERROR: ${error_message}" >&2
+  exit 1
 }
 
 
 function check_file_exists()
 {
-	local file_path="$1"
+  local file_path="$1"
 
-	if [ ! -f "${file_path}" ]; then
-		error_and_exit "File ${file_path} does not exist"
-	fi
+  if [ ! -f "${file_path}" ]; then
+    error_and_exit "File ${file_path} does not exist"
+  fi
 }
 
 
 # This function pretty prints all the currently available template file names
 function print_allowed_json_template_names()
 {
-	local target_dir="$1"
+  local target_dir="$1"
 
-	# list JSON files in the templates dir
-	# filter the output of 'find' to extract just the filenames without extensions
-	# prefix the results with indents and hyphen bullets
-	find "${target_dir}" -name '*.json' | sed -e 's/.*\/\(.*\)\.json/  - \1/'
+  # list JSON files in the templates dir
+  # filter the output of 'find' to extract just the filenames without extensions
+  # prefix the results with indents and hyphen bullets
+  find "${target_dir}" -name '*.json' | sed -e 's/.*\/\(.*\)\.json/  - \1/'
 }
 
 
@@ -66,24 +66,24 @@ function print_allowed_json_template_names()
 # If the command is not installed, then it will exit with an appropriate error and the given advice
 function check_command_installed()
 {
-	local cmd="$1"
-	local advice="$2"
+  local cmd="$1"
+  local advice="$2"
 
-	# disable exit on error throughout this section as it's designed to fail
-	# when cmd is not installed
-	set +e
-	local is_cmd_installed
-	command -v "${cmd}" > /dev/null
-	is_cmd_installed=$?
-	set -e
+  # disable exit on error throughout this section as it's designed to fail
+  # when cmd is not installed
+  set +e
+  local is_cmd_installed
+  command -v "${cmd}" > /dev/null
+  is_cmd_installed=$?
+  set -e
 
-	local error="This script depends on the '${cmd}' command being installed"
-	# append advice if any was provided
-	if [[ "${advice}" != "" ]]; then
-		error="${error} (${advice})"
-	fi
+  local error="This script depends on the '${cmd}' command being installed"
+  # append advice if any was provided
+  if [[ "${advice}" != "" ]]; then
+    error="${error} (${advice})"
+  fi
 
-	continue_or_error_and_exit ${is_cmd_installed} "${error}"
+  continue_or_error_and_exit ${is_cmd_installed} "${error}"
 }
 
 
@@ -91,27 +91,27 @@ function check_command_installed()
 # Note: It uses the `jq` command line tool, and will fail with a helpful error if the tool is not installed.
 function edit_json_template_for_path()
 {
-	local json_path="$1"
-	local json_value="$2"
-	local json_template_name="$3"
-	local target_json="${target_template_dir}/${json_template_name}.json"
-	local temp_template_json="${target_json}.tmp"
+  local json_path="$1"
+  local json_value="$2"
+  local json_template_name="$3"
+  local target_json="${target_template_dir}/${json_template_name}.json"
+  local temp_template_json="${target_json}.tmp"
 
-	check_file_exists "${target_json}"
+  check_file_exists "${target_json}"
 
-	check_command_installed 'jq' 'Try: https://stedolan.github.io/jq/download/'
+  check_command_installed 'jq' 'Try: https://stedolan.github.io/jq/download/'
 
-	# this is the JSON path in jq format
-	# in the future we could call a function here to translate simple dot-based paths into jq format paths
-	# For example: Translate 'infrastructure.resource_group.name' to '"infrastructure", "resource_group", "name"'
-	local jq_json_path="${json_path}"
-	local jq_command="jq --arg value ${json_value} 'setpath([${jq_json_path}]; \$value)' ${target_json}"
+  # this is the JSON path in jq format
+  # in the future we could call a function here to translate simple dot-based paths into jq format paths
+  # For example: Translate 'infrastructure.resource_group.name' to '"infrastructure", "resource_group", "name"'
+  local jq_json_path="${json_path}"
+  local jq_command="jq --arg value ${json_value} 'setpath([${jq_json_path}]; \$value)' ${target_json}"
 
-	# edit JSON template file contents and write to temp file
-	eval "${jq_command}" > "${temp_template_json}"
+  # edit JSON template file contents and write to temp file
+  eval "${jq_command}" > "${temp_template_json}"
 
-	# replace original JSON template file with temporary edited one
-	mv "${temp_template_json}" "${target_json}"
+  # replace original JSON template file with temporary edited one
+  mv "${temp_template_json}" "${target_json}"
 }
 
 # This function is used to compare semver strings
@@ -135,7 +135,7 @@ function test_semver()
       [[ ${minor} -gt 0 ]] && echo -n ">" || echo -n "<"
     else
       (( patch=${actual_semver_parts[2]:-0} - ${required_semver_parts[2]:-0} ))
-			# shellcheck disable=SC2015
+      # shellcheck disable=SC2015
       [[ ${patch} -gt 0 ]] && echo -n ">" || ( [[ ${patch} -eq 0 ]] && echo -n "=" || echo -n "<" )
     fi
   fi

--- a/util/sap_os_offers.json
+++ b/util/sap_os_offers.json
@@ -1,0 +1,22 @@
+{
+  "sles": {
+    "publisher": "suse",
+    "offer": "sles-sap-12-sp5",
+    "sku": "gen1"
+  },
+  "sles12sp5": {
+    "publisher": "suse",
+    "offer": "sles-sap-12-sp5",
+    "sku": "gen1"
+  },
+  "rhel": {
+    "publisher": "RedHat",
+    "offer": "RHEL-SAP-HA",
+    "sku": "7.6"
+  },
+  "redhat76": {
+    "publisher": "RedHat",
+    "offer": "RHEL-SAP-HA",
+    "sku": "7.6"
+  }
+}

--- a/util/set_sap_os.sh
+++ b/util/set_sap_os.sh
@@ -73,7 +73,7 @@ function list_available_offers()
 
 function edit_json_template_for_sap_os()
 {
-  local sap_os="$(echo $1 | tr '[A-Z]' '[a-z]')"
+  local sap_os="$(echo $1 | tr '[:upper:]' '[:lower:]')"
   local json_template_name="$2"
   local target_json="${target_template_dir}/${json_template_name}.json"
   local temp_template_json="${target_json}.tmp"

--- a/util/set_sap_os.sh
+++ b/util/set_sap_os.sh
@@ -73,17 +73,17 @@ function list_available_offers()
 
 function edit_json_template_for_sap_os()
 {
-  local sap_os="$1"
+  local sap_os="$(echo $1 | tr '[A-Z]' '[a-z]')"
   local json_template_name="$2"
   local target_json="${target_template_dir}/${json_template_name}.json"
   local temp_template_json="${target_json}.tmp"
 
   # This sets stored values from the sap_os_offers.json
   # Check if the passed in value is known
-  if list_available_offers | grep -q "^  - ${sap_os,,}$" 2>/dev/null; then
-    local sap_os_publisher=$(jq ".${sap_os,,}.publisher" "${list_of_offers}")
-    local sap_os_offer=$(jq ".${sap_os,,}.offer" "${list_of_offers}")
-    local sap_os_sku=$(jq ".${sap_os,,}.sku" "${list_of_offers}")
+  if list_available_offers | grep -q "^  - ${sap_os}$" 2>/dev/null; then
+    local sap_os_publisher=$(jq ".${sap_os}.publisher" "${list_of_offers}")
+    local sap_os_offer=$(jq ".${sap_os}.offer" "${list_of_offers}")
+    local sap_os_sku=$(jq ".${sap_os}.sku" "${list_of_offers}")
 
   else
     # Passed in value is unknown

--- a/util/set_sap_os.sh
+++ b/util/set_sap_os.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+
+###############################################################################
+#
+# Purpose:
+# This script simplifies the user interaction with the JSON input templates so
+# the user does not need to manually edit JSON files when configuring the
+# required OS for their SAP HANA VMs.
+#
+###############################################################################
+
+# exit immediately if a command fails
+set -o errexit
+
+# exit immediately if an unset variable is used
+set -o nounset
+
+# import common functions that are reused across scripts
+# shellcheck disable=SC1091
+source util/common_utils.sh
+
+readonly list_of_offers=$(dirname "$0")/sap_os_offers.json
+
+function main()
+{
+  check_command_line_arguments "$@"
+
+  local sap_os="$1"
+  local template_name="$2"
+
+  edit_json_template_for_sap_os "${sap_os}" "${template_name}"
+}
+
+
+function check_command_line_arguments()
+{
+  local args_count=$#
+  local usage="Usage: ${0} \"<SAP OS offer>\" \"<template name>\""
+
+  # Check there are just two arguments provided
+  if [[ ${args_count} -ne 2 ]]; then
+    echo "${usage}"
+    echo
+    echo "Available SAP OS offers:"
+    list_available_offers
+    echo
+    echo "Available Templates:"
+    list_available_templates
+    echo
+    if [[ ${args_count} -eq 0 ]]; then
+      # No arguments: just show the help and exit gracefully
+      exit
+    else
+      # Incorrect number of arguments
+      error_and_exit "${usage}"
+    fi
+  fi
+}
+
+
+function list_available_templates()
+{
+  # shellcheck disable=SC2154
+  print_allowed_json_template_names "${target_template_dir}" | grep 'hana'
+}
+
+
+function list_available_offers()
+{
+  jq 'keys_unsorted' "${list_of_offers}" | sed -n -e '/[a-zA-Z]/s/^[^"]*"\([^"]*\).*/  - \1/gp'
+}
+
+
+function edit_json_template_for_sap_os()
+{
+  local sap_os="$1"
+  local json_template_name="$2"
+  local target_json="${target_template_dir}/${json_template_name}.json"
+  local temp_template_json="${target_json}.tmp"
+
+  # This sets stored values from the sap_os_offers.json
+  # Check if the passed in value is known
+  if list_available_offers | grep -q "^  - ${sap_os,,}$" 2>/dev/null; then
+    local sap_os_publisher=$(jq ".${sap_os,,}.publisher" "${list_of_offers}")
+    local sap_os_offer=$(jq ".${sap_os,,}.offer" "${list_of_offers}")
+    local sap_os_sku=$(jq ".${sap_os,,}.sku" "${list_of_offers}")
+
+  else
+    # Passed in value is unknown
+    echo "Available SAP OS offers:"
+    list_available_offers
+    error_and_exit "${sap_os} is not a recognised SAP OS offer"
+  fi
+
+  # Ensure the template name is known
+  if ! list_available_templates | grep -q "^  - ${json_template_name}$" 2>/dev/null; then
+    echo "Available Templates:"
+    list_available_templates
+    echo
+    error_and_exit "${json_template_name} is not a recognised template"
+  fi
+
+  # We need the jq "walk" function from v1.6: https://stedolan.github.io/jq/manual/#walk(f)
+  local jq_version=$(jq --version | cut -f2 -d-)
+  local jq_def_walk
+  if [[ $(test_semver "${jq_version}" "1.6") == "<" ]]; then
+    # Build it by hand if jq is pre-1.6
+    # https://github.com/stedolan/jq/blob/ccc79e592cfe1172db5f2def5a24c2f7cfd418bf/src/builtin.jq#L255-L262
+    jq_def_walk='def walk(f):
+      . as $in | if type == "object" then
+        reduce keys_unsorted[] as $key ( {}; . + { ($key): ($in[$key] | walk(f)) } ) | f
+      elif type == "array" then map( walk(f) ) | f
+      else f end;'
+  else
+    jq_def_walk=""
+  fi
+
+  # Always set new values, regardless of any values already present
+  # Using the "walk" function, follow the JSON tree looking for arrays
+  # When an array is found, map each element. For each element:
+  #   If it contains a "platform" property with the value "HANA", then:
+  #    If it has an "os" property having a "publisher"/"offer"/"sku" property, then:
+  #      Replace the value of the appropriate property.
+  jq "${jq_def_walk}
+      walk(if type == \"array\" then
+        map(select(.platform? == \"HANA\") .os?={
+            publisher: ${sap_os_publisher},
+            offer: ${sap_os_offer},
+            sku: ${sap_os_sku} } )
+        else . end)" ${target_json} >${temp_template_json} && mv ${temp_template_json} ${target_json}
+}
+
+# Execute the main program flow with all arguments
+main "$@"

--- a/util/set_sap_os.sh
+++ b/util/set_sap_os.sh
@@ -23,117 +23,117 @@ readonly list_of_offers=$(dirname "$0")/sap_os_offers.json
 
 function main()
 {
-  check_command_line_arguments "$@"
+	check_command_line_arguments "$@"
 
-  local sap_os="$1"
-  local template_name="$2"
+	local sap_os="$1"
+	local template_name="$2"
 
-  edit_json_template_for_sap_os "${sap_os}" "${template_name}"
+	edit_json_template_for_sap_os "${sap_os}" "${template_name}"
 }
 
 
 function check_command_line_arguments()
 {
-  local args_count=$#
-  local usage="Usage: ${0} \"<SAP OS offer>\" \"<template name>\""
+	local args_count=$#
+	local usage="Usage: ${0} \"<SAP OS offer>\" \"<template name>\""
 
-  # Check there are just two arguments provided
-  if [[ ${args_count} -ne 2 ]]; then
-    echo "${usage}"
-    echo
-    echo "Available SAP OS offers:"
-    list_available_offers
-    echo
-    echo "Available Templates:"
-    list_available_templates
-    echo
-    if [[ ${args_count} -eq 0 ]]; then
-      # No arguments: just show the help and exit gracefully
-      exit
-    else
-      # Incorrect number of arguments
-      error_and_exit "${usage}"
-    fi
-  fi
+	# Check there are just two arguments provided
+	if [[ ${args_count} -ne 2 ]]; then
+		echo "${usage}"
+		echo
+		echo "Available SAP OS offers:"
+		list_available_offers
+		echo
+		echo "Available Templates:"
+		list_available_templates
+		echo
+		if [[ ${args_count} -eq 0 ]]; then
+			# No arguments: just show the help and exit gracefully
+			exit
+		else
+			# Incorrect number of arguments
+			error_and_exit "${usage}"
+		fi
+	fi
 }
 
 
 function list_available_templates()
 {
-  # shellcheck disable=SC2154
-  print_allowed_json_template_names "${target_template_dir}" | grep 'hana'
+	# shellcheck disable=SC2154
+	print_allowed_json_template_names "${target_template_dir}" | grep 'hana'
 }
 
 
 function list_available_offers()
 {
-  jq 'keys_unsorted' "${list_of_offers}" | sed -n -e '/[a-zA-Z]/s/^[^"]*"\([^"]*\).*/  - \1/gp'
+	jq 'keys_unsorted' "${list_of_offers}" | sed -n -e '/[a-zA-Z]/s/^[^"]*"\([^"]*\).*/  - \1/gp'
 }
 
 
 function edit_json_template_for_sap_os()
 {
-  local sap_os
-  sap_os="$(echo "$1" | tr '[:upper:]' '[:lower:]')"
-  local json_template_name="$2"
-  local target_json="${target_template_dir}/${json_template_name}.json"
-  local temp_template_json="${target_json}.tmp"
+	local sap_os
+	sap_os="$(echo "$1" | tr '[:upper:]' '[:lower:]')"
+	local json_template_name="$2"
+	local target_json="${target_template_dir}/${json_template_name}.json"
+	local temp_template_json="${target_json}.tmp"
 
-  # This sets stored values from the sap_os_offers.json
-  # Check if the passed in value is known
-  if list_available_offers | grep -q "^  - ${sap_os}$" 2>/dev/null; then
-    local sap_os_publisher
-    local sap_os_offer
-    local sap_os_sku
-    sap_os_publisher=$(jq ".${sap_os}.publisher" "${list_of_offers}")
-    sap_os_offer=$(jq ".${sap_os}.offer" "${list_of_offers}")
-    sap_os_sku=$(jq ".${sap_os}.sku" "${list_of_offers}")
+	# This sets stored values from the sap_os_offers.json
+	# Check if the passed in value is known
+	if list_available_offers | grep -q "^  - ${sap_os}$" 2>/dev/null; then
+		local sap_os_publisher
+		local sap_os_offer
+		local sap_os_sku
+		sap_os_publisher=$(jq ".${sap_os}.publisher" "${list_of_offers}")
+		sap_os_offer=$(jq ".${sap_os}.offer" "${list_of_offers}")
+		sap_os_sku=$(jq ".${sap_os}.sku" "${list_of_offers}")
 
-  else
-    # Passed in value is unknown
-    echo "Available SAP OS offers:"
-    list_available_offers
-    error_and_exit "${sap_os} is not a recognised SAP OS offer"
-  fi
+	else
+		# Passed in value is unknown
+		echo "Available SAP OS offers:"
+		list_available_offers
+		error_and_exit "${sap_os} is not a recognised SAP OS offer"
+	fi
 
-  # Ensure the template name is known
-  if ! list_available_templates | grep -q "^  - ${json_template_name}$" 2>/dev/null; then
-    echo "Available Templates:"
-    list_available_templates
-    echo
-    error_and_exit "${json_template_name} is not a recognised template"
-  fi
+	# Ensure the template name is known
+	if ! list_available_templates | grep -q "^  - ${json_template_name}$" 2>/dev/null; then
+		echo "Available Templates:"
+		list_available_templates
+		echo
+		error_and_exit "${json_template_name} is not a recognised template"
+	fi
 
-  # We need the jq "walk" function from v1.6: https://stedolan.github.io/jq/manual/#walk(f)
-  local jq_version
-  jq_version=$(jq --version | cut -f2 -d-)
-  local jq_def_walk
-  if [[ $(test_semver "${jq_version}" "1.6") == "<" ]]; then
-    # Build it by hand if jq is pre-1.6
-    # https://github.com/stedolan/jq/blob/ccc79e592cfe1172db5f2def5a24c2f7cfd418bf/src/builtin.jq#L255-L262
-    # shellcheck disable=2016
-    jq_def_walk='def walk(f):
-      . as $in | if type == "object" then
-        reduce keys_unsorted[] as $key ( {}; . + { ($key): ($in[$key] | walk(f)) } ) | f
-      elif type == "array" then map( walk(f) ) | f
-      else f end;'
-  else
-    jq_def_walk=""
-  fi
+	# We need the jq "walk" function from v1.6: https://stedolan.github.io/jq/manual/#walk(f)
+	local jq_version
+	jq_version=$(jq --version | cut -f2 -d-)
+	local jq_def_walk
+	if [[ $(test_semver "${jq_version}" "1.6") == "<" ]]; then
+		# Build it by hand if jq is pre-1.6
+		# https://github.com/stedolan/jq/blob/ccc79e592cfe1172db5f2def5a24c2f7cfd418bf/src/builtin.jq#L255-L262
+		# shellcheck disable=2016
+		jq_def_walk='def walk(f):
+			. as $in | if type == "object" then
+				reduce keys_unsorted[] as $key ( {}; . + { ($key): ($in[$key] | walk(f)) } ) | f
+			elif type == "array" then map( walk(f) ) | f
+			else f end;'
+	else
+		jq_def_walk=""
+	fi
 
-  # Always set new values, regardless of any values already present
-  # Using the "walk" function, follow the JSON tree looking for arrays
-  # When an array is found, map each element. For each element:
-  #   If it contains a "platform" property with the value "HANA", then:
-  #    If it has an "os" property having a "publisher"/"offer"/"sku" property, then:
-  #      Replace the value of the appropriate property.
-  jq "${jq_def_walk}
-      walk(if type == \"array\" then
-        map(select(.platform? == \"HANA\") .os?={
-            publisher: ${sap_os_publisher},
-            offer: ${sap_os_offer},
-            sku: ${sap_os_sku} } )
-        else . end)" "${target_json}" >"${temp_template_json}" && mv "${temp_template_json}" "${target_json}"
+	# Always set new values, regardless of any values already present
+	# Using the "walk" function, follow the JSON tree looking for arrays
+	# When an array is found, map each element. For each element:
+	#   If it contains a "platform" property with the value "HANA", then:
+	#    If it has an "os" property having a "publisher"/"offer"/"sku" property, then:
+	#      Replace the value of the appropriate property.
+	jq "${jq_def_walk}
+			walk(if type == \"array\" then
+				map(select(.platform? == \"HANA\") .os?={
+						publisher: ${sap_os_publisher},
+						offer: ${sap_os_offer},
+						sku: ${sap_os_sku} } )
+				else . end)" "${target_json}" >"${temp_template_json}" && mv "${temp_template_json}" "${target_json}"
 }
 
 # Execute the main program flow with all arguments

--- a/util/set_sap_os.sh
+++ b/util/set_sap_os.sh
@@ -73,7 +73,8 @@ function list_available_offers()
 
 function edit_json_template_for_sap_os()
 {
-  local sap_os="$(echo $1 | tr '[:upper:]' '[:lower:]')"
+  local sap_os
+  sap_os="$(echo "$1" | tr '[:upper:]' '[:lower:]')"
   local json_template_name="$2"
   local target_json="${target_template_dir}/${json_template_name}.json"
   local temp_template_json="${target_json}.tmp"
@@ -81,9 +82,12 @@ function edit_json_template_for_sap_os()
   # This sets stored values from the sap_os_offers.json
   # Check if the passed in value is known
   if list_available_offers | grep -q "^  - ${sap_os}$" 2>/dev/null; then
-    local sap_os_publisher=$(jq ".${sap_os}.publisher" "${list_of_offers}")
-    local sap_os_offer=$(jq ".${sap_os}.offer" "${list_of_offers}")
-    local sap_os_sku=$(jq ".${sap_os}.sku" "${list_of_offers}")
+    local sap_os_publisher
+    local sap_os_offer
+    local sap_os_sku
+    sap_os_publisher=$(jq ".${sap_os}.publisher" "${list_of_offers}")
+    sap_os_offer=$(jq ".${sap_os}.offer" "${list_of_offers}")
+    sap_os_sku=$(jq ".${sap_os}.sku" "${list_of_offers}")
 
   else
     # Passed in value is unknown
@@ -101,11 +105,13 @@ function edit_json_template_for_sap_os()
   fi
 
   # We need the jq "walk" function from v1.6: https://stedolan.github.io/jq/manual/#walk(f)
-  local jq_version=$(jq --version | cut -f2 -d-)
+  local jq_version
+  jq_version=$(jq --version | cut -f2 -d-)
   local jq_def_walk
   if [[ $(test_semver "${jq_version}" "1.6") == "<" ]]; then
     # Build it by hand if jq is pre-1.6
     # https://github.com/stedolan/jq/blob/ccc79e592cfe1172db5f2def5a24c2f7cfd418bf/src/builtin.jq#L255-L262
+    # shellcheck disable=2016
     jq_def_walk='def walk(f):
       . as $in | if type == "object" then
         reduce keys_unsorted[] as $key ( {}; . + { ($key): ($in[$key] | walk(f)) } ) | f
@@ -127,7 +133,7 @@ function edit_json_template_for_sap_os()
             publisher: ${sap_os_publisher},
             offer: ${sap_os_offer},
             sku: ${sap_os_sku} } )
-        else . end)" ${target_json} >${temp_template_json} && mv ${temp_template_json} ${target_json}
+        else . end)" "${target_json}" >"${temp_template_json}" && mv "${temp_template_json}" "${target_json}"
 }
 
 # Execute the main program flow with all arguments


### PR DESCRIPTION
## Problem

- Closes #434
- Closes #416
- Closes #423

## Description

This PR:

- Sets `enable_https_traffic_only = true` as documented in #434.
- Updates the `single_node_hana` template to use the latest SLES image (#416).
- Adds a new `test_semver` function to `util/common_utils.sh` to enable easy version checking.
- Adds a new `util/set_sap_os.sh` script to configure the `input.json` with the required OS image for HANA VMs (#423).
- Adds a new `util/sap_os_offers.json` file containing a dictionary of suitable images (SLES and Red Hat) for provisioning HANA VMs.
- Documents the new functionality.

## Pre-Requisites

None.

## Commitment to Test

- Testing takes about 5 minutes. It's not necessary to build infrastructure.
- Review changed files.

## Test Instructions / Acceptance Criteria

- [ ] Confirm the `enable_https_traffic_only` changes at <https://github.com/Azure/sap-hana/blob/5404c340bc0c46bc4d9aac21c39ca394caae02bb/deploy/v2/terraform/modules/common_infrastructure/infrastructure.tf#L195> and <https://github.com/Azure/sap-hana/blob/5404c340bc0c46bc4d9aac21c39ca394caae02bb/deploy/v2/terraform/modules/common_infrastructure/infrastructure.tf#L227>
- [ ] Confirm documentation changes make sense.
- [ ] Confirm that running `util/set_sap_os.sh` displays available options for SAP OS offers and templates:

  ```text
  Available SAP OS offers:
    - rhel
    - redhat76
    - sles
    - sles12sp5

  Available Templates:
    - single_node_hana
    - clustered_hana
    - clustered_hana_copy
  ```

- [ ] Confirm that running `util/set_sap_os.sh x y z` displays available options for SAP OS offers and templates, together with an error:

  ```text
  Usage: util/set_sap_os.sh "<SAP OS offer>" "<template name>"

  Available SAP OS offers:
    - rhel
    - redhat76
    - sles
    - sles12sp5

  Available Templates:
    - single_node_hana
    - clustered_hana
    - clustered_hana_copy

  ERROR: Usage: util/set_sap_os.sh "<SAP OS offer>" "<template name>"
  ```

- [ ] Confirm that running `util/set_sap_os.sh xxx clustered_hana` displays available options for SAP OS offers, together with an error:

  ```text
  Available SAP OS offers:
    - rhel
    - redhat76
    - sles
    - sles12sp5
  ERROR: xxx is not a recognised SAP OS offer
  ```

- [ ] Confirm that running `util/set_sap_os.sh rhel xxx` displays available options for templates, together with an error:

  ```text
  Available Templates:
    - single_node_hana
    - clustered_hana
    - clustered_hana_copy

  ERROR: xxx is not a recognised template
  ```

- [ ] Confirm the expected, unmodified OS values in `clustered_hana.json` with `grep -A6 platform.*HANA deploy/v2/template_samples/clustered_hana.json `:

  ```text
      "platform": "HANA",
      "db_version": "2.00.043",
      "os": {
        "publisher": "suse",
        "offer": "sles-sap-12-sp5",
        "sku": "gen1"
      },
  ```

- [ ] Confirm the OS values can be switched to Red Hat with `util/set_sap_os.sh redhat76 clustered_hana` followed by `grep -A6 platform.*HANA deploy/v2/template_samples/clustered_hana.json`:

  ```text
      "platform": "HANA",
      "db_version": "2.00.043",
      "os": {
        "publisher": "RedHat",
        "offer": "RHEL-SAP-HA",
        "sku": "76sapha-gen2"
      },
  ```

- [ ] Confirm that only the HANA VMs have been set with `grep -A3 publisher deploy/v2/template_samples/clustered_hana.json`:

  ```text
          "publisher": "MicrosoftWindowsServer",
          "offer": "WindowsServer",
          "sku": "2016-Datacenter"
        },
  --
          "publisher": "Canonical",
          "offer": "UbuntuServer",
          "sku": "16.04-LTS"
        },
  --
          "publisher": "Canonical",
          "offer": "UbuntuServer",
          "sku": "18.04-LTS"
        },
  --
        "publisher": "RedHat",
        "offer": "RHEL-SAP-HA",
        "sku": "76sapha-gen2"
      },
  ```

- [ ] Confirm the JSON passes validation by `jq` with `jq type deploy/v2/template_samples/clustered_hana.json`:

  ```text
  "object"
  ```
