### PR TITLE
Handling monitoring repo when large instance

### DIFF
--- a/deploy/v2/ansible/roles/enable-prometheus/tasks/main.yml
+++ b/deploy/v2/ansible/roles/enable-prometheus/tasks/main.yml
@@ -6,9 +6,16 @@
   set_fact:
     distro: "SLE_{{ ansible_facts['distribution_major_version'] }}_SP{{ ansible_facts['distribution_release'] }}"
 
-- name: Add repository
+- name: Check if server_monitoring.repo is present
+  stat:
+    path: /etc/zypp/repos.d/server_monitoring.repo
+  register: monitor_repo
+
+- name: Add monitoring repository if it does not exist 
   zypper_repository:
     repo: "https://download.opensuse.org/repositories/server:/monitoring/{{ distro }}/server:monitoring.repo"
+    state: present
+  when: monitor_repo.stat.exists == false
 
 - name: Install Prometheus with Node and HA Cluster exporters
   zypper:

--- a/deploy/v2/ansible/sap_playbook.yml
+++ b/deploy/v2/ansible/sap_playbook.yml
@@ -33,7 +33,8 @@
       when:
         - output.options.enable_prometheus == True
         - ansible_facts['distribution_file_variety'] == 'SUSE'
-        - ansible_facts['distribution_version'] is regex("(12.[3-4]|15.\d)")
+        - ansible_facts['distribution_version'] is regex("(12\.[3-5]|15\.\d)")
+        - hana_database.size != "LargeInstance"
 
 # Mount Azure File share on all linux jumpboxes including rti
 - hosts: localhost:jumpboxes_linux


### PR DESCRIPTION
1. Ignore enabling prometheus when it is large instance, because internet is not available for bare metal.
2. Fixes #411. ansible zypper_repository isn't providing idempotency. Adding pre-check is a workaround.
3. Update regex. Currently we want to support SUSE 12.3-12.5 and 15.x when enabling promtheus.