### PR TITLE
Add check of installation paths in Large Instance

### DIFF
--- a/deploy/v2/ansible/roles/os-disk-setup/tasks/installation_path_prechecks.yml
+++ b/deploy/v2/ansible/roles/os-disk-setup/tasks/installation_path_prechecks.yml
@@ -13,3 +13,10 @@
      path_status_flag: "{{ item.stat.exists }}"
   loop: "{{ path_status.results }}"
   when: item.stat.exists == False
+
+- name: Check the paths status in Large Instance
+  fail:
+    msg: "Not all paths are ready in Large Instance"
+  when: 
+    - hana_database.size == "LargeInstance"
+    - path_status_flag is defined

--- a/deploy/v2/ansible/roles/sap-media-download/tasks/main.yml
+++ b/deploy/v2/ansible/roles/sap-media-download/tasks/main.yml
@@ -6,7 +6,7 @@
 - name: Install unzip
   package: 
     name: unzip
-    state: latest
+    state: present
 
 # Explicitly install bs4 with python3
 - name: Install beautifulsoup4

--- a/deploy/v2/ansible/roles/sap-media-transfer/tasks/media_hanadbnode_copy.yml
+++ b/deploy/v2/ansible/roles/sap-media-transfer/tasks/media_hanadbnode_copy.yml
@@ -3,7 +3,7 @@
 - name: Install unzip
   package:
     name: unzip
-    state: latest
+    state: present
 
 - name: Check whether the installation media already exists and has been extracted
   stat: path={{ hana_software_loc }}


### PR DESCRIPTION
1. unzip is preinstalled on most images. No need to use the lastest version.
   And for Large Instance, there is no internet available, set state =
   latest may require downloading through internet.
2. Add check of paths status in Large Instance, if not all paths are
   ready, playbook fails instantly. Because there is nothing we can do
   if they are not ready.