### PR TITLE
Staging. Backlog: Copy XSA Key Files

### DIFF
--- a/deploy/v2/ansible/roles/hana-system-replication/tasks/copy_ssfs_key_path.yml
+++ b/deploy/v2/ansible/roles/hana-system-replication/tasks/copy_ssfs_key_path.yml
@@ -1,0 +1,38 @@
+---
+
+- name: Ensure the secondary node {{ ssfs_file_path }} file is backed up and removed
+  when: ansible_hostname != hana_database.nodes[0].dbname
+  block:
+
+    - name: Check {{ ssfs_file_path }} backup file exists on the secondary node
+      stat:
+        path: "{{ ssfs_file_path }}.bak"
+      register: ssfs_backup_result
+
+    - name: Ensure {{ ssfs_file_path }} file is backed up on the secondary node
+      file:
+        src: "{{ ssfs_file_path }}"
+        path: "{{ ssfs_file_path }}.bak"
+        state: hard
+      when: ssfs_backup_result.stat.exists == false
+
+    - name: Ensure original {{ ssfs_file_path }} file is removed from the secondary node
+      file:
+        path: "{{ ssfs_file_path }}"
+        state: absent
+
+- name: Ensure the primary node {{ ssfs_file_path }} file is placed on the secondary node
+  when: ansible_hostname == hana_database.nodes[1].dbname
+  block:
+
+    # Note that we use the IP of the primary node and not its hostname, because
+    # it appears that the RTI attempts to resolve the hostname itself and fails.
+
+    - name: Ensure the primary node {{ ssfs_file_path }} file is placed on the secondary node
+      synchronize:
+        set_remote_user: false
+        src: "{{ ssfs_file_path }}"
+        dest: "{{ ssfs_file_path }}"
+        mode: push
+        archive: true
+      delegate_to: "{{ hana_database.nodes[0].ip_admin_nic }}"

--- a/deploy/v2/ansible/roles/hana-system-replication/tasks/copy_ssfs_keys.yml
+++ b/deploy/v2/ansible/roles/hana-system-replication/tasks/copy_ssfs_keys.yml
@@ -9,61 +9,22 @@
       when: ansible_hostname != hana_database.nodes[0].dbname
       block:
 
-        - name: Check SSFS_{{ sid | upper }}.DAT backup file exists on the secondary node
-          stat:
-            path: "{{ path_ssfs_dat }}.bak"
-          register: dat_backup_result
+        - name: Ensure {{ path_ssfs_dat }} file is copied
+          import_tasks: copy_ssfs_key_path.yml
+          vars:
+            ssfs_file_path: "{{ path_ssfs_dat }}"
 
-        - name: Ensure SSFS_{{ sid | upper }}.DAT file is backed up on the secondary node
-          file:
-            src: "{{ path_ssfs_dat }}"
-            path: "{{ path_ssfs_dat }}.bak"
-            state: hard
-          when: dat_backup_result.stat.exists == false
+        - name: Ensure {{ path_ssfs_key }} file is copied
+          import_tasks: copy_ssfs_key_path.yml
+          vars:
+            ssfs_file_path: "{{ path_ssfs_key }}"
 
-        - name: Check SSFS_{{ sid | upper }}.KEY backup file exists on the secondary node
-          stat:
-            path: "{{ path_ssfs_key }}.bak"
-          register: key_backup_result
+        - name: Ensure {{ path_xsa_ssfs_dat }} file is copied
+          import_tasks: copy_ssfs_key_path.yml
+          vars:
+            ssfs_file_path: "{{ path_xsa_ssfs_dat }}"
 
-        - name: Ensure SSFS_{{ sid | upper }}.KEY file is backed up on the secondary node
-          file:
-            src: "{{ path_ssfs_key }}"
-            path: "{{ path_ssfs_key }}.bak"
-            state: hard
-          when: key_backup_result.stat.exists == false
-
-        - name: Ensure original SSFS_{{ sid | upper }}.DAT file is removed on the secondary node
-          file:
-            path: "{{ path_ssfs_dat }}"
-            state: absent
-
-        - name: Ensure original SSFS_{{ sid | upper }}.KEY file is removed on the secondary node
-          file:
-            path: "{{ path_ssfs_key }}"
-            state: absent
-
-    - name: Ensure the primary node SSFS files are placed on the secondary node
-      when: ansible_hostname == hana_database.nodes[1].dbname
-      block:
-
-        # Note that we use the IP of the primary node and not its hostname, because
-        # it appears that the RTI attempts to resolve the hostname itself and fails.
-
-        - name: Ensure the primary node SSFS_{{ sid | upper }}.DAT file is placed on the secondary node
-          synchronize:
-            set_remote_user: false
-            src: "{{ path_ssfs_dat }}"
-            dest: "{{ path_ssfs_dat }}"
-            mode: push
-            archive: true
-          delegate_to: "{{ hana_database.nodes[0].ip_admin_nic }}"
-
-        - name: Ensure the primary node SSFS_{{ sid | upper }}.KEY file is placed on the secondary node
-          synchronize:
-            set_remote_user: false
-            src: "{{ path_ssfs_key }}"
-            dest: "{{ path_ssfs_key }}"
-            mode: push
-            archive: true
-          delegate_to: "{{ hana_database.nodes[0].ip_admin_nic }}"
+        - name: Ensure {{ path_xsa_ssfs_key }} file is copied
+          import_tasks: copy_ssfs_key_path.yml
+          vars:
+            ssfs_file_path: "{{ path_xsa_ssfs_key }}"

--- a/deploy/v2/ansible/roles/hana-system-replication/tasks/main.yml
+++ b/deploy/v2/ansible/roles/hana-system-replication/tasks/main.yml
@@ -1,6 +1,7 @@
 ---
 
 - import_tasks: pre_checks.yml
+- import_tasks: set_runtime_path_facts.yml
 - import_tasks: set_trust_relationship.yml
 - import_tasks: copy_ssfs_keys.yml
 - import_tasks: create_hana_backup.yml

--- a/deploy/v2/ansible/roles/hana-system-replication/tasks/pre_checks.yml
+++ b/deploy/v2/ansible/roles/hana-system-replication/tasks/pre_checks.yml
@@ -18,7 +18,6 @@
       - "instance_number | trim | regex_search('^\\d\\d$') | length == 2"  # must be 2 digits <num><num>, e.g. 00, not 0 or a0
       - "hana_dir | trim | length != 0"
       - "sap_dir | trim | length != 0"
-      - "tmp_ssfs_dir | trim | length != 0"
 
 - name: Check that HANA was installed successfully and is running normally
   become_user: "{{ sid_admin_user }}"
@@ -72,19 +71,3 @@
   changed_when: false
   tags:
     - skip_ansible_lint
-
-- name: Ensure the Primary node SSFS files are present on the primary node
-  when: ansible_hostname == hana_database.nodes[0].dbname
-  block:
-
-    - name: Ensure the Primary node SSFS_{{ sid | upper }}.DAT file exists
-      stat:
-        path: "{{ path_ssfs_dat }}"
-      register: primary_dat_file_result
-      failed_when: primary_dat_file_result.failed
-
-    - name: Ensure the Primary node SSFS_{{ sid | upper }}.KEY file exists
-      stat:
-        path: "{{ path_ssfs_key }}"
-      register: primary_key_file_result
-      failed_when: primary_key_file_result.failed

--- a/deploy/v2/ansible/roles/hana-system-replication/tasks/set_runtime_path_facts.yml
+++ b/deploy/v2/ansible/roles/hana-system-replication/tasks/set_runtime_path_facts.yml
@@ -1,0 +1,36 @@
+---
+
+- name: Check runtime value of SAP global path
+  become_user: "{{ sid_admin_user }}"
+  shell: >
+    set -o pipefail && grep '^alias cdglo=' ~/.sapenv.sh | sed -e 's/^.* //' -e 's/$SAPSYSTEMNAME/{{ sid | upper }}/' -e "s/'//"
+  register: global_path_status
+  changed_when: false
+
+- name: Set SAP global directory fact
+  set_fact:
+    hana_global_dir: "{{ global_path_status.stdout_lines[0] }}"
+
+- name: Set associated SAP global directory facts
+  set_fact:
+    path_global_ini: "{{ hana_global_dir }}/hdb/custom/config/global.ini"
+    path_ssfs_dat: "{{ hana_global_dir }}/security/rsecssfs/data/SSFS_{{ sid | upper }}.DAT"
+    path_ssfs_key: "{{ hana_global_dir }}/security/rsecssfs/key/SSFS_{{ sid | upper }}.KEY"
+    path_xsa_ssfs_dat: "{{ hana_global_dir }}/xsa/security/ssfs/data/SSFS_{{ sid | upper }}.DAT"
+    path_xsa_ssfs_key: "{{ hana_global_dir }}/xsa/security/ssfs/key/SSFS_{{ sid | upper }}.KEY"
+
+- name: Ensure the Primary node SSFS files are present on the primary node
+  when: ansible_hostname == hana_database.nodes[0].dbname
+  block:
+
+    - name: Ensure the Primary node SSFS_{{ sid | upper }}.DAT file exists
+      stat:
+        path: "{{ path_ssfs_dat }}"
+      register: primary_dat_file_result
+      failed_when: primary_dat_file_result.failed
+
+    - name: Ensure the Primary node SSFS_{{ sid | upper }}.KEY file exists
+      stat:
+        path: "{{ path_ssfs_key }}"
+      register: primary_key_file_result
+      failed_when: primary_key_file_result.failed

--- a/deploy/v2/ansible/roles/hana-system-replication/vars/main.yml
+++ b/deploy/v2/ansible/roles/hana-system-replication/vars/main.yml
@@ -8,25 +8,13 @@
 hana_group: "sapsys"
 hana_dir: "/hana"
 sap_dir: "/usr/sap"
-tmp_ssfs_dir: "/tmp"
 
 sid_admin_user: "{{ sid | lower }}adm"
-
-hsr_dat_name: "SSFS_{{ sid | upper }}.DAT"
-hsr_key_name: "SSFS_{{ sid | upper }}.KEY"
-
-tmp_ssfs_dat: "{{ tmp_ssfs_dir }}/{{ hsr_dat_name }}"
-tmp_ssfs_key: "{{ tmp_ssfs_dir }}/{{ hsr_key_name }}"
 
 hana_data_dir: "{{ hana_dir }}/data"
 hana_backup_dir: "{{ hana_dir }}/backup"
 hana_shared_dir: "{{ hana_dir }}/shared"
-hana_global_dir: "{{ hana_shared_dir }}/{{ sid | upper }}/global"
 hana_instance_executable_dir: "{{ sap_dir }}/{{ sid | upper }}/HDB{{ instance_number }}/exe"
-
-path_ssfs_dat: "{{ hana_global_dir }}/security/rsecssfs/data/{{ hsr_dat_name }}"
-path_ssfs_key: "{{ hana_global_dir }}/security/rsecssfs/key/{{ hsr_key_name }}"
-path_global_ini: "{{ hana_global_dir }}/hdb/custom/config/global.ini"
 
 path_sys_rep_status: "{{ hana_instance_executable_dir }}/python_support/systemReplicationStatus.py"
 


### PR DESCRIPTION
* Add script to simplify checking workstation dependencies

* Add script to simplify checking current Azure subscription

* Add utils README to describe purpose and testing

* Add script to generate SP auth details and prevent them being committed to the repo

* Add new V2 usage guide and terraform scripting

* Add util script purposes and share common code throughout

* Add script to simplify setting SAP Launchpad credentials

* Fix minor typos in usage guide

* Correct grammar

Co-Authored-By: Rob Fallows <rfallows@centiq.co.uk>

* Correct grammar

Co-Authored-By: Rob Fallows <rfallows@centiq.co.uk>

* Update util/check_subscription.sh

Co-Authored-By: Rob Fallows <rfallows@centiq.co.uk>

* Correcting copypasta typos in the code

* Fix semantic version regex for Ubuntu

* Create service principal now handles failures better

* Add note on Windows support to USAGE doc

* Link to shellcheck website for reference

* Reorder USAGE's long-running tasks list to the order they occur

* Update USAGE for note regarding ansible running from the local workstation

* Simplify conditionals to use if statements

* Improve documetation around service principal creation with external link

* Switch create SP script to use heredoc

* Added link for reference to OSX sed differences

* Revert to basic bash printing to terminal

* remove unused variables

* move vars into runtime facts task

* Refactor to simplify and extend

* fix xsa ssfs key paths

* move code block

Co-authored-by: Ben Moss <bmoss@centiq.co.uk>