### PR TITLE
[CAYL] Improve stability of v2 azure pipeline

### DIFF
--- a/deploy/v2/terraform/ansible.tf
+++ b/deploy/v2/terraform/ansible.tf
@@ -1,4 +1,5 @@
 resource "null_resource" "ansible_playbook" {
+  count      = var.options.ansible_execution ? 1 : 0
   depends_on = [module.hdb_node.dbnode-data-disk-att, module.jumpbox.prepare-rti, module.jumpbox.vm-windows]
   connection {
     type        = "ssh"
@@ -17,7 +18,7 @@ resource "null_resource" "ansible_playbook" {
       "export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES",
       "export ANSIBLE_HOST_KEY_CHECKING=False",
       "source ~/export-clustering-sp-details.sh",
-      var.options.ansible_execution ? "ansible-playbook -i hosts ~/sap-hana/deploy/v2/ansible/sap_playbook.yml" : "ansible-playbook --version"
+      "ansible-playbook -i hosts ~/sap-hana/deploy/v2/ansible/sap_playbook.yml"
     ]
   }
 }

--- a/templates/ansible-deployment-steps-daily.yaml
+++ b/templates/ansible-deployment-steps-daily.yaml
@@ -14,12 +14,17 @@ parameters:
     testCaseName: ''
 steps:
   - script: |
+      az login --service-principal --user $(hana-pipeline-spn-id) --password  $(hana-pipeline-spn-pw) --tenant $(landscape-tenant) --output none
+      az network vnet subnet update -g ${{parameters.testCaseName}} -n subnet-mgmt --vnet-name vnet-mgmt --network-security-group nsg-mgmt --output none
+      echo "az network vnet subnet update -g ${{parameters.testCaseName}} -n subnet-mgmt --vnet-name vnet-mgmt --network-security-group nsg-mgmt"
+    displayName: 'Update NSG for subnet subnet-mgmt'
+  - script: |
       echo "Ansible Deployment in progress..."
       cd deploy/v2/ansible_config_files
       rti_user=$(cat output.json | jq -r '.jumpboxes.linux[] | select(.destroy_after_deploy == "true") | .authentication.username')
-      rti_public_ip=$(cat output.json | jq -r '.jumpboxes.linux[] | select(.destroy_after_deploy == "true") | .public_ip_address')     
-      ssh -i /tmp/sshkey -o StrictHostKeyChecking=no "${rti_user}"@"${rti_public_ip}" ansible-playbook --version
+      rti_public_ip=$(cat output.json | jq -r '.jumpboxes.linux[] | select(.destroy_after_deploy == "true") | .public_ip_address')
       ssh -i /tmp/sshkey -o StrictHostKeyChecking=no "${rti_user}"@"${rti_public_ip}" '
+      ansible-playbook --version
       export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
       export ANSIBLE_HOST_KEY_CHECKING=False
       source export-clustering-sp-details.sh

--- a/templates/ansible-deployment-steps-daily.yaml
+++ b/templates/ansible-deployment-steps-daily.yaml
@@ -16,7 +16,6 @@ steps:
   - script: |
       az login --service-principal --user $(hana-pipeline-spn-id) --password  $(hana-pipeline-spn-pw) --tenant $(landscape-tenant) --output none
       az network vnet subnet update -g ${{parameters.testCaseName}} -n subnet-mgmt --vnet-name vnet-mgmt --network-security-group nsg-mgmt --output none
-      echo "az network vnet subnet update -g ${{parameters.testCaseName}} -n subnet-mgmt --vnet-name vnet-mgmt --network-security-group nsg-mgmt"
     displayName: 'Update NSG for subnet subnet-mgmt'
   - script: |
       echo "Ansible Deployment in progress..."

--- a/templates/ansible-deployment-steps.yaml
+++ b/templates/ansible-deployment-steps.yaml
@@ -9,16 +9,19 @@ parameters:
     testCaseName: ''
 steps:
   - script: |
-      echo "Ansible Deployment in Progress..."
+      az login --service-principal --user $(hana-pipeline-spn-id) --password  $(hana-pipeline-spn-pw) --tenant $(landscape-tenant) --output none
+      az network vnet subnet update -g ${{parameters.testCaseName}} -n subnet-mgmt --vnet-name vnet-mgmt --network-security-group nsg-mgmt --output none
+      echo "az network vnet subnet update -g ${{parameters.testCaseName}} -n subnet-mgmt --vnet-name vnet-mgmt --network-security-group nsg-mgmt"
+    displayName: 'Update NSG for subnet subnet-mgmt'
+  - script: |
       cd deploy/v2/ansible_config_files
       rti_user=$(cat output.json | jq -r '.jumpboxes.linux[] | select(.destroy_after_deploy == "true") | .authentication.username')
-      rti_public_ip=$(cat output.json | jq -r '.jumpboxes.linux[] | select(.destroy_after_deploy == "true") | .public_ip_address')     
-      ssh -i /tmp/sshkey -o StrictHostKeyChecking=no "${rti_user}"@"${rti_public_ip}" << EOF
+      rti_public_ip=$(cat output.json | jq -r '.jumpboxes.linux[] | select(.destroy_after_deploy == "true") | .public_ip_address')      
+      ssh -i /tmp/sshkey -o StrictHostKeyChecking=no "${rti_user}"@"${rti_public_ip}" '
       ansible-playbook --version
       cd sap-hana
-      git checkout $(System.PullRequest.SourceBranch)      
-      EOF
-      ssh -i /tmp/sshkey -o StrictHostKeyChecking=no "${rti_user}"@"${rti_public_ip}" '
+      git checkout $(System.PullRequest.SourceBranch)
+      cd ~
       export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
       export ANSIBLE_HOST_KEY_CHECKING=False
       source export-clustering-sp-details.sh

--- a/templates/ansible-deployment-steps.yaml
+++ b/templates/ansible-deployment-steps.yaml
@@ -11,7 +11,6 @@ steps:
   - script: |
       az login --service-principal --user $(hana-pipeline-spn-id) --password  $(hana-pipeline-spn-pw) --tenant $(landscape-tenant) --output none
       az network vnet subnet update -g ${{parameters.testCaseName}} -n subnet-mgmt --vnet-name vnet-mgmt --network-security-group nsg-mgmt --output none
-      echo "az network vnet subnet update -g ${{parameters.testCaseName}} -n subnet-mgmt --vnet-name vnet-mgmt --network-security-group nsg-mgmt"
     displayName: 'Update NSG for subnet subnet-mgmt'
   - script: |
       cd deploy/v2/ansible_config_files


### PR DESCRIPTION
## Problem
We often see i/o timeout in v2 pipeline

## Description
The i/o timeout happens when disk attachment is taking too long due to the fact those API calls are done sequentially.
There is a process monitor our subscription and apply NRMS NSG which suppose to increase security within Azure.  By having disk attachment running longer, it increase the chance to have NRMS NSG attached to the deployed VNET. Hence blocked port 22.

## Solution
- Remove `ansible-playbook` version check in `deploy/v2/terraform/ansible.tf` if `ansible_execution` set to false. This can avoid this remote task being called in TF completely in our pipeline.
- Reassign the original NSG to the management VNET in pipeline before ansible tasks. This way we make sure we can run the playbook via port 22 from RTI.

## Test
Tested by creating pipeline with this branch.
