### PR TITLE
Reload of the kernel sysrq value is not required.

### DIFF
--- a/tools/enable-kdump.sh
+++ b/tools/enable-kdump.sh
@@ -120,12 +120,8 @@ systemctl enable kdump
 ExitIfFailed $? "Failed to enable kdump service"
 
 # set kernel.sysrq to 184(recommended)
-sysctl kernel.sysrq=184
+echo 184 > /proc/sys/kernel/sysrq
 ExitIfFailed $? "Failed to set kernel.sysrq value to 184"
-
-# load the new kernel.sysrq
-sysctl -p
-ExitIfFailed $? "Failed to load new kernel.sysrq value"
 
 echo "KDUMP is successfully enabled, please reboot the system to apply the change"
 exit 0


### PR DESCRIPTION
After running enable kdump script on the host, reboot of the host is required for the changes to be applied so after reboot sysrq change will also become effective. 