### PR TITLE
Add ansible to configure SBD fencing

### DIFF
--- a/deploy/v2/ansible/roles/hana-os-clustering/defaults/main.yml
+++ b/deploy/v2/ansible/roles/hana-os-clustering/defaults/main.yml
@@ -1,0 +1,8 @@
+---
+
+iscsi_sbd_services:
+  - iscsid
+  - iscsi
+  - sbd
+
+iscsi_object: iqn.2006-04

--- a/deploy/v2/ansible/roles/hana-os-clustering/tasks/cluster-Suse.yml
+++ b/deploy/v2/ansible/roles/hana-os-clustering/tasks/cluster-Suse.yml
@@ -80,6 +80,7 @@
         timeout="600"
 
     - name: Ensure the STONITH fencing device is created
+      when: hana_database.size != "LargeInstance"
       shell: >
         crm configure primitive rsc_st_azure stonith:fence_azure_arm params
         subscriptionId="{{ sap_hana_fencing_agent_subscription_id }}"
@@ -87,6 +88,33 @@
         tenantId="{{ sap_hana_fencing_agent_tenant_id }}"
         login="{{ sap_hana_fencing_agent_client_id }}"
         passwd="{{ sap_hana_fencing_agent_client_password }}"
+    
+    - name: Ensure the STONITH SBD is created
+      when: groups['iscsi'] | length > 0
+      block:
+
+         # How long to wait for STONITH actions(reboot, on, off) to complete
+        - name: Configure time-out
+          shell: >
+            crm configure property stonith-timeout=144
+            crm configure property stonith-enabled=true
+
+        - name: List resource
+          shell: >
+            crm resource list
+          register:
+            sbd_device
+        
+        - name: Stop and remove stonith-sbd
+          shell: >
+            crm resource stop "{{ sbd_device }}"
+            crm resource delete "{{ sbd_device }
+        
+        - name: Create SBD disk STONITH resource
+          shell: >
+            crm configure primitive "{{ sbd_device }}" stonith:external/sbd \
+            params pcmk_delay_max="15" \
+            op monitor interval="15" timeout="15"
 
     - name: Ensure SAP HANA Topology resource is configured
       shell: >

--- a/deploy/v2/ansible/roles/hana-os-clustering/tasks/main.yml
+++ b/deploy/v2/ansible/roles/hana-os-clustering/tasks/main.yml
@@ -1,6 +1,12 @@
 ---
 
 - import_tasks: pre_checks.yml
+
+# If iSCSI devices are provisioned, SBD will be set up.
+- import_tasks: sbd-device-setup.yml
+  when: groups['iscsi'] | length > 0
+
 - import_tasks: provision.yml
   when: cluster_existence_check_result.rc != 0
+  
 - import_tasks: post_provision_report.yml

--- a/deploy/v2/ansible/roles/hana-os-clustering/tasks/sbd-device-setup.yml
+++ b/deploy/v2/ansible/roles/hana-os-clustering/tasks/sbd-device-setup.yml
@@ -1,0 +1,130 @@
+---
+
+- name: Enable iscsid, iscsi, sbd
+  service: name="{{ item }}" enabled=yes
+  loops: "{{ iscsi_sbd_services | flattern(levels=1) }}"
+
+- name: Set initiatorname
+  lineinfile:
+    dest: '/etc/iscsi/initiatorname.iscsi'
+    regexp: '^InitiatorName=iqn'
+    line: "InitiatorName={{ iscsi_object }}.{{ hostname }}.local:{{ hostname }}"
+    state: 'present'
+  register: iscsi_register_initiator_name
+
+- name: Restart iscsid
+  service: name=iscsid state=restarted
+  when: iscsi_register_initiator_name.changed
+
+- name: Restart iscsi
+  service: name=iscsi state=restarted
+  when: iscsi_register_initiator_name.changed
+
+# Connect the iSCSI devices
+- name: Connect the iSCSI devices
+  loop: "{{ groups['iscsi'] }}" 
+  block:
+
+    - name: Discover targets on portal {{ item.ip }}
+      open_iscsi:
+        discover: yes
+        portal: "{{ item.ip }}"
+        port: "{{ iscsi_port }}"
+      register: discover_iscsi_device
+
+    - debug:
+        msg: "{{ discover_iscsi_device }}"
+      when: discover_iscsi_device
+
+    - name: Set connecting to the portal
+      open_iscsi:
+        target: "{{ iscsi_object }}.db{{ cluster_name }}.local:db{{ cluster_name }}"
+        login: yes
+        portal: "{{ item.ip }}"
+        port: "{{ iscsi_port }}"
+      register: login_iscsi_device
+
+    - debug:
+        msg: "{{ login_iscsi_device }}"
+      when: login_iscsi_device
+
+    - name: Set automatic connecting at startup
+      open_iscsi:
+        auto_node_startup: yes
+        portal: "{{ item }}"
+        port: "{{ iscsi_port }}"
+      register: set_update_iscsi_device
+
+    - debug:
+        msg: "{{ set_update_iscsi_device }}"
+      when: set_update_iscsi_device
+
+- name: Call lsscsi and get location
+  shell: lsscsi -l | grep {{ cluster_name }} | awk '{ print $6; }' | grep -oP "^/dev/\K.*"
+  register: lsscsi_output
+
+- debug:
+    msg: "{{ lsscsi_output }}"
+  when: lsscsi_output
+
+- name: Configure SBD device
+  set_fact:
+    sbd_devices: ""
+  loop: {{ lsscsi_output.stdout }}
+  block:
+
+    - name: Get disk with correct disk-id
+      shell: ls -l /dev/disk/by-id/scsi-* | grep {{ item }} | grep scsi-3 | awk '{ print $9; }'
+      register: scsi_disk_path
+
+    - debug:
+        msg: "{{ scsi_disk_path }}"
+      when: scsi_disk_path
+
+    - sbd_devices: "{{ sbd_devices }};{{ scsi_disk_path }}"
+      when:
+        scsi_disk_path is not failed
+
+# what does these numbers mean?
+    - name: Create corosync sbd device
+      command: sbd -d {{ scsi_disk_path.stdout }} -1 60 -4 120 create
+
+- name: Adapt the SBD config to have device
+  lineinfile:
+    dest: '/etc/sysconfig/sbd'
+    regexp: 'SBD_DEVICE='
+    line: "SBD_DEVICE=\"{{ sbd_devices }}\""
+    state: 'present'
+  register: device_added
+
+- name: Adapt the SBD config to have pacemaker enabled
+  lineinfile:
+    dest: '/etc/sysconfig/sbd'
+    regexp: 'SBD_PACEMAKER='
+    line: "SBD_PACEMAKER=yes"
+    state: 'present'
+  register: pacemaker_enabled
+
+- name: Adapt the SBD config to have SDB startmode set to always
+  lineinfile:
+    dest: '/etc/sysconfig/sbd'
+    regexp: 'SBD_STARTMODE='
+    line: "SBD_STARTMODE=always"
+    state: 'present'
+  register: startmode_set
+  
+- name: Create softdog config
+  shell: echo softdog | sudo tee /etc/modules-load.d/softdog.conf
+  register: softdog_config
+
+- debug:
+    msg: "{{ softdog_config }}"
+  when: softdog_config
+
+- name: Load the softdog module
+  shell: modprobe -v softdog
+  register: load_softdog
+
+- debug:
+    msg: "{{ load_softdog }}"
+  when: load_softdog

--- a/deploy/v2/ansible/roles/iscsi-target-install/defaults/main.yml
+++ b/deploy/v2/ansible/roles/iscsi-target-install/defaults/main.yml
@@ -1,0 +1,14 @@
+---
+# dbus-1-python is recommended by Azure official reference but it is obsolete
+install_packages:
+  - targetcli-fb
+
+uninstall_packages:
+  - lio-utils
+  - python-rtslib
+  - python-configshell
+  - targetcli
+
+iscsi_object: iqn.2006-04
+
+cluster_type: "db"

--- a/deploy/v2/ansible/roles/iscsi-target-install/tasks/main.yml
+++ b/deploy/v2/ansible/roles/iscsi-target-install/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+
+- import_tasks: provision.yml
+
+- import_tasks: post_provision_report.yml

--- a/deploy/v2/ansible/roles/iscsi-target-install/tasks/post_provision_report.yml
+++ b/deploy/v2/ansible/roles/iscsi-target-install/tasks/post_provision_report.yml
@@ -1,0 +1,6 @@
+---
+
+- name: Check if iSCSI is set up correctly
+  shell: >
+    targetcli ls
+  register: device_info

--- a/deploy/v2/ansible/roles/iscsi-target-install/tasks/provision.yml
+++ b/deploy/v2/ansible/roles/iscsi-target-install/tasks/provision.yml
@@ -1,0 +1,39 @@
+---
+
+- name: Update SLES
+  zypper:
+    name: '*'
+    state: latest
+    disable_recommends: no
+
+- name: Remove packages
+  package:
+    name: "{{ item }}"
+    state: absent
+  loop: "{{ uninstall_packages | flatten(levels=1) }}"
+
+- name: Install packages
+  package:
+    name: "{{ item }}"
+    state: present
+  loop: "{{ install_packages | flatten(levels=1) }}"
+
+- name: Enable the iSCSI target service
+  service: name=targetcli enabled=yes state=started
+
+- name: Create iSCSI device on iSCSI target server
+  block:
+
+    - name: Create the root folder for all SBD devices
+      file: 
+        path: /sbd
+        state: directory
+
+    - name: Create the SBD device for the {{ cluster_type }} cluster of SAP System
+      shell: >
+        targetcli backstores/fileio create sbd{{ cluster_name }} /sbd/sbd{{ cluster_name }} 50M write_back=false;
+        targetcli iscsi/ create {{ iscsi_object }}.{{ cluster_name }}.local:{{ cluster_name }};
+        targetcli iscsi/{{ iscsi_object }}.{{ cluster_name }}.local:{{ cluster_name }}/tpg1/luns/ create /backstores/fileio/sbd{{ cluster_name }};
+        targetcli iscsi/{{ iscsi_object }}.{{ cluster_name }}.local:{{ cluster_name }}/tpg1/acls/ create {{ iscsi_object }}.{{ hana_database.nodes[0].dbname }}.local:{{ hana_database.nodes[0].dbname }};
+        targetcli iscsi/{{ iscsi_object }}.{{ cluster_name }}.local:{{ cluster_name }}/tpg1/acls/ create {{ iscsi_object }}.{{ hana_database.nodes[1].dbname }}.local:{{ hana_database.nodes[1].dbname }};
+        targetcli saveconfig

--- a/deploy/v2/ansible/roles/iscsi-target-install/vars/main.yml
+++ b/deploy/v2/ansible/roles/iscsi-target-install/vars/main.yml
@@ -1,0 +1,5 @@
+---
+
+cluster_type: "db"
+
+cluster_name: "{{ cluster_type }}{{ hana_database.instance.sid }}"

--- a/deploy/v2/ansible/sap_playbook.yml
+++ b/deploy/v2/ansible/sap_playbook.yml
@@ -71,6 +71,15 @@
       tasks_from: media_hanadbnode_copy.yml
     when: hana_database.size == "LargeInstance"
 
+- hosts: iscsi
+  become: true
+  become_user: root
+  roles:
+   - role: iscsi-target-install
+     when: 
+       - hana_database.high_availability
+       - groups['iscsi'] | length > 0
+
 # Hana DB components install
 - hosts: hanadbnodes
   become: true

--- a/deploy/v2/template_samples/clustered_hana_with_sbd.json
+++ b/deploy/v2/template_samples/clustered_hana_with_sbd.json
@@ -95,7 +95,7 @@
           "sku": "16.04-LTS"
         },
         "authentication": {
-          "type": "password",
+          "type": "key",
           "username": "azureadm",
           "password": "Sap@hana2019!"
         },


### PR DESCRIPTION
1. Add a role iscsi-target-install to set up iSCSI target servers and
   create iSCSI device on iSCSI target server. Since this iSCSI can be
   used in multiple clusters(Database, ASCS, nfs etc.), this role is
   designed to be generic.
2. Add SBD setup yml file