### PR TITLE
Ignore Terraform generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ set-sp.sh
 
 # ignore any clustering auth scripts
 set-clustering-auth*.sh
+
+# Ignore Terraform generated files
+deploy/v2/ansible_config_files


### PR DESCRIPTION
## Problem

v2 Terraform generates files for copying sensitive information to the `RTI` VM within the directory structure managed in Git. See #476

## Description

Adds the path the `.gitignore` file to prevent sensitive information being accidentally committed to the repository.

## Testing/Acceptance Criteria

In a checkout of the code:

1. Create a test file:\
   `touch deploy/v2/ansible_config_files/test`
1. Check the `git status` of the repository
   - [ ] The file `deploy/v2/ansible_config_files/test` does not appear in the list of Untracked files
