### PR TITLE
Add ansible to configure SBD fencing

### DIFF
--- a/deploy/v2/ansible/roles/hana-os-clustering/defaults/main.yml
+++ b/deploy/v2/ansible/roles/hana-os-clustering/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+
+iscsi_object: iqn.2006-04
+
+iscsi_port: 3260

--- a/deploy/v2/ansible/roles/hana-os-clustering/tasks/cluster-Suse.yml
+++ b/deploy/v2/ansible/roles/hana-os-clustering/tasks/cluster-Suse.yml
@@ -53,7 +53,7 @@
     dest: /etc/corosync/corosync.conf
     mode: 0600
 
-- name: Ensure the Corosync service is restarted
+- name: Ensure the Corosync service is restarted on primary node.
   when: inventory_hostname == hana_database.nodes[0].ip_admin_nic
   systemd:
     name: corosync

--- a/deploy/v2/ansible/roles/hana-os-clustering/tasks/cluster-Suse.yml
+++ b/deploy/v2/ansible/roles/hana-os-clustering/tasks/cluster-Suse.yml
@@ -6,6 +6,11 @@
 - name: Ensure a list of package version is available for checking the cloud-netconfig-azure version
   package_facts:
 
+# If iSCSI devices are provisioned and the os is Suse, SBD will be set up
+- name: Ensure SBD devices are set up on hanadbnodes when provided
+  when: groups['iscsi'] | length > 0
+  include_tasks: sbd_device_setup.yml
+
 # eth1 is the "db" NIC
 - name: Ensure clustering can manage Virtual IPs on the Database Interface
   when: ansible_facts.packages["cloud-netconfig-azure"] and (ansible_facts.packages["cloud-netconfig-azure"][0].version | float) < 1.3
@@ -17,7 +22,7 @@
 
 # https://rpm.pbone.net/index.php3/stat/45/idpl/27916721/numer/8/nazwa/ha-cluster-init
 - name: Ensure Primary node initiates the Cluster
-  when: ansible_hostname == hana_database.nodes[0].dbname
+  when: inventory_hostname == hana_database.nodes[0].ip_admin_nic
   block:
     - name: Ensure csync2 is configured
       shell: crm cluster init -y csync2 --interface eth1
@@ -29,7 +34,7 @@
       shell: "crm cluster init -y cluster --name 'hdb_{{ hana_database.instance.sid | upper }}' --interface eth1"
 
 - name: Ensure Secondary node joins the Cluster
-  when: ansible_hostname == hana_database.nodes[1].dbname
+  when: inventory_hostname == hana_database.nodes[1].ip_admin_nic
   block:
     - name: Ensure the configuration files are synchronised
       shell: "crm cluster join -y -c {{ hana_database.nodes[0].ip_db_nic }} csync2 --interface eth1"
@@ -49,12 +54,72 @@
     mode: 0600
 
 - name: Ensure the Corosync service is restarted
+  when: inventory_hostname == hana_database.nodes[0].ip_admin_nic
   systemd:
     name: corosync
     state: restarted
 
+- pause:
+    seconds: 20
+
+- name: Ensure the Corosync service is restarted
+  when: inventory_hostname == hana_database.nodes[1].ip_admin_nic
+  systemd:
+    name: corosync
+    state: restarted
+
+- pause:
+    seconds: 20
+
+- name: Ensure the STONITH SBD is created
+  when: 
+    - inventory_hostname == hana_database.nodes[0].ip_admin_nic
+    - groups['iscsi'] | length > 0 
+  block:
+
+    - name: Check if SBD resource exists
+      shell: crm resource list | grep 'sbd' | awk '{ print $1; }'
+      register: sbd_device
+      failed_when: false
+    
+    # "stonith-sbd" is the sbd device in most cases if there has already existed a SBD
+    - name: Ensure current SBD device is stoped and removed if exists
+      shell: |
+        crm resource stop {{ sbd_device.stdout }}
+        crm configure delete {{ sbd_device.stdout }}
+      when: sbd_device.stdout | length > 0
+      
+    - name: Ensure SBD disk STONITH resource is created
+      shell: >
+        crm configure primitive stonith-sbd stonith:external/sbd \
+        params pcmk_delay_max="15" \
+        op monitor interval="15" timeout="15"
+    
+    - name: Check the current SBD status
+      shell: crm_mon -1 | grep sbd
+      register: sbd_report
+      changed_when: False
+      failed_when: False
+
+    - debug:
+        msg: "{{ sbd_report.stdout }}" 
+
+- name: Ensure Azure scheduled events is configured
+  when: inventory_hostname == hana_database.nodes[0].ip_admin_nic
+  block: 
+  # After configuring the Pacemaker resources for azure-events agent, when you place the cluster in or out of maintenance mode, you may get warning messages like:
+  # WARNING: cib-bootstrap-options: unknown attribute 'hostName_ hostname'
+  # WARNING: cib-bootstrap-options: unknown attribute 'azure-events_globalPullState'
+  # WARNING: cib-bootstrap-options: unknown attribute 'hostName_ hostname'
+  # These warning messages can be ignored.
+    - name:  Ensure Pacemaker resources for the Azure agent is created
+      shell: crm configure primitive rsc_azure-events ocf:heartbeat:azure-events op monitor interval=10s
+
+    - name: Ensure clone resource azure-events is configure
+      shell: crm configure clone cln_azure-events rsc_azure-events
+
 - name: Ensure the Cluster STONITH is configured
-  when: ansible_hostname == hana_database.nodes[0].dbname
+  when: inventory_hostname == hana_database.nodes[0].ip_admin_nic
   block:
     - name: Ensure maintenance mode is enabled
       shell: "crm configure property maintenance-mode=true"
@@ -79,7 +144,8 @@
         crm configure op_defaults \$id="op-options"
         timeout="600"
 
-    - name: Ensure the STONITH fencing device is created
+    - name: Ensure the STONITH Azure fence agent is created
+      when: hana_database.size != "LargeInstance"
       shell: >
         crm configure primitive rsc_st_azure stonith:fence_azure_arm params
         subscriptionId="{{ sap_hana_fencing_agent_subscription_id }}"
@@ -165,6 +231,15 @@
 
     - name: Ensure any required cluster resources are cleaned up
       shell: "crm resource cleanup rsc_SAPHana_{{ hana_database.instance.sid | upper }}_HDB{{ hana_database.instance.instance_number }}"
+
+    - name: Check current SBD status after clean resources
+      shell: crm_mon -1 | grep sbd
+      register: sbd_report_afterclean
+      changed_when: False
+      failed_when: False
+
+    - debug:
+        msg: "{{ sbd_report_afterclean.stdout }}" 
 
     - name: Ensure maintenance mode is disabled
       shell: "crm configure property maintenance-mode=false"

--- a/deploy/v2/ansible/roles/hana-os-clustering/tasks/cluster-Suse.yml
+++ b/deploy/v2/ansible/roles/hana-os-clustering/tasks/cluster-Suse.yml
@@ -62,7 +62,7 @@
 - pause:
     seconds: 20
 
-- name: Ensure the Corosync service is restarted
+- name: Ensure the Corosync service is restarted on secondary node
   when: inventory_hostname == hana_database.nodes[1].ip_admin_nic
   systemd:
     name: corosync

--- a/deploy/v2/ansible/roles/hana-os-clustering/tasks/post_provision_report.yml
+++ b/deploy/v2/ansible/roles/hana-os-clustering/tasks/post_provision_report.yml
@@ -13,3 +13,15 @@
 - name: Output cluster status
   debug:
     msg: "{{ cluster_status_report.stdout }}"
+
+- name: Check the SBD devices status
+  when: ansible_os_family == 'Suse'
+  shell: crm_mon -1 | grep sbd
+  register: sbd_status_report
+  changed_when: False
+  failed_when: False
+
+- name: Output SBD status
+  when: ansible_os_family == 'Suse'
+  debug:
+    msg: "{{ sbd_status_report.stdout }}"

--- a/deploy/v2/ansible/roles/hana-os-clustering/tasks/pre_checks.yml
+++ b/deploy/v2/ansible/roles/hana-os-clustering/tasks/pre_checks.yml
@@ -1,6 +1,5 @@
 ---
 
-
 - name: Check the required Clustering configuration variables are set
   assert:
     that:

--- a/deploy/v2/ansible/roles/hana-os-clustering/tasks/sbd_device_setup.yml
+++ b/deploy/v2/ansible/roles/hana-os-clustering/tasks/sbd_device_setup.yml
@@ -1,0 +1,91 @@
+---
+
+- name: Ensure iscsid, iscsi, sbd services are enabled
+  service: name={{ item }} enabled=yes
+  loop:
+    - iscsid
+    - iscsi
+    - sbd
+
+- name: Ensure initiator name is set
+  vars:
+    currentHostName: "{{ hana_database.nodes[0].dbname if inventory_hostname == hana_database.nodes[0].ip_admin_nic else hana_database.nodes[1].dbname }}"
+    initiatorName: "{{ iscsi_object }}.{{ currentHostName }}.local:{{ currentHostName }}"
+  lineinfile:
+    dest: '/etc/iscsi/initiatorname.iscsi'
+    regexp: '^InitiatorName=iqn'
+    line: InitiatorName={{ initiatorName }}
+    state: 'present'
+
+- name: Ensure iscsid, iscsi are restarted
+  service: name={{ item }} state=restarted
+  loop:
+    - iscsid
+    - iscsi
+
+# Connect the iSCSI devices
+- name: Discover targets on portals, set connecting, mark targets to auto start
+  shell: |
+    iscsiadm -m discovery --type=st --portal={{ item }}:{{ iscsi_port }}
+    iscsiadm -m node -T {{ target }} --login --portal={{ item }}:{{ iscsi_port }}
+    iscsiadm -m node -p {{ item }}:{{ iscsi_port }} --op=update --name=node.startup --value=automatic
+  loop: "{{ groups['iscsi'] }}" 
+  register: login_iscsi_device
+
+- name: Call lsscsi and get devices names
+  shell: lsscsi -l | grep {{ storage_object }} | awk '{ print $6; }' | grep -oP "^/dev/\K.*"
+  register: iscsi_devices_names
+
+- name: Check if iSCSI device(s) is able to be discovered
+  assert:
+    that: iscsi_devices_names.stdout_lines | length > 0
+    fail_msg: "No iSCSI device is discovered"
+    success_msg: "There are {{ iscsi_devices_names.stdout_lines | length }} iSCSI devices discovered"
+
+- name: Get disk with correct disk-id
+  shell: ls -l /dev/disk/by-id/scsi-* | grep {{ item }} | grep scsi-3 | awk '{ print $9; }'
+  loop: "{{ iscsi_devices_names.stdout_lines }}"
+  register: iscsi_devices_ids
+
+- name: Check if iSCSI device(s) ID is able to be fetched
+  assert:
+    that: iscsi_devices_ids.results | length > 0
+    fail_msg: "Not able to get iSCSI devices ID(s)"
+    success_msg: "There are {{ iscsi_devices_ids.results | length }} iSCSI devices ID fetched"
+
+- name: Get SBD devices list
+  set_fact: 
+    sbd_devices: "{{ item.stdout }};{{ sbd_devices | default('') }}"
+  loop: "{{ iscsi_devices_ids.results }}"
+
+- name: Ensure SBD device is created on the first cluster node
+  when: inventory_hostname == hana_database.nodes[0].ip_admin_nic
+  command: sbd -d {{ item.stdout }} -1 60 -4 120 create
+  loop: "{{ iscsi_devices_ids.results }}"
+
+- name: Ensure the SBD config has device ids
+  lineinfile:
+    dest: '/etc/sysconfig/sbd'
+    regexp: 'SBD_DEVICE='
+    line: "SBD_DEVICE=\"{{ sbd_devices }}\""
+    state: 'present'
+
+- name: Ensure the SBD config to have pacemaker enabled
+  lineinfile:
+    dest: '/etc/sysconfig/sbd'
+    regexp: 'SBD_PACEMAKER='
+    line: "SBD_PACEMAKER=yes"
+    state: 'present'
+
+- name: Ensure the SBD config has SDB startmode set to always
+  lineinfile:
+    dest: '/etc/sysconfig/sbd'
+    regexp: 'SBD_STARTMODE='
+    line: "SBD_STARTMODE=always"
+    state: 'present'
+  
+- name: Ensure softdog config is created
+  shell: echo softdog | sudo tee /etc/modules-load.d/softdog.conf
+
+- name: Load the softdog module
+  shell: modprobe -v softdog

--- a/deploy/v2/ansible/roles/hana-os-clustering/vars/main.yml
+++ b/deploy/v2/ansible/roles/hana-os-clustering/vars/main.yml
@@ -26,3 +26,9 @@ cluster_status_cmd:
   Suse: "crm status full"
 
 cluster_status_report_wait_in_s: 60
+
+# The following values should be same as iSCSI configuration
+# run 'sudo targetcli ls' on iSCSI target virtual machines to get all iSCSI configuration
+cluster_name: db{{ hana_database.instance.sid | lower }}
+storage_object: sbd{{ cluster_name }}
+target: "{{ iscsi_object }}.{{ cluster_name }}.local:{{ cluster_name }}"

--- a/deploy/v2/ansible/roles/iscsi-target-install/defaults/main.yml
+++ b/deploy/v2/ansible/roles/iscsi-target-install/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+
+iscsi_object: iqn.2006-04

--- a/deploy/v2/ansible/roles/iscsi-target-install/tasks/iscsi_device_create.yml
+++ b/deploy/v2/ansible/roles/iscsi-target-install/tasks/iscsi_device_create.yml
@@ -1,0 +1,17 @@
+---
+
+- name: Ensure SBD device for clusters is created
+  vars:
+    cluster_name: "{{ item.key }}"
+    storage_object: sbd{{ cluster_name }}
+    target: "{{ iscsi_object }}.{{ cluster_name }}.local:{{ cluster_name }}"
+    initiator1: "{{ iscsi_object }}.{{ item.value[0] | default(hana_database.nodes[0].dbname) }}.local:{{ item.value[0] | default(hana_database.nodes[0].dbname) }}"
+    initiator2: "{{ iscsi_object }}.{{ item.value[1] | default(hana_database.nodes[1].dbname) }}.local:{{ item.value[1] | default(hana_database.nodes[1].dbname) }}"
+  shell: |
+    targetcli backstores/fileio create {{ storage_object }} /sbd/{{ storage_object }} 50M write_back=false
+    targetcli iscsi/ create {{ target }}
+    targetcli iscsi/{{ target }}/tpg1/luns/ create /backstores/fileio/{{ storage_object }}
+    targetcli iscsi/{{ target }}/tpg1/acls/ create {{ initiator1 }}
+    targetcli iscsi/{{ target }}/tpg1/acls/ create {{ initiator2 }}
+    targetcli saveconfig
+  loop: "{{ clusters | dict2items }}"

--- a/deploy/v2/ansible/roles/iscsi-target-install/tasks/main.yml
+++ b/deploy/v2/ansible/roles/iscsi-target-install/tasks/main.yml
@@ -3,6 +3,5 @@
 - import_tasks: pre_checks.yml
 
 - import_tasks: provision.yml
-  when: cluster_existence_check_result.rc != 0
 
 - import_tasks: post_provision_report.yml

--- a/deploy/v2/ansible/roles/iscsi-target-install/tasks/post_provision_report.yml
+++ b/deploy/v2/ansible/roles/iscsi-target-install/tasks/post_provision_report.yml
@@ -1,0 +1,10 @@
+---
+
+- name: Check the SBD devices status
+  shell: targetcli ls
+  register: device_info
+  changed_when: false
+
+- name: Output SBD devices status
+  debug:
+    msg: "{{ device_info.stdout }}"

--- a/deploy/v2/ansible/roles/iscsi-target-install/tasks/pre_checks.yml
+++ b/deploy/v2/ansible/roles/iscsi-target-install/tasks/pre_checks.yml
@@ -1,0 +1,9 @@
+---
+
+- name: Check if iSCSI target servers are provisioned
+  assert:
+    that: groups['iscsi'] | length > 0
+
+- name: Check if Linux distro of iSCSI target virtual machines is Suse 
+  assert:
+    that: ansible_os_family == 'Suse'

--- a/deploy/v2/ansible/roles/iscsi-target-install/tasks/provision.yml
+++ b/deploy/v2/ansible/roles/iscsi-target-install/tasks/provision.yml
@@ -1,0 +1,39 @@
+---
+
+- name: Update SLES
+  zypper:
+    name: '*'
+    state: latest
+    disable_recommends: no
+
+- name: Remove packages
+  package:
+    name: "{{ item }}"
+    state: absent
+  loop:
+    - lio-utils
+    - python-rtslib
+    - python-configshell
+    - targetcli
+
+# Note: dbus-1-python is recommended by Azure official reference but it is obsolete
+- name: Install packages
+  package:
+    name: "{{ item }}"
+    state: present
+  loop: 
+    - targetcli-fb
+
+- name: Ensure the iSCSI target service is enabled
+  service: name=targetcli enabled=yes state=started
+
+- name: Ensure iSCSI device on iSCSI target server is created
+  block:
+    - name: Ensure the root folder for all SBD devices is created
+      file: 
+        path: /sbd
+        state: directory
+      register: root_folder_status
+
+    - when: root_folder_status is not failed
+      import_tasks: iscsi_device_create.yml

--- a/deploy/v2/ansible/roles/iscsi-target-install/vars/main.yml
+++ b/deploy/v2/ansible/roles/iscsi-target-install/vars/main.yml
@@ -1,0 +1,21 @@
+---
+# Configure the clusters using following format
+#
+# clusters:
+#   cluster_name:
+#     - hostname of the first node
+#     - hostname of the second node
+#
+# eg:
+# clusters:
+#   db{{ hana_database.instance.sid | lower }}:
+#     - "{{ hana_database.nodes[0].dbname }}"
+#     - "{{ hana_database.nodes[1].dbname }}"
+#   nfs:
+#   ascs{{ hana_database.instance.sid | lower }}:
+# 
+# hostnames can be omitted, then hana_database nodes will be default values
+clusters:
+  db{{ hana_database.instance.sid | lower }}:
+    - "{{ hana_database.nodes[0].dbname }}"
+    - "{{ hana_database.nodes[1].dbname }}"

--- a/deploy/v2/ansible/sap_playbook.yml
+++ b/deploy/v2/ansible/sap_playbook.yml
@@ -79,6 +79,16 @@
     - role: large-instance-environment-setup
       when: hana_database.size == "LargeInstance"
 
+# Only SLES support SBD fencing
+- hosts: iscsi
+  become: true
+  become_user: root
+  roles:
+   - role: iscsi-target-install
+     when: 
+       - hana_database.high_availability
+       - hostvars[hana_database.nodes[0].ip_admin_nic].ansible_os_family == 'Suse'
+
 # Hana DB components install
 - hosts: hanadbnodes
   become: true

--- a/deploy/v2/ansible/vars/ha-packages.yml
+++ b/deploy/v2/ansible/vars/ha-packages.yml
@@ -12,3 +12,4 @@ ha_packages:
     - corosync
     - resource-agents
     - fence-agents
+    - cloud-netconfig-azure

--- a/deploy/v2/template_samples/clustered_hana_with_sbd.json
+++ b/deploy/v2/template_samples/clustered_hana_with_sbd.json
@@ -95,9 +95,8 @@
           "sku": "16.04-LTS"
         },
         "authentication": {
-          "type": "password",
-          "username": "azureadm",
-          "password": "Sap@hana2019!"
+          "type": "key",
+          "username": "azureadm"
         },
         "components": [
           "hana_studio_linux"


### PR DESCRIPTION
1. Add a role iscsi-target-install to set up iSCSI target servers and
   create iSCSI device on iSCSI target server. Since this iSCSI can be
   used in multiple clusters(Database, ASCS, nfs etc.) through
   configuration, this role is designed to be generic.
2. Add SBD setup yml files to set up sbd device on hanadbnodes when linux distribution is Suse.
3. Azure fencing agent will be bypassed when it is large instance.
4. Add azure scheduled events to allow time for the application to prepare
   for events like VM shutdown, VM redeployment, etc.