### PR TITLE
Update backup mount point of Large Instance

### DIFF
--- a/deploy/v2/hdb_sizes.json
+++ b/deploy/v2/hdb_sizes.json
@@ -26,7 +26,7 @@
             {
                 "name" : "backup",
                 "count" : 1,
-                "mount_point" : "/hana/backup"
+                "mount_point" : "/hana/logbackups"
             }
         ]
     },


### PR DESCRIPTION
Baremetal configure the mount point as "/hana/logbackups". Update the mount point of large instance.