### PR TITLE
Adjust IP space for iSCSI

### DIFF
--- a/deploy/template_samples/clustered_hana_with_sbd.json
+++ b/deploy/template_samples/clustered_hana_with_sbd.json
@@ -48,7 +48,7 @@
         "subnet_iscsi": {
           "is_existing": "false",
           "name": "subnet-iscsi",
-          "prefix": "10.1.3.0/24",
+          "prefix": "10.1.4.0/24",
           "nsg": {
             "is_existing": "false",
             "name": "nsg-iscsi"

--- a/deploy/template_samples/clustered_hana_with_sbd.json
+++ b/deploy/template_samples/clustered_hana_with_sbd.json
@@ -44,11 +44,20 @@
             "is_existing": "false",
             "name": "nsg-db"
           }
+        },
+        "subnet_iscsi": {
+          "is_existing": "false",
+          "name": "subnet-iscsi",
+          "prefix": "10.1.3.0/24",
+          "nsg": {
+            "is_existing": "false",
+            "name": "nsg-iscsi"
+          }
         }
       }
     },
     "iscsi": {
-      "iscsi_count": 1,
+      "iscsi_count": 3,
       "size":"Standard_D2s_v3",
       "os": {
         "publisher": "SUSE",
@@ -63,45 +72,8 @@
   },
   "jumpboxes": {
     "windows": [
-      {
-        "name": "jumpbox-windows",
-        "destroy_after_deploy": "false",
-        "size": "Standard_D2s_v3",
-        "disk_type": "StandardSSD_LRS",
-        "os": {
-          "publisher": "MicrosoftWindowsServer",
-          "offer": "WindowsServer",
-          "sku": "2016-Datacenter"
-        },
-        "authentication": {
-          "type": "password",
-          "username": "azureadm",
-          "password": "Sap@hana2019!"
-        },
-        "components": [
-          "hana_studio_windows"
-        ]
-      }
     ],
     "linux": [
-      {
-        "name": "jumpbox-linux",
-        "destroy_after_deploy": "false",
-        "size": "Standard_D2s_v3",
-        "disk_type": "StandardSSD_LRS",
-        "os": {
-          "publisher": "Canonical",
-          "offer": "UbuntuServer",
-          "sku": "16.04-LTS"
-        },
-        "authentication": {
-          "type": "key",
-          "username": "azureadm"
-        },
-        "components": [
-          "hana_studio_linux"
-        ]
-      },
       {
         "name": "rti",
         "destroy_after_deploy": "true",
@@ -151,16 +123,6 @@
       },
       "components": {
         "hana_database": [],
-        "hana_client_linux": [],
-        "xs": [
-          "xsac_alm_pi_ui",
-          "xsac_portal_serv",
-          "xsac_services",
-          "xsac_ui5_fesv5",
-          "xsac_ui5_sb",
-          "xsac_xsa_cockpit"
-        ],
-        "shine": []
       },
       "xsa": {
         "routing": "ports"

--- a/deploy/terraform/modules/common_infrastructure/iscsi.tf
+++ b/deploy/terraform/modules/common_infrastructure/iscsi.tf
@@ -8,6 +8,9 @@
 TODO:  Fix Naming convention and document in the Naming Convention Doc
 +--------------------------------------4--------------------------------------*/
 
+/*-----------------------------------------------------------------------------8
+iSCSI device IP address range: .4 - .9
++--------------------------------------4--------------------------------------*/
 # Creates the NIC and IP address for iSCSI device
 resource "azurerm_network_interface" "iscsi" {
   count               = local.iscsi.iscsi_count
@@ -18,7 +21,7 @@ resource "azurerm_network_interface" "iscsi" {
   ip_configuration {
     name                          = "ipconfig-iscsi"
     subnet_id                     = var.infrastructure.vnets.sap.subnet_db.is_existing ? data.azurerm_subnet.subnet-sap-db[0].id : azurerm_subnet.subnet-sap-db[0].id
-    private_ip_address            = var.infrastructure.vnets.sap.subnet_db.is_existing ? local.iscsi.iscsi_nic_ips[count.index] : lookup(local.iscsi, "iscsi_nic_ips", false) != false ? local.iscsi.iscsi_nic_ips[count.index] : cidrhost(var.infrastructure.vnets.sap.subnet_db.prefix, tonumber(count.index) + 4 + length(local.dbnodes) + length(local.hana-databases))
+    private_ip_address            = var.infrastructure.vnets.sap.subnet_db.is_existing ? local.iscsi.iscsi_nic_ips[count.index] : lookup(local.iscsi, "iscsi_nic_ips", false) != false ? local.iscsi.iscsi_nic_ips[count.index] : cidrhost(var.infrastructure.vnets.sap.subnet_db.prefix, tonumber(count.index) + 4)
     private_ip_address_allocation = "static"
   }
 }

--- a/deploy/terraform/modules/common_infrastructure/iscsi.tf
+++ b/deploy/terraform/modules/common_infrastructure/iscsi.tf
@@ -9,7 +9,58 @@ TODO:  Fix Naming convention and document in the Naming Convention Doc
 +--------------------------------------4--------------------------------------*/
 
 /*-----------------------------------------------------------------------------8
-iSCSI device IP address range: .4 - .9
+Only create/import iSCSI subnet and nsg when iSCSI device(s) will be deployed
++--------------------------------------4--------------------------------------*/
+# Creates iSCSI subnet of SAP VNET
+resource "azurerm_subnet" "iscsi" {
+  count                = local.iscsi.iscsi_count == 0 ? 0 : (local.subnet_iscsi.is_existing ? 0 : 1)
+  name                 = local.subnet_iscsi.name
+  resource_group_name  = var.infrastructure.vnets.sap.is_existing ? data.azurerm_virtual_network.vnet-sap[0].resource_group_name : azurerm_virtual_network.vnet-sap[0].resource_group_name
+  virtual_network_name = var.infrastructure.vnets.sap.is_existing ? data.azurerm_virtual_network.vnet-sap[0].name : azurerm_virtual_network.vnet-sap[0].name
+  address_prefixes     = [local.subnet_iscsi.prefix]
+}
+
+# Imports data of existing SAP iSCSI subnet
+data "azurerm_subnet" "iscsi" {
+  count                = local.iscsi_count == 0 ? 0 : (local.subnet_iscsi.is_existing ? 1 : 0)
+  name                 = split("/", local.subnet_iscsi.arm_id)[10]
+  resource_group_name  = split("/", local.subnet_iscsi.arm_id)[4]
+  virtual_network_name = split("/", local.subnet_iscsi.arm_id)[8]
+}
+
+# Creates SAP iSCSI subnet nsg
+resource "azurerm_network_security_group" "iscsi" {
+  count               = local.iscsi.iscsi_count == 0 ? 0 : (local.subnet_iscsi.nsg.is_existing ? 0 : 1)
+  name                = local.subnet_iscsi.nsg.name
+  location            = var.infrastructure.region
+  resource_group_name = var.infrastructure.resource_group.is_existing ? data.azurerm_resource_group.resource-group[0].name : azurerm_resource_group.resource-group[0].name
+}
+
+# Imports the SAP iSCSI subnet nsg data
+data "azurerm_network_security_group" "iscsi" {
+  count               = local.iscsi.iscsi_count == 0 ? 0 : (local.subnet_iscsi.nsg.is_existing ? 1 : 0)
+  name                = split("/", var.infrastructure.vnets.sap.subnet_db.nsg.arm_id)[8]
+  resource_group_name = split("/", var.infrastructure.vnets.sap.subnet_db.nsg.arm_id)[4]
+}
+
+# Creates network security rule to deny external traffic for SAP iSCSI subnet
+resource "azurerm_network_security_rule" "iscsi" {
+  count                       = local.iscsi_count == 0 ? 0 : (local.subnet_iscsi.is_existing ? 0 : 1)
+  name                        = "deny-inbound-traffic"
+  resource_group_name         = var.infrastructure.resource_group.is_existing ? data.azurerm_resource_group.resource-group[0].name : azurerm_resource_group.resource-group[0].name
+  network_security_group_name = azurerm_network_security_group.iscsi[0].name
+  priority                    = 102
+  direction                   = "Inbound"
+  access                      = "deny"
+  protocol                    = "Tcp"
+  source_port_range           = "*"
+  destination_port_range      = "*"
+  source_address_prefix       = "*"
+  destination_address_prefix  = var.infrastructure.vnets.sap.subnet_admin.prefix
+}
+
+/*-----------------------------------------------------------------------------8
+iSCSI device IP address range: .4 - 
 +--------------------------------------4--------------------------------------*/
 # Creates the NIC and IP address for iSCSI device
 resource "azurerm_network_interface" "iscsi" {
@@ -20,10 +71,17 @@ resource "azurerm_network_interface" "iscsi" {
 
   ip_configuration {
     name                          = "ipconfig-iscsi"
-    subnet_id                     = var.infrastructure.vnets.sap.subnet_db.is_existing ? data.azurerm_subnet.subnet-sap-db[0].id : azurerm_subnet.subnet-sap-db[0].id
-    private_ip_address            = var.infrastructure.vnets.sap.subnet_db.is_existing ? local.iscsi.iscsi_nic_ips[count.index] : lookup(local.iscsi, "iscsi_nic_ips", false) != false ? local.iscsi.iscsi_nic_ips[count.index] : cidrhost(var.infrastructure.vnets.sap.subnet_db.prefix, tonumber(count.index) + 4)
+    subnet_id                     = local.subnet_iscsi.is_existing ? data.azurerm_subnet.iscsi[0].id : azurerm_subnet.iscsi[0].id
+    private_ip_address            = local.subnet_iscsi.is_existing ? local.iscsi.iscsi_nic_ips[count.index] : lookup(local.iscsi, "iscsi_nic_ips", false) != false ? local.iscsi.iscsi_nic_ips[count.index] : cidrhost(local.subnet_iscsi.prefix, tonumber(count.index) + 4)
     private_ip_address_allocation = "static"
   }
+}
+
+# Manages the association between NIC and NSG.
+resource "azurerm_network_interface_security_group_association" "iscsi" {
+  count                     = local.iscsi.iscsi_count
+  network_interface_id      = azurerm_network_interface.iscsi[count.index].id
+  network_security_group_id = local.subnet_iscsi.nsg.is_existing ? data.azurerm_network_security_group.iscsi[0].id : azurerm_network_security_group.iscsi[0].id
 }
 
 # Manages Linux Virtual Machine for iSCSI

--- a/deploy/terraform/modules/common_infrastructure/variables_local.tf
+++ b/deploy/terraform/modules/common_infrastructure/variables_local.tf
@@ -20,4 +20,7 @@ locals {
 
   # Shortcut to iSCSI definition
   iscsi = merge(lookup(var.infrastructure, "iscsi", {}), { "iscsi_count" = "${local.iscsi_count}" })
+
+  # Shortcut to subnet block for iSCSI in input JSON
+  subnet_iscsi = merge({ "is_existing" = "false" }, lookup(var.infrastructure.vnets.sap, "subnet_iscsi", {}))
 }

--- a/deploy/terraform/modules/common_infrastructure/variables_local.tf
+++ b/deploy/terraform/modules/common_infrastructure/variables_local.tf
@@ -11,39 +11,6 @@ locals {
     if database.platform == "HANA"
   ]
 
-  # Numerically indexed Hash of HANA DB nodes to be created
-  dbnodes = flatten([
-    [
-      for database in local.hana-databases : [
-        for dbnode in database.dbnodes : {
-          platform       = database.platform,
-          name           = "${dbnode.name}-0",
-          admin_nic_ip   = lookup(dbnode, "admin_nic_ips", [false, false])[0],
-          db_nic_ip      = lookup(dbnode, "db_nic_ips", [false, false])[0],
-          size           = database.size,
-          os             = database.os,
-          authentication = database.authentication
-          sid            = database.instance.sid
-        }
-      ]
-    ],
-    [
-      for database in local.hana-databases : [
-        for dbnode in database.dbnodes : {
-          platform       = database.platform,
-          name           = "${dbnode.name}-1",
-          admin_nic_ip   = lookup(dbnode, "admin_nic_ips", [false, false])[1],
-          db_nic_ip      = lookup(dbnode, "db_nic_ips", [false, false])[1],
-          size           = database.size,
-          os             = database.os,
-          authentication = database.authentication
-          sid            = database.instance.sid
-        }
-      ]
-      if database.high_availability
-    ]
-  ])
-
   # iSCSI target device(s) is only created when below conditions met:
   # - iscsi is defined in input JSON
   # - AND

--- a/deploy/terraform/modules/hdb_node/vm-hdb.tf
+++ b/deploy/terraform/modules/hdb_node/vm-hdb.tf
@@ -59,7 +59,7 @@ resource "azurerm_network_interface_security_group_association" "nic-dbnodes-db-
 # LOAD BALANCER ===================================================================================================
 
 /*-----------------------------------------------------------------------------8
-Load balancer front IP address range: .10 - .20
+Load balancer front IP address range: .10 - .19
 +--------------------------------------4--------------------------------------*/
 
 resource "azurerm_lb" "hana-lb" {

--- a/deploy/terraform/modules/hdb_node/vm-hdb.tf
+++ b/deploy/terraform/modules/hdb_node/vm-hdb.tf
@@ -7,7 +7,7 @@
 # NICS ============================================================================================================
 
 /*-----------------------------------------------------------------------------8
-HANA DB Linux Server private IP range: .20 - 
+HANA DB Linux Server private IP range: .10 - 
 +--------------------------------------4--------------------------------------*/
 
 # Creates the admin traffic NIC and private IP address for database nodes
@@ -21,7 +21,7 @@ resource "azurerm_network_interface" "nics-dbnodes-admin" {
   ip_configuration {
     name                          = "${local.dbnodes[count.index].name}-admin-nic-ip"
     subnet_id                     = var.subnet-sap-admin[0].id
-    private_ip_address            = var.infrastructure.vnets.sap.subnet_admin.is_existing ? local.dbnodes[count.index].admin_nic_ip : lookup(local.dbnodes[count.index], "admin_nic_ip", false) != false ? local.dbnodes[count.index].admin_nic_ip : cidrhost(var.infrastructure.vnets.sap.subnet_admin.prefix, tonumber(count.index) + 20)
+    private_ip_address            = var.infrastructure.vnets.sap.subnet_admin.is_existing ? local.dbnodes[count.index].admin_nic_ip : lookup(local.dbnodes[count.index], "admin_nic_ip", false) != false ? local.dbnodes[count.index].admin_nic_ip : cidrhost(var.infrastructure.vnets.sap.subnet_admin.prefix, tonumber(count.index) + 10)
     private_ip_address_allocation = "static"
   }
 }
@@ -38,7 +38,7 @@ resource "azurerm_network_interface" "nics-dbnodes-db" {
     primary                       = true
     name                          = "${local.dbnodes[count.index].name}-db-nic-ip"
     subnet_id                     = var.subnet-sap-db[0].id
-    private_ip_address            = var.infrastructure.vnets.sap.subnet_db.is_existing ? local.dbnodes[count.index].db_nic_ip : lookup(local.dbnodes[count.index], "db_nic_ip", false) != false ? local.dbnodes[count.index].db_nic_ip : cidrhost(var.infrastructure.vnets.sap.subnet_db.prefix, tonumber(count.index) + 20)
+    private_ip_address            = var.infrastructure.vnets.sap.subnet_db.is_existing ? local.dbnodes[count.index].db_nic_ip : lookup(local.dbnodes[count.index], "db_nic_ip", false) != false ? local.dbnodes[count.index].db_nic_ip : cidrhost(var.infrastructure.vnets.sap.subnet_db.prefix, tonumber(count.index) + 10)
     private_ip_address_allocation = "static"
   }
 }
@@ -59,7 +59,7 @@ resource "azurerm_network_interface_security_group_association" "nic-dbnodes-db-
 # LOAD BALANCER ===================================================================================================
 
 /*-----------------------------------------------------------------------------8
-Load balancer front IP address range: .10 - .19
+Load balancer front IP address range: .4 - .9
 +--------------------------------------4--------------------------------------*/
 
 resource "azurerm_lb" "hana-lb" {
@@ -72,7 +72,7 @@ resource "azurerm_lb" "hana-lb" {
     name                          = "hana-${each.value.sid}-lb-feip"
     subnet_id                     = var.subnet-sap-db[0].id
     private_ip_address_allocation = "Static"
-    private_ip_address            = var.infrastructure.vnets.sap.subnet_db.is_existing ? each.value.frontend_ip : lookup(each.value, "frontend_ip", false) != false ? each.value.frontend_ip : cidrhost(var.infrastructure.vnets.sap.subnet_db.prefix, tonumber(each.key) + 10)
+    private_ip_address            = var.infrastructure.vnets.sap.subnet_db.is_existing ? each.value.frontend_ip : lookup(each.value, "frontend_ip", false) != false ? each.value.frontend_ip : cidrhost(var.infrastructure.vnets.sap.subnet_db.prefix, tonumber(each.key) + 4)
   }
 }
 

--- a/deploy/terraform/modules/hdb_node/vm-hdb.tf
+++ b/deploy/terraform/modules/hdb_node/vm-hdb.tf
@@ -7,7 +7,7 @@
 # NICS ============================================================================================================
 
 /*-----------------------------------------------------------------------------8
-HANA DB Linux Server private IP range: .10 - 
+HANA DB Linux Server private IP range: .20 - 
 +--------------------------------------4--------------------------------------*/
 
 # Creates the admin traffic NIC and private IP address for database nodes
@@ -21,7 +21,7 @@ resource "azurerm_network_interface" "nics-dbnodes-admin" {
   ip_configuration {
     name                          = "${local.dbnodes[count.index].name}-admin-nic-ip"
     subnet_id                     = var.subnet-sap-admin[0].id
-    private_ip_address            = var.infrastructure.vnets.sap.subnet_admin.is_existing ? local.dbnodes[count.index].admin_nic_ip : lookup(local.dbnodes[count.index], "admin_nic_ip", false) != false ? local.dbnodes[count.index].admin_nic_ip : cidrhost(var.infrastructure.vnets.sap.subnet_admin.prefix, tonumber(count.index) + 14)
+    private_ip_address            = var.infrastructure.vnets.sap.subnet_admin.is_existing ? local.dbnodes[count.index].admin_nic_ip : lookup(local.dbnodes[count.index], "admin_nic_ip", false) != false ? local.dbnodes[count.index].admin_nic_ip : cidrhost(var.infrastructure.vnets.sap.subnet_admin.prefix, tonumber(count.index) + 20)
     private_ip_address_allocation = "static"
   }
 }
@@ -38,7 +38,7 @@ resource "azurerm_network_interface" "nics-dbnodes-db" {
     primary                       = true
     name                          = "${local.dbnodes[count.index].name}-db-nic-ip"
     subnet_id                     = var.subnet-sap-db[0].id
-    private_ip_address            = var.infrastructure.vnets.sap.subnet_db.is_existing ? local.dbnodes[count.index].db_nic_ip : lookup(local.dbnodes[count.index], "db_nic_ip", false) != false ? local.dbnodes[count.index].db_nic_ip : cidrhost(var.infrastructure.vnets.sap.subnet_db.prefix, tonumber(count.index) + 14)
+    private_ip_address            = var.infrastructure.vnets.sap.subnet_db.is_existing ? local.dbnodes[count.index].db_nic_ip : lookup(local.dbnodes[count.index], "db_nic_ip", false) != false ? local.dbnodes[count.index].db_nic_ip : cidrhost(var.infrastructure.vnets.sap.subnet_db.prefix, tonumber(count.index) + 20)
     private_ip_address_allocation = "static"
   }
 }
@@ -59,7 +59,7 @@ resource "azurerm_network_interface_security_group_association" "nic-dbnodes-db-
 # LOAD BALANCER ===================================================================================================
 
 /*-----------------------------------------------------------------------------8
-Load balancer front IP address range: .4 - .9
+Load balancer front IP address range: .10 - .20
 +--------------------------------------4--------------------------------------*/
 
 resource "azurerm_lb" "hana-lb" {
@@ -72,7 +72,7 @@ resource "azurerm_lb" "hana-lb" {
     name                          = "hana-${each.value.sid}-lb-feip"
     subnet_id                     = var.subnet-sap-db[0].id
     private_ip_address_allocation = "Static"
-    private_ip_address            = var.infrastructure.vnets.sap.subnet_db.is_existing ? each.value.frontend_ip : lookup(each.value, "frontend_ip", false) != false ? each.value.frontend_ip : cidrhost(var.infrastructure.vnets.sap.subnet_db.prefix, tonumber(each.key) + 4)
+    private_ip_address            = var.infrastructure.vnets.sap.subnet_db.is_existing ? each.value.frontend_ip : lookup(each.value, "frontend_ip", false) != false ? each.value.frontend_ip : cidrhost(var.infrastructure.vnets.sap.subnet_db.prefix, tonumber(each.key) + 10)
   }
 }
 

--- a/templates/tempGen/sap-allNew-HA.json
+++ b/templates/tempGen/sap-allNew-HA.json
@@ -8,7 +8,7 @@
           "subnet_iscsi": {
             "is_existing": "false",
             "name": "subnet-iscsi",
-            "prefix": "10.1.3.0/24",
+            "prefix": "10.1.4.0/24",
             "nsg": {
               "is_existing": "false",
               "name": "nsg-iscsi"

--- a/templates/tempGen/sap-allNew-HA.json
+++ b/templates/tempGen/sap-allNew-HA.json
@@ -3,6 +3,19 @@
       "resource_group" : {
           "name" : "var-rg-name"
       },
+      "vnets": {
+        "sap": {
+          "subnet_iscsi": {
+            "is_existing": "false",
+            "name": "subnet-iscsi",
+            "prefix": "10.1.3.0/24",
+            "nsg": {
+              "is_existing": "false",
+              "name": "nsg-iscsi"
+            }
+          }
+        }
+      },
       "iscsi": {
       "iscsi_count": 3,
       "size":"Standard_D2s_v3",


### PR DESCRIPTION
## Problem
iSCSI device need to have it's own subnet in sap vnet, since it is not tight to any SID.

## Description
- iSCSI will deploy it's own subnet, use .4 - 
- Move LB to still use .4 - .9
- Move DB VMs to use .10 -

## Test
local run terraform plan to confirm the IP spaces.