### PR TITLE
[HOTFIX] Skip prometheus if error

### DIFF
--- a/deploy/ansible/roles/enable-prometheus/tasks/main.yml
+++ b/deploy/ansible/roles/enable-prometheus/tasks/main.yml
@@ -20,8 +20,7 @@
   ignore_errors: yes
 
 - name: Ensure Prometheus is installed and configured
-  when: (add_repo_status.failed is defined and add_repo_status.failed == false) or
-        (add_repo_status.skipped is defined and add_repo_status.skipped == True)
+  when: not (add_repo_status.failed is defined and add_repo_status.failed == true)
   block:
   - name: Install Prometheus with Node and HA Cluster exporters
     zypper:

--- a/deploy/ansible/roles/enable-prometheus/tasks/main.yml
+++ b/deploy/ansible/roles/enable-prometheus/tasks/main.yml
@@ -16,28 +16,34 @@
     repo: "https://download.opensuse.org/repositories/server:/monitoring/{{ distro }}/server:monitoring.repo"
     state: present
   when: monitor_repo.stat.exists == false
+  register: add_repo_status
+  ignore_errors: yes
 
-- name: Install Prometheus with Node and HA Cluster exporters
-  zypper:
-    name: "{{ item }}"
-    disable_gpg_check: yes
-  loop:
-    - golang-github-prometheus-node_exporter
-    - prometheus-ha_cluster_exporter
+- name: Ensure Prometheus is installed and configured
+  when: (add_repo_status.failed is defined and add_repo_status.failed == false) or
+        (add_repo_status.skipped is defined and add_repo_status.skipped == True)
+  block:
+  - name: Install Prometheus with Node and HA Cluster exporters
+    zypper:
+      name: "{{ item }}"
+      disable_gpg_check: yes
+    loop:
+      - golang-github-prometheus-node_exporter
+      - prometheus-ha_cluster_exporter
 
-- name: Set arguments for Node exporter
-  lineinfile:
-    path: /etc/sysconfig/prometheus-node_exporter
-    regexp: 'ARGS=.*'
-    line: 'ARGS="--collector.systemd"'
+  - name: Set arguments for Node exporter
+    lineinfile:
+      path: /etc/sysconfig/prometheus-node_exporter
+      regexp: 'ARGS=.*'
+      line: 'ARGS="--collector.systemd"'
 
-- name: Start the Node exporter
-  service:
-    name: prometheus-node_exporter
-    state: started
+  - name: Start the Node exporter
+    service:
+      name: prometheus-node_exporter
+      state: started
 
-- name: Start the HA Cluster exporter (HA Clusters only)
-  service:
-    name: prometheus-ha_cluster_exporter
-    state: started
-  when: hana_database.high_availability == True
+  - name: Start the HA Cluster exporter (HA Clusters only)
+    service:
+      name: prometheus-ha_cluster_exporter
+      state: started
+    when: hana_database.high_availability == True


### PR DESCRIPTION
## Problem
There is a change in cert of Prometheus repo.
This caused add repo task to fail in pipeline.

## Description
The rest of the playbook has no dependency on prometheus.
Therefore we skip prometheus if add repo fails, but continue with the rest of playbook