### PR TITLE
Optimize Ansible: Make packages installation fail fast

### DIFF
--- a/deploy/ansible/sap_playbook.yml
+++ b/deploy/ansible/sap_playbook.yml
@@ -35,6 +35,7 @@
       include_vars:
         file: ../hdb_sizes.json
         name: hdb_sizes
+  max_fail_percentage: 0
   roles:
     - role: os-preparation
     - role: os-disk-setup


### PR DESCRIPTION
Sometimes, there are pkgs missing in the repo, especially when os is SLES. Since all os pkgs specified should be installed successfully before subsequent steps, add a check to make it fail fast.
Symptom:
failed: [10.1.1.15] (item=libyui-qt-pkg7) => {"ansible_loop_var": "item", "changed": false, "cmd": ["/usr/bin/zypper", "--quiet", "--non-interactive", "--xmlout", "install", "--type", "package", "--auto-agree-with-licenses", "--no-recommends", "--", "+libyui-qt-pkg7"], "item": "libyui-qt-pkg7", "msg": "Zypper run failed.", "rc": 106, "stderr": "", "stderr_lines": [], "stdout": "<?xml version='1.0'?>\n<stream>\n<prompt id=\"11\">\n<text>File &apos;repomd.xml&apos; from repository &apos;SLE-Module-Adv-Systems-Management12-Pool&apos; is unsigned...
