### PR TITLE
Hotfix: SCS LB IPs in HA mode, closes 552

### DIFF
--- a/deploy/terraform/modules/app_tier/scs-vm.tf
+++ b/deploy/terraform/modules/app_tier/scs-vm.tf
@@ -27,7 +27,7 @@ resource "azurerm_lb" "scs-lb" {
       name                          = "${frontend_ip_configuration.value == 0 ? "scs" : "ers"}-${var.application.sid}-lb-feip"
       subnet_id                     = var.infrastructure.vnets.sap.subnet_app.is_existing ? data.azurerm_subnet.subnet-sap-app[0].id : azurerm_subnet.subnet-sap-app[0].id
       private_ip_address_allocation = "Static"
-      private_ip_address            = cidrhost(var.infrastructure.vnets.sap.subnet_app.prefix, tonumber(count.index) + local.ip_offsets.scs_lb)
+      private_ip_address            = cidrhost(var.infrastructure.vnets.sap.subnet_app.prefix, tonumber(frontend_ip_configuration.value) + local.ip_offsets.scs_lb)
     }
   }
 }


### PR DESCRIPTION
# Problem

Dynamically generated IPs for HA SCS Load Balancer front end configuration are using the wrong variable.  See #552

## Description

This PR updates the variable used when generating the front end IP configurations