### PR TITLE
Enable/Disable HDB module

### DIFF
--- a/deploy/terraform/modules/hdb_node/hdb-nsg.tf
+++ b/deploy/terraform/modules/hdb_node/hdb-nsg.tf
@@ -6,7 +6,7 @@
 
 # Creates network security rule to allow internal traffic for SAP db subnet
 resource "azurerm_network_security_rule" "nsr-internal-db" {
-  count                       = var.infrastructure.vnets.sap.subnet_db.nsg.is_existing ? 0 : 1
+  count                       = local.enable_deployment ? (var.infrastructure.vnets.sap.subnet_db.nsg.is_existing ? 0 : 1) : 0
   name                        = "allow-internal-traffic"
   resource_group_name         = var.infrastructure.vnets.sap.subnet_db.nsg.is_existing ? data.azurerm_network_security_group.nsg-db[0].resource_group_name : azurerm_network_security_group.nsg-db[0].resource_group_name
   network_security_group_name = var.infrastructure.vnets.sap.subnet_db.nsg.is_existing ? data.azurerm_network_security_group.nsg-db[0].name : azurerm_network_security_group.nsg-db[0].name
@@ -22,7 +22,7 @@ resource "azurerm_network_security_rule" "nsr-internal-db" {
 
 # Creates network security rule to deny external traffic for SAP db subnet
 resource "azurerm_network_security_rule" "nsr-external-db" {
-  count                       = var.infrastructure.vnets.sap.subnet_db.nsg.is_existing ? 0 : 1
+  count                       = local.enable_deployment ? (var.infrastructure.vnets.sap.subnet_db.nsg.is_existing ? 0 : 1) : 0
   name                        = "deny-inbound-traffic"
   resource_group_name         = var.infrastructure.vnets.sap.subnet_db.nsg.is_existing ? data.azurerm_network_security_group.nsg-db[0].resource_group_name : azurerm_network_security_group.nsg-db[0].resource_group_name
   network_security_group_name = var.infrastructure.vnets.sap.subnet_db.nsg.is_existing ? data.azurerm_network_security_group.nsg-db[0].name : azurerm_network_security_group.nsg-db[0].name
@@ -38,7 +38,7 @@ resource "azurerm_network_security_rule" "nsr-external-db" {
 
 # Creates network security rule for SAP admin subnet
 resource "azurerm_network_security_rule" "nsr-admin" {
-  count                       = var.infrastructure.vnets.sap.subnet_admin.nsg.is_existing ? 0 : 1
+  count                       = local.enable_deployment ? (var.infrastructure.vnets.sap.subnet_admin.nsg.is_existing ? 0 : 1) : 0
   name                        = "nsr-subnet-admin"
   resource_group_name         = var.infrastructure.vnets.sap.subnet_admin.nsg.is_existing ? data.azurerm_network_security_group.nsg-admin[0].resource_group_name : azurerm_network_security_group.nsg-admin[0].resource_group_name
   network_security_group_name = var.infrastructure.vnets.sap.subnet_admin.nsg.is_existing ? data.azurerm_network_security_group.nsg-admin[0].name : azurerm_network_security_group.nsg-admin[0].name

--- a/deploy/terraform/modules/hdb_node/infrastructure.tf
+++ b/deploy/terraform/modules/hdb_node/infrastructure.tf
@@ -1,6 +1,6 @@
 # Creates admin subnet of SAP VNET
 resource "azurerm_subnet" "subnet-sap-admin" {
-  count                = var.infrastructure.vnets.sap.subnet_admin.is_existing ? 0 : 1
+  count                = local.enable_deployment ? (var.infrastructure.vnets.sap.subnet_admin.is_existing ? 0 : 1) : 0
   name                 = var.infrastructure.vnets.sap.subnet_admin.name
   resource_group_name  = var.vnet-sap[0].resource_group_name
   virtual_network_name = var.vnet-sap[0].name
@@ -9,7 +9,7 @@ resource "azurerm_subnet" "subnet-sap-admin" {
 
 # Creates db subnet of SAP VNET
 resource "azurerm_subnet" "subnet-sap-db" {
-  count                = var.infrastructure.vnets.sap.subnet_db.is_existing ? 0 : 1
+  count                = local.enable_deployment ? (var.infrastructure.vnets.sap.subnet_db.is_existing ? 0 : 1) : 0
   name                 = var.infrastructure.vnets.sap.subnet_db.name
   resource_group_name  = var.vnet-sap[0].resource_group_name
   virtual_network_name = var.vnet-sap[0].name
@@ -18,7 +18,7 @@ resource "azurerm_subnet" "subnet-sap-db" {
 
 # Imports data of existing SAP admin subnet
 data "azurerm_subnet" "subnet-sap-admin" {
-  count                = var.infrastructure.vnets.sap.subnet_admin.is_existing ? 1 : 0
+  count                = local.enable_deployment ? (var.infrastructure.vnets.sap.subnet_admin.is_existing ? 1 : 0) : 0
   name                 = split("/", var.infrastructure.vnets.sap.subnet_admin.arm_id)[10]
   resource_group_name  = split("/", var.infrastructure.vnets.sap.subnet_admin.arm_id)[4]
   virtual_network_name = split("/", var.infrastructure.vnets.sap.subnet_admin.arm_id)[8]
@@ -26,7 +26,7 @@ data "azurerm_subnet" "subnet-sap-admin" {
 
 # Imports data of existing SAP db subnet
 data "azurerm_subnet" "subnet-sap-db" {
-  count                = var.infrastructure.vnets.sap.subnet_db.is_existing ? 1 : 0
+  count                = local.enable_deployment ? (var.infrastructure.vnets.sap.subnet_db.is_existing ? 1 : 0) : 0
   name                 = split("/", var.infrastructure.vnets.sap.subnet_db.arm_id)[10]
   resource_group_name  = split("/", var.infrastructure.vnets.sap.subnet_db.arm_id)[4]
   virtual_network_name = split("/", var.infrastructure.vnets.sap.subnet_db.arm_id)[8]
@@ -34,7 +34,7 @@ data "azurerm_subnet" "subnet-sap-db" {
 
 # Creates SAP admin subnet nsg
 resource "azurerm_network_security_group" "nsg-admin" {
-  count               = var.infrastructure.vnets.sap.subnet_admin.nsg.is_existing ? 0 : 1
+  count               = local.enable_deployment ? (var.infrastructure.vnets.sap.subnet_admin.nsg.is_existing ? 0 : 1) : 0
   name                = var.infrastructure.vnets.sap.subnet_admin.nsg.name
   location            = var.infrastructure.region
   resource_group_name = var.vnet-sap[0].resource_group_name
@@ -42,7 +42,7 @@ resource "azurerm_network_security_group" "nsg-admin" {
 
 # Creates SAP db subnet nsg
 resource "azurerm_network_security_group" "nsg-db" {
-  count               = var.infrastructure.vnets.sap.subnet_db.nsg.is_existing ? 0 : 1
+  count               = local.enable_deployment ? (var.infrastructure.vnets.sap.subnet_db.nsg.is_existing ? 0 : 1) : 0
   name                = var.infrastructure.vnets.sap.subnet_db.nsg.name
   location            = var.infrastructure.region
   resource_group_name = var.vnet-sap[0].resource_group_name
@@ -50,28 +50,28 @@ resource "azurerm_network_security_group" "nsg-db" {
 
 # Imports the SAP admin subnet nsg data
 data "azurerm_network_security_group" "nsg-admin" {
-  count               = var.infrastructure.vnets.sap.subnet_admin.nsg.is_existing ? 1 : 0
+  count               = local.enable_deployment ? (var.infrastructure.vnets.sap.subnet_admin.nsg.is_existing ? 1 : 0) : 0
   name                = split("/", var.infrastructure.vnets.sap.subnet_admin.nsg.arm_id)[8]
   resource_group_name = split("/", var.infrastructure.vnets.sap.subnet_admin.nsg.arm_id)[4]
 }
 
 # Imports the SAP db subnet nsg data
 data "azurerm_network_security_group" "nsg-db" {
-  count               = var.infrastructure.vnets.sap.subnet_db.nsg.is_existing ? 1 : 0
+  count               = local.enable_deployment ? (var.infrastructure.vnets.sap.subnet_db.nsg.is_existing ? 1 : 0) : 0
   name                = split("/", var.infrastructure.vnets.sap.subnet_db.nsg.arm_id)[8]
   resource_group_name = split("/", var.infrastructure.vnets.sap.subnet_db.nsg.arm_id)[4]
 }
 
 # Associates SAP admin nsg to SAP admin subnet
 resource "azurerm_subnet_network_security_group_association" "Associate-nsg-admin" {
-  count                     = signum((var.infrastructure.vnets.sap.subnet_admin.is_existing ? 0 : 1) + (var.infrastructure.vnets.sap.subnet_admin.nsg.is_existing ? 0 : 1))
+  count                     = local.enable_deployment ? (signum((var.infrastructure.vnets.sap.subnet_admin.is_existing ? 0 : 1) + (var.infrastructure.vnets.sap.subnet_admin.nsg.is_existing ? 0 : 1))) : 0
   subnet_id                 = var.infrastructure.vnets.sap.subnet_admin.is_existing ? data.azurerm_subnet.subnet-sap-admin[0].id : azurerm_subnet.subnet-sap-admin[0].id
   network_security_group_id = var.infrastructure.vnets.sap.subnet_admin.nsg.is_existing ? data.azurerm_network_security_group.nsg-admin[0].id : azurerm_network_security_group.nsg-admin[0].id
 }
 
 # Associates SAP db nsg to SAP db subnet
 resource "azurerm_subnet_network_security_group_association" "Associate-nsg-db" {
-  count                     = signum((var.infrastructure.vnets.sap.subnet_db.is_existing ? 0 : 1) + (var.infrastructure.vnets.sap.subnet_db.nsg.is_existing ? 0 : 1))
+  count                     = local.enable_deployment ? (signum((var.infrastructure.vnets.sap.subnet_db.is_existing ? 0 : 1) + (var.infrastructure.vnets.sap.subnet_db.nsg.is_existing ? 0 : 1))) : 0
   subnet_id                 = var.infrastructure.vnets.sap.subnet_db.is_existing ? data.azurerm_subnet.subnet-sap-db[0].id : azurerm_subnet.subnet-sap-db[0].id
   network_security_group_id = var.infrastructure.vnets.sap.subnet_db.nsg.is_existing ? data.azurerm_network_security_group.nsg-db[0].id : azurerm_network_security_group.nsg-db[0].id
 }

--- a/deploy/terraform/modules/hdb_node/vm-hdb.tf
+++ b/deploy/terraform/modules/hdb_node/vm-hdb.tf
@@ -12,7 +12,7 @@ HANA DB Linux Server private IP range: .10 -
 
 # Creates the admin traffic NIC and private IP address for database nodes
 resource "azurerm_network_interface" "nics-dbnodes-admin" {
-  count                         = length(local.dbnodes)
+  count                         = local.enable_deployment ? length(local.dbnodes) : 0
   name                          = "${local.dbnodes[count.index].name}-admin-nic"
   location                      = var.resource-group[0].location
   resource_group_name           = var.resource-group[0].name
@@ -28,7 +28,7 @@ resource "azurerm_network_interface" "nics-dbnodes-admin" {
 
 # Creates the DB traffic NIC and private IP address for database nodes
 resource "azurerm_network_interface" "nics-dbnodes-db" {
-  count                         = length(local.dbnodes)
+  count                         = local.enable_deployment ? length(local.dbnodes) : 0
   name                          = "${local.dbnodes[count.index].name}-db-nic"
   location                      = var.resource-group[0].location
   resource_group_name           = var.resource-group[0].name
@@ -50,32 +50,32 @@ Load balancer front IP address range: .4 - .9
 +--------------------------------------4--------------------------------------*/
 
 resource "azurerm_lb" "hana-lb" {
-  for_each            = local.loadbalancers
-  name                = "hana-${each.value.sid}-lb"
+  count               = local.enable_deployment ? length(local.sid-infra) : 0
+  name                = "hana-${local.sid-infra[count.index].sid}-lb"
   resource_group_name = var.resource-group[0].name
   location            = var.resource-group[0].location
 
   frontend_ip_configuration {
-    name                          = "hana-${each.value.sid}-lb-feip"
+    name                          = "hana-${local.sid-infra[count.index].sid}-lb-feip"
     subnet_id                     = var.infrastructure.vnets.sap.subnet_db.is_existing ? data.azurerm_subnet.subnet-sap-db[0].id : azurerm_subnet.subnet-sap-db[0].id
     private_ip_address_allocation = "Static"
-    private_ip_address            = var.infrastructure.vnets.sap.subnet_db.is_existing ? each.value.frontend_ip : lookup(each.value, "frontend_ip", false) != false ? each.value.frontend_ip : cidrhost(var.infrastructure.vnets.sap.subnet_db.prefix, tonumber(each.key) + 4)
+    private_ip_address            = var.infrastructure.vnets.sap.subnet_db.is_existing ? local.sid-infra[count.index].frontend_ip : lookup(local.sid-infra[count.index], "frontend_ip", false) != false ? local.sid-infra[count.index].frontend_ip : cidrhost(var.infrastructure.vnets.sap.subnet_db.prefix, tonumber(count.index) + 4)
   }
 }
 
 resource "azurerm_lb_backend_address_pool" "hana-lb-back-pool" {
-  for_each            = local.loadbalancers
+  count               = local.enable_deployment ? length(local.sid-infra) : 0
   resource_group_name = var.resource-group[0].name
-  loadbalancer_id     = azurerm_lb.hana-lb[tonumber(each.key)].id
-  name                = "hana-${each.value.sid}-lb-bep"
+  loadbalancer_id     = azurerm_lb.hana-lb[count.index].id
+  name                = "hana-${local.sid-infra[count.index].sid}-lb-bep"
 }
 
 resource "azurerm_lb_probe" "hana-lb-health-probe" {
-  for_each            = local.loadbalancers
+  count               = local.enable_deployment ? length(local.sid-infra) : 0
   resource_group_name = var.resource-group[0].name
-  loadbalancer_id     = azurerm_lb.hana-lb[0].id
-  name                = "hana-${each.value.sid}-lb-hp"
-  port                = "625${each.value.instance_number}"
+  loadbalancer_id     = azurerm_lb.hana-lb[count.index].id
+  name                = "hana-${local.sid-infra[count.index].sid}-lb-hp"
+  port                = "625${local.sid-infra[count.index].instance_number}"
   protocol            = "Tcp"
   interval_in_seconds = 5
   number_of_probes    = 2
@@ -85,31 +85,31 @@ resource "azurerm_lb_probe" "hana-lb-health-probe" {
 # Current behavior, it will try to add all VMs in the cluster into the backend pool, which would not work since we do not have availability sets created yet.
 # In a scale-out scenario, we need to rewrite this code according to the scale-out + HA reference architecture.
 resource "azurerm_network_interface_backend_address_pool_association" "hana-lb-nic-bep" {
-  count                   = length(azurerm_network_interface.nics-dbnodes-db)
+  count                   = local.enable_deployment ? length(azurerm_network_interface.nics-dbnodes-db) : 0
   network_interface_id    = azurerm_network_interface.nics-dbnodes-db[count.index].id
   ip_configuration_name   = azurerm_network_interface.nics-dbnodes-db[count.index].ip_configuration[0].name
-  backend_address_pool_id = azurerm_lb_backend_address_pool.hana-lb-back-pool[0].id
+  backend_address_pool_id = azurerm_lb_backend_address_pool.hana-lb-back-pool[index(local.hdb-sids, local.dbnodes[count.index].sid)].id
 }
 
 resource "azurerm_lb_rule" "hana-lb-rules" {
-  count                          = length(local.loadbalancers-ports)
+  count                          = local.enable_deployment ? length(local.loadbalancer_ports) : 0
   resource_group_name            = var.resource-group[0].name
-  loadbalancer_id                = azurerm_lb.hana-lb[0].id
-  name                           = "HANA_${local.loadbalancers[0].sid}_${local.loadbalancers[0].ports[count.index]}"
+  loadbalancer_id                = azurerm_lb.hana-lb[index(local.hdb-sids, local.loadbalancer_ports[count.index].sid)].id
+  name                           = "HANA_${local.loadbalancer_ports[count.index].sid}_${local.loadbalancer_ports[count.index].port}"
   protocol                       = "Tcp"
-  frontend_port                  = local.loadbalancers[0].ports[count.index]
-  backend_port                   = local.loadbalancers[0].ports[count.index]
-  frontend_ip_configuration_name = "hana-${local.loadbalancers[0].sid}-lb-feip"
-  backend_address_pool_id        = azurerm_lb_backend_address_pool.hana-lb-back-pool[0].id
-  probe_id                       = azurerm_lb_probe.hana-lb-health-probe[0].id
+  frontend_port                  = local.loadbalancer_ports[count.index].port
+  backend_port                   = local.loadbalancer_ports[count.index].port
+  frontend_ip_configuration_name = "hana-${local.loadbalancer_ports[count.index].sid}-lb-feip"
+  backend_address_pool_id        = azurerm_lb_backend_address_pool.hana-lb-back-pool[index(local.hdb-sids, local.loadbalancer_ports[count.index].sid)].id
+  probe_id                       = azurerm_lb_probe.hana-lb-health-probe[index(local.hdb-sids, local.loadbalancer_ports[count.index].sid)].id
   enable_floating_ip             = true
 }
 
 # AVAILABILITY SET ================================================================================================
 
 resource "azurerm_availability_set" "hana-as" {
-  for_each                     = local.loadbalancers
-  name                         = "${each.value.sid}-as"
+  count                        = local.enable_deployment ? length(local.sid-infra) : 0
+  name                         = "${local.sid-infra[count.index].sid}-as"
   location                     = var.resource-group[0].location
   resource_group_name          = var.resource-group[0].name
   platform_update_domain_count = 20
@@ -122,7 +122,7 @@ resource "azurerm_availability_set" "hana-as" {
 
 # Creates managed data disk
 resource "azurerm_managed_disk" "data-disk" {
-  count                = length(local.data-disk-list)
+  count                = local.enable_deployment ? length(local.data-disk-list) : 0
   name                 = local.data-disk-list[count.index].name
   location             = var.resource-group[0].location
   resource_group_name  = var.resource-group[0].name
@@ -133,12 +133,12 @@ resource "azurerm_managed_disk" "data-disk" {
 
 # Manages Linux Virtual Machine for HANA DB servers
 resource "azurerm_linux_virtual_machine" "vm-dbnode" {
-  count                           = length(local.dbnodes)
+  count                           = local.enable_deployment ? length(local.dbnodes) : 0
   name                            = local.dbnodes[count.index].name
   computer_name                   = local.dbnodes[count.index].name
   location                        = var.resource-group[0].location
   resource_group_name             = var.resource-group[0].name
-  availability_set_id             = azurerm_availability_set.hana-as[0].id
+  availability_set_id             = azurerm_availability_set.hana-as[index(local.hdb-sids, local.dbnodes[count.index].sid)].id
   proximity_placement_group_id    =  lookup(var.infrastructure, "ppg", false) != false ? (var.ppg[0].id) : null
   network_interface_ids           = [
     azurerm_network_interface.nics-dbnodes-admin[count.index].id,
@@ -179,7 +179,7 @@ resource "azurerm_linux_virtual_machine" "vm-dbnode" {
 
 # Manages attaching a Disk to a Virtual Machine
 resource "azurerm_virtual_machine_data_disk_attachment" "vm-dbnode-data-disk" {
-  count                     = length(local.data-disk-list)
+  count                     = local.enable_deployment ? length(local.data-disk-list) : 0
   managed_disk_id           = azurerm_managed_disk.data-disk[count.index].id
   virtual_machine_id        = azurerm_linux_virtual_machine.vm-dbnode[floor(count.index / length(local.data-disk-per-dbnode))].id
   caching                   = local.data-disk-list[count.index].caching


### PR DESCRIPTION
# Problem

The HDB module cannot be disabled without entirely removing the `databases` entry.  This is required by the design going forwards.

See #506 

## Description

This PR creates a local variable in the HDB module and updates other local variables to allow the use of counts throughout the hdb node module.  This also allows us to create 0 resources if required.