### PR TITLE
Terraform: Add Application VMs to generated Ansible inventory

### DIFF
--- a/deploy/ansible/sap_playbook.yml
+++ b/deploy/ansible/sap_playbook.yml
@@ -6,7 +6,7 @@
   pre_tasks:
     - name: Include output JSON
       include_vars:
-        file: "{{ inventory_dir }}/output.json"
+        file: "{{ lookup('env', 'PWD') }}/output.json"
         name: output
 
     - name: Create dictionary with HANA database inforamtion from output.JSON
@@ -22,7 +22,7 @@
   roles:
     - role: inventory-validation
       when:
-        - hana_database.size != "LargeInstance"   
+        - hana_database.size != "LargeInstance"
 
 # Prepare os, disks and mount points on Hana Database servers
 - hosts: hanadbnodes
@@ -85,7 +85,7 @@
   become_user: root
   roles:
    - role: iscsi-target-install
-     when: 
+     when:
        - hana_database.high_availability
        - hostvars[hana_database.nodes[0].ip_admin_nic].ansible_os_family == 'Suse'
 

--- a/deploy/ansible/sap_playbook.yml
+++ b/deploy/ansible/sap_playbook.yml
@@ -6,7 +6,7 @@
   pre_tasks:
     - name: Include output JSON
       include_vars:
-        file: "{{ lookup('env', 'PWD') }}/output.json"
+        file: "{{ inventory_dir }}/output.json"
         name: output
 
     - name: Create dictionary with HANA database inforamtion from output.JSON

--- a/deploy/terraform/ansible.tf
+++ b/deploy/terraform/ansible.tf
@@ -7,9 +7,9 @@ resource "null_resource" "prepare_rti_files" {
   depends_on = [module.output_files.ansible-inventory, module.output_files.output-json, module.jumpbox.prepare-rti]
 
   triggers = {
-    hosts  = sha1(local.file_hosts)
-    hosts2 = sha1(local.file_hosts2)
-    output = sha1(local.file_output)
+    hosts     = sha1(local.file_hosts)
+    hosts_yml = sha1(local.file_hosts_yml)
+    output    = sha1(local.file_output)
   }
 
   connection {

--- a/deploy/terraform/ansible.tf
+++ b/deploy/terraform/ansible.tf
@@ -8,6 +8,7 @@ resource "null_resource" "prepare-rti-files" {
 
   triggers = {
     hosts  = sha1(local.file_hosts)
+    hosts2 = sha1(local.file_hosts2)
     output = sha1(local.file_output)
   }
 

--- a/deploy/terraform/ansible.tf
+++ b/deploy/terraform/ansible.tf
@@ -47,7 +47,7 @@ resource "null_resource" "ansible_playbook" {
       "export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES",
       "export ANSIBLE_HOST_KEY_CHECKING=False",
       "source ~/export-clustering-sp-details.sh",
-      "ansible-playbook -i hosts ~/sap-hana/deploy/ansible/sap_playbook.yml"
+      "ansible-playbook -i hosts.yml ~/sap-hana/deploy/ansible/sap_playbook.yml"
     ]
   }
 }

--- a/deploy/terraform/module.tf
+++ b/deploy/terraform/module.tf
@@ -87,4 +87,7 @@ module "output_files" {
   nics-dbnodes-admin           = module.hdb_node.nics-dbnodes-admin
   nics-dbnodes-db              = module.hdb_node.nics-dbnodes-db
   loadbalancers                = module.hdb_node.loadbalancers
+  hdb-sids                     = module.hdb_node.hdb-sids
+  nics-scs                     = module.app_tier.nics-scs
+  nics-app                     = module.app_tier.nics-app
 }

--- a/deploy/terraform/modules/app_tier/outputs.tf
+++ b/deploy/terraform/modules/app_tier/outputs.tf
@@ -1,0 +1,7 @@
+output "nics-scs" {
+  value = azurerm_network_interface.nics-scs
+}
+
+output "nics-app" {
+  value = azurerm_network_interface.nics-app
+}

--- a/deploy/terraform/modules/hdb_node/outputs.tf
+++ b/deploy/terraform/modules/hdb_node/outputs.tf
@@ -10,6 +10,10 @@ output "loadbalancers" {
   value = azurerm_lb.hana-lb
 }
 
+output "hdb-sids" {
+  value = local.hdb-sids
+}
+
 # Workaround to create dependency betweeen ../main.tf ansible_execution and module hdb_node
 output "dbnode-data-disk-att" {
   value = azurerm_virtual_machine_data_disk_attachment.vm-dbnode-data-disk

--- a/deploy/terraform/modules/output_files/ansible_inventory.tmpl
+++ b/deploy/terraform/modules/output_files/ansible_inventory.tmpl
@@ -84,6 +84,6 @@ ${ip-scs}  ansible_connection=ssh ansible_user=${application.authentication.user
 %{~ endfor }
 
 [app]
-%{ for ip-app in ips-app }
+%{~ for ip-app in ips-app }
 ${ip-app}  ansible_connection=ssh ansible_user=${application.authentication.username}
 %{~ endfor }

--- a/deploy/terraform/modules/output_files/ansible_inventory.tmpl
+++ b/deploy/terraform/modules/output_files/ansible_inventory.tmpl
@@ -61,6 +61,12 @@ ${ip-dbnode-admin}  ansible_connection=ssh  ansible_user=${dbnodes[index(ips-dbn
 ${ip-dbnode-admin}  ansible_connection=ssh  ansible_user=${dbnodes[index(ips-dbnodes-admin, ip-dbnode-admin)].authentication.username}  ansible_ssh_pass=${dbnodes[index(ips-dbnodes-admin, ip-dbnode-admin)].authentication.password}  ansible_become_pass=${dbnodes[index(ips-dbnodes-admin, ip-dbnode-admin)].authentication.password}
 %{~ endif }
 %{~ endfor }
+%{~ for ip-scs in ips-scs }
+${ip-scs}  ansible_connection=ssh ansible_user=${application.authentication.username}
+%{~ endfor }
+%{ for ip-app in ips-app }
+${ip-app}  ansible_connection=ssh ansible_user=${application.authentication.username}
+%{~ endfor }
 
 [hanadbnodes]
 %{~ for ip-dbnode-admin in ips-dbnodes-admin }

--- a/deploy/terraform/modules/output_files/ansible_inventory.tmpl
+++ b/deploy/terraform/modules/output_files/ansible_inventory.tmpl
@@ -71,3 +71,13 @@ ${ip-dbnode-admin}  ansible_connection=ssh  ansible_user=${dbnodes[index(ips-dbn
 ${ip-dbnode-admin}  ansible_connection=ssh  ansible_user=${dbnodes[index(ips-dbnodes-admin, ip-dbnode-admin)].authentication.username}  ansible_ssh_pass=${dbnodes[index(ips-dbnodes-admin, ip-dbnode-admin)].authentication.password}  ansible_become_pass=${dbnodes[index(ips-dbnodes-admin, ip-dbnode-admin)].authentication.password}
 %{~ endif }
 %{~ endfor }
+
+[scs]
+%{~ for ip-scs in ips-scs }
+${ip-scs}  ansible_connection=ssh ansible_user=${application.authentication.username}
+%{~ endfor }
+
+[app]
+%{ for ip-app in ips-app }
+${ip-app}  ansible_connection=ssh ansible_user=${application.authentication.username}
+%{~ endfor }

--- a/deploy/terraform/modules/output_files/ansible_inventory.yml.tmpl
+++ b/deploy/terraform/modules/output_files/ansible_inventory.yml.tmpl
@@ -87,3 +87,10 @@ all:
         hanadbnodes:
         scs:
         app:
+
+    # Localhost provisioning
+    local:
+      hosts:
+        localhost:
+          ansible_connection: "local"
+          ansible_user:       "azureadm"

--- a/deploy/terraform/modules/output_files/ansible_inventory.yml.tmpl
+++ b/deploy/terraform/modules/output_files/ansible_inventory.yml.tmpl
@@ -1,0 +1,91 @@
+all:
+  children:
+    iscsi:
+      hosts:
+%{~ for ip-iscsi in ips-iscsi }
+        ${ip-iscsi}:
+%{~ if iscsi.authentication.type == "key" }
+          ansible_connection: "ssh"
+          ansible_user:       "${iscsi.authentication.username}"
+%{~ endif }
+%{~ if iscsi.authentication.type == "password" }
+          ansible_user:        "${iscsi.authentication.username}"
+          ansible_ssh_pass:    "${iscsi.authentication.password}"
+          ansible_become_pass: "${iscsi.authentication.password}"
+%{~ endif }
+%{~ endfor }
+
+    jumpboxes_windows:
+      hosts:
+%{~ for jumpbox-windows in jumpboxes-windows }
+        ${ips-jumpboxes-windows[index(jumpboxes-windows, jumpbox-windows)]}:
+          ansible_connection:                   "winrm"
+          ansible_user:                         "${jumpbox-windows.authentication.username}"
+          ansible_ssh_pass:                     "${jumpbox-windows.authentication.password}"
+          ansible_ssh_port:                     5986
+          ansible_winrm_transport:              "ntlm"
+          ansible_winrm_server_cert_validation: "ignore"
+%{~ endfor }
+
+    jumpboxes_linux:
+      hosts:
+%{~ for jumpbox-linux in jumpboxes-linux }
+%{~ if jumpbox-linux.destroy_after_deploy != "true"}
+        ${ips-jumpboxes-linux[index(jumpboxes-linux, jumpbox-linux)]}:
+%{~ if jumpbox-linux.authentication.type == "key" }
+          ansible_connection: "ssh"
+          ansible_user:       "${jumpbox-linux.authentication.username}"
+%{~ endif }
+%{~ if jumpbox-linux.authentication.type == "password" }
+          ansible_connection:  "ssh"
+          ansible_user:        "${jumpbox-linux.authentication.username}"
+          ansible_ssh_pass:    "${jumpbox-linux.authentication.password}"
+          ansible_become_pass: "${jumpbox-linux.authentication.password}"
+%{~ endif }
+%{~ endif }
+%{~ endfor }
+
+    hanadbnodes:
+      hosts:
+%{~ for ip-dbnode-admin in ips-dbnodes-admin }
+        ${ip-dbnode-admin}:
+%{~ if dbnodes[index(ips-dbnodes-admin, ip-dbnode-admin)].authentication.type == "key" }
+          ansible_connection: "ssh"
+          ansible_user:       "${dbnodes[index(ips-dbnodes-admin, ip-dbnode-admin)].authentication.username}"
+%{~ endif }
+%{~ if dbnodes[index(ips-dbnodes-admin, ip-dbnode-admin)].authentication.type == "password" }
+          ansible_connection:  "ssh"
+          ansible_user:        "${dbnodes[index(ips-dbnodes-admin, ip-dbnode-admin)].authentication.username}"
+          ansible_ssh_pass:    "${dbnodes[index(ips-dbnodes-admin, ip-dbnode-admin)].authentication.password}"
+          ansible_become_pass: "${dbnodes[index(ips-dbnodes-admin, ip-dbnode-admin)].authentication.password}"
+%{~ endif }
+%{~ endfor }
+
+    scs:
+      hosts:
+%{~ for ip-scs in ips-scs }
+        ${ip-scs}:
+          ansible_connection: "ssh"
+          ansible_user:       "${application.authentication.username}"
+%{~ endfor }
+
+    app:
+      hosts:
+%{~ for ip-app in ips-app }
+        ${ip-app}:
+          ansible_connection: "ssh"
+          ansible_user:       "${application.authentication.username}"
+%{~ endfor }
+
+    # Groups below are collections of the above groups for easier refernce
+    all_jumpboxes:
+      children:
+        jumpboxes_windows:
+        jumpboxes_linux:
+
+    all_linux_servers:
+      children:
+        jumpboxes_linux:
+        hanadbnodes:
+        scs:
+        app:

--- a/deploy/terraform/modules/output_files/ansible_inventory.yml.tmpl
+++ b/deploy/terraform/modules/output_files/ansible_inventory.yml.tmpl
@@ -4,9 +4,9 @@ all:
       hosts:
 %{~ for ip-iscsi in ips-iscsi }
         ${ip-iscsi}:
+          ansible_connection:  "ssh"
 %{~ if iscsi.authentication.type == "key" }
-          ansible_connection: "ssh"
-          ansible_user:       "${iscsi.authentication.username}"
+          ansible_user:        "${iscsi.authentication.username}"
 %{~ endif }
 %{~ if iscsi.authentication.type == "password" }
           ansible_user:        "${iscsi.authentication.username}"
@@ -32,12 +32,11 @@ all:
 %{~ for jumpbox-linux in jumpboxes-linux }
 %{~ if jumpbox-linux.destroy_after_deploy != "true"}
         ${ips-jumpboxes-linux[index(jumpboxes-linux, jumpbox-linux)]}:
+          ansible_connection:  "ssh"
 %{~ if jumpbox-linux.authentication.type == "key" }
-          ansible_connection: "ssh"
-          ansible_user:       "${jumpbox-linux.authentication.username}"
+          ansible_user:        "${jumpbox-linux.authentication.username}"
 %{~ endif }
 %{~ if jumpbox-linux.authentication.type == "password" }
-          ansible_connection:  "ssh"
           ansible_user:        "${jumpbox-linux.authentication.username}"
           ansible_ssh_pass:    "${jumpbox-linux.authentication.password}"
           ansible_become_pass: "${jumpbox-linux.authentication.password}"
@@ -49,12 +48,11 @@ all:
       hosts:
 %{~ for ip-dbnode-admin in ips-dbnodes-admin }
         ${ip-dbnode-admin}:
+          ansible_connection:  "ssh"
 %{~ if dbnodes[index(ips-dbnodes-admin, ip-dbnode-admin)].authentication.type == "key" }
-          ansible_connection: "ssh"
-          ansible_user:       "${dbnodes[index(ips-dbnodes-admin, ip-dbnode-admin)].authentication.username}"
+          ansible_user:        "${dbnodes[index(ips-dbnodes-admin, ip-dbnode-admin)].authentication.username}"
 %{~ endif }
 %{~ if dbnodes[index(ips-dbnodes-admin, ip-dbnode-admin)].authentication.type == "password" }
-          ansible_connection:  "ssh"
           ansible_user:        "${dbnodes[index(ips-dbnodes-admin, ip-dbnode-admin)].authentication.username}"
           ansible_ssh_pass:    "${dbnodes[index(ips-dbnodes-admin, ip-dbnode-admin)].authentication.password}"
           ansible_become_pass: "${dbnodes[index(ips-dbnodes-admin, ip-dbnode-admin)].authentication.password}"

--- a/deploy/terraform/modules/output_files/inventory.tf
+++ b/deploy/terraform/modules/output_files/inventory.tf
@@ -53,7 +53,7 @@ resource "local_file" "output-json" {
         } if local.dbnodes[index(local.ips-dbnodes-admin, ip-dbnode-admin)].platform == database.platform
       ],
       loadbalancer = {
-        frontend_ip = var.loadbalancers[index(var.databases, database)].private_ip_address
+        frontend_ip = var.loadbalancers[index(var.hdb-sids, database.instance.sid)].private_ip_address
       }
       }
     ],
@@ -83,8 +83,31 @@ resource "local_file" "ansible-inventory" {
     ips-jumpboxes-linux   = local.ips-jumpboxes-linux,
     ips-dbnodes-admin     = local.ips-dbnodes-admin,
     ips-dbnodes-db        = local.ips-dbnodes-db,
-    dbnodes               = local.dbnodes
+    dbnodes               = local.dbnodes,
+    application           = var.application,
+    ips-scs               = local.ips-scs,
+    ips-app               = local.ips-app
     }
   )
   filename = "${terraform.workspace}/ansible_config_files/hosts"
+}
+
+# Generates the Ansible Inventory file
+resource "local_file" "ansible-inventory-yml" {
+  content = templatefile("${path.module}/ansible_inventory.yml.tmpl", {
+    iscsi                 = lookup(var.infrastructure, "iscsi", {}),
+    jumpboxes-windows     = var.jumpboxes.windows,
+    jumpboxes-linux       = var.jumpboxes-linux,
+    ips-iscsi             = local.ips-iscsi,
+    ips-jumpboxes-windows = local.ips-jumpboxes-windows,
+    ips-jumpboxes-linux   = local.ips-jumpboxes-linux,
+    ips-dbnodes-admin     = local.ips-dbnodes-admin,
+    ips-dbnodes-db        = local.ips-dbnodes-db,
+    dbnodes               = local.dbnodes,
+    application           = var.application,
+    ips-scs               = local.ips-scs,
+    ips-app               = local.ips-app
+    }
+  )
+  filename = "${terraform.workspace}/ansible_config_files/hosts.yml"
 }

--- a/deploy/terraform/modules/output_files/outputs.tf
+++ b/deploy/terraform/modules/output_files/outputs.tf
@@ -5,3 +5,7 @@ output "output-json" {
 output "ansible-inventory" {
   value = local_file.ansible-inventory
 }
+
+output "ansible-inventory-yml" {
+  value = local_file.ansible-inventory-yml
+}

--- a/deploy/terraform/modules/output_files/variables_local.tf
+++ b/deploy/terraform/modules/output_files/variables_local.tf
@@ -38,6 +38,18 @@ variable "loadbalancers" {
   description = "List of LoadBalancers created for HANA Databases"
 }
 
+variable "hdb-sids" {
+  description = "List of SIDs used when generating Load Balancers"
+}
+
+variable "nics-scs" {
+  description = "List of NICs for the SCS Application VMs"
+}
+
+variable "nics-app" {
+  description = "List of NICs for the Application Instance VMs"
+}
+
 locals {
   ips-iscsi                    = var.nics-iscsi[*].private_ip_address
   ips-jumpboxes-windows        = var.nics-jumpboxes-windows[*].private_ip_address
@@ -55,6 +67,7 @@ locals {
           authentication = database.authentication,
           name           = "${dbnode.name}-0"
         }
+        if database.platform == "HANA"
       ],
       [
         for dbnode in database.dbnodes : {
@@ -63,8 +76,10 @@ locals {
           authentication = database.authentication,
           name           = "${dbnode.name}-1"
         }
-        if database.high_availability
+        if database.platform == "HANA" && database.high_availability
       ]
     ])
   ])
+  ips-scs = [for key, value in var.nics-scs : value.private_ip_address]
+  ips-app = [for key, value in var.nics-app : value.private_ip_address]
 }

--- a/deploy/terraform/variables_local.tf
+++ b/deploy/terraform/variables_local.tf
@@ -23,5 +23,6 @@ locals {
   ], 0) : ""
 
   file_hosts  = fileexists("${terraform.workspace}/ansible_config_files/hosts") ? file("${terraform.workspace}/ansible_config_files/hosts") : ""
+  file_hosts2 = fileexists("${terraform.workspace}/ansible_config_files/hosts.yml") ? file("${terraform.workspace}/ansible_config_files/hosts.yml") : ""
   file_output = fileexists("${terraform.workspace}/ansible_config_files/output.json") ? file("${terraform.workspace}/ansible_config_files/output.json") : ""
 }

--- a/deploy/terraform/variables_local.tf
+++ b/deploy/terraform/variables_local.tf
@@ -22,7 +22,7 @@ locals {
     if database.platform == "HANA"
   ], 0) : ""
 
-  file_hosts  = fileexists("${terraform.workspace}/ansible_config_files/hosts") ? file("${terraform.workspace}/ansible_config_files/hosts") : ""
-  file_hosts2 = fileexists("${terraform.workspace}/ansible_config_files/hosts.yml") ? file("${terraform.workspace}/ansible_config_files/hosts.yml") : ""
-  file_output = fileexists("${terraform.workspace}/ansible_config_files/output.json") ? file("${terraform.workspace}/ansible_config_files/output.json") : ""
+  file_hosts     = fileexists("${terraform.workspace}/ansible_config_files/hosts") ? file("${terraform.workspace}/ansible_config_files/hosts") : ""
+  file_hosts_yml = fileexists("${terraform.workspace}/ansible_config_files/hosts.yml") ? file("${terraform.workspace}/ansible_config_files/hosts.yml") : ""
+  file_output    = fileexists("${terraform.workspace}/ansible_config_files/output.json") ? file("${terraform.workspace}/ansible_config_files/output.json") : ""
 }

--- a/documentation/ansible/running-ansible-playbook.md
+++ b/documentation/ansible/running-ansible-playbook.md
@@ -17,8 +17,7 @@ Master Branch's status: [![Build Status](https://dev.azure.com/azuresaphana/Azur
    - Start the ansible playbook<sup>[1](#myfootnote1)</sup>:
 
     ```bash
-    ansible-playbook -i hosts ~/sap-hana/deploy/v2/ansible/sap_playbook.yml 
-    ``` 
+    ansible-playbook -i hosts.yml ~/sap-hana/deploy/v2/ansible/sap_playbook.yml
+    ```
 
 <sup>[1](#myfootnote1): The ansible playbook currently configures the VMs without HANA installation.</sup>
-

--- a/templates/ansible-deployment-steps-daily.yaml
+++ b/templates/ansible-deployment-steps-daily.yaml
@@ -29,7 +29,7 @@ steps:
       export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
       export ANSIBLE_HOST_KEY_CHECKING=False
       source export-clustering-sp-details.sh
-      ansible-playbook -i hosts sap-hana/deploy/ansible/sap_playbook.yml
+      ansible-playbook -i hosts.yml sap-hana/deploy/ansible/sap_playbook.yml
       '
     displayName: 'Ansible Deployment'
     env:

--- a/templates/ansible-deployment-steps.yaml
+++ b/templates/ansible-deployment-steps.yaml
@@ -26,7 +26,7 @@ steps:
       export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
       export ANSIBLE_HOST_KEY_CHECKING=False
       source export-clustering-sp-details.sh
-      ansible-playbook -i hosts sap-hana/deploy/ansible/sap_playbook.yml
+      ansible-playbook -i hosts.yml sap-hana/deploy/ansible/sap_playbook.yml
       '
     displayName: 'Ansible Deployment'
     env:


### PR DESCRIPTION
# Problem

See #558 - Application VMs are not currently in the generated Ansible inventory.  

## Description

This PR:

- Adds the Application VMs to the inventory
- Creates a duplicate YAML format inventory
- Updates the Ansible execution code to use the YAML format inventory
- Updates the Ansible Execution documentation to use the YAML format inventory
- Updates the HDB Loadbalancer use in `output_files` to prevent issue if multiple HANA platform entries are added to `databases`

Closes #558

## Notes

- [This change to the SAP Playbook](https://github.com/Azure/sap-hana/pull/560/files#diff-a73b84fbeab05fe149919c634ed1dc5aR9) is necessary as using a YAML format Inventory prevents [`inventory_dir` variable isn't always declared](https://github.com/ansible/ansible/issues/30901#issuecomment-334530854)