### PR TITLE
Create NSG with the RG in JSON

### DIFF
--- a/deploy/terraform/modules/app_tier/infrastructure.tf
+++ b/deploy/terraform/modules/app_tier/infrastructure.tf
@@ -19,8 +19,8 @@ data "azurerm_subnet" "subnet-sap-app" {
 resource "azurerm_network_security_group" "nsg-app" {
   count               = local.enable_deployment ? (var.infrastructure.vnets.sap.subnet_app.nsg.is_existing ? 0 : 1) : 0
   name                = var.infrastructure.vnets.sap.subnet_app.nsg.name
-  location            = var.infrastructure.region
-  resource_group_name = var.vnet-sap[0].resource_group_name
+  location            = var.resource-group[0].location
+  resource_group_name = var.resource-group[0].name
 }
 
 # Imports the SAP app subnet nsg data

--- a/deploy/terraform/modules/hdb_node/infrastructure.tf
+++ b/deploy/terraform/modules/hdb_node/infrastructure.tf
@@ -36,16 +36,16 @@ data "azurerm_subnet" "subnet-sap-db" {
 resource "azurerm_network_security_group" "nsg-admin" {
   count               = local.enable_deployment ? (var.infrastructure.vnets.sap.subnet_admin.nsg.is_existing ? 0 : 1) : 0
   name                = var.infrastructure.vnets.sap.subnet_admin.nsg.name
-  location            = var.infrastructure.region
-  resource_group_name = var.vnet-sap[0].resource_group_name
+  location            = var.resource-group[0].location
+  resource_group_name = var.resource-group[0].name
 }
 
 # Creates SAP db subnet nsg
 resource "azurerm_network_security_group" "nsg-db" {
   count               = local.enable_deployment ? (var.infrastructure.vnets.sap.subnet_db.nsg.is_existing ? 0 : 1) : 0
   name                = var.infrastructure.vnets.sap.subnet_db.nsg.name
-  location            = var.infrastructure.region
-  resource_group_name = var.vnet-sap[0].resource_group_name
+  location            = var.resource-group[0].location
+  resource_group_name = var.resource-group[0].name
 }
 
 # Imports the SAP admin subnet nsg data


### PR DESCRIPTION
## Problem:
Currently if we reuse vnet, NSG will be created in the rg of that vnet, instead of the RG defined in JSON.

## Solution:
Correct that for both hdb and app module.