### PR TITLE
Adjust dependency for null resource

### DIFF
--- a/deploy/terraform/ansible.tf
+++ b/deploy/terraform/ansible.tf
@@ -3,7 +3,7 @@
     1. prepare-rti-files: copy required files for Ansible onto RTI
     2. ansible_playbook: run playbook
 +--------------------------------------4--------------------------------------*/
-resource "null_resource" "prepare-rti-files" {
+resource "null_resource" "prepare_rti_files" {
   depends_on = [module.output_files.ansible-inventory, module.output_files.output-json]
 
   triggers = {
@@ -37,7 +37,7 @@ resource "null_resource" "prepare-rti-files" {
 
 resource "null_resource" "ansible_playbook" {
   count      = var.options.ansible_execution ? 1 : 0
-  depends_on = [null_resource.prepare-rti-files, module.hdb_node.dbnode-data-disk-att, module.jumpbox.prepare-rti, module.jumpbox.vm-windows]
+  depends_on = [null_resource.prepare_rti_files, module.hdb_node.dbnode-data-disk-att, module.jumpbox.prepare-rti, module.jumpbox.vm-windows]
 
   connection {
     type        = "ssh"

--- a/deploy/terraform/ansible.tf
+++ b/deploy/terraform/ansible.tf
@@ -4,7 +4,7 @@
     2. ansible_playbook: run playbook
 +--------------------------------------4--------------------------------------*/
 resource "null_resource" "prepare-rti-files" {
-  depends_on = [module.hdb_node.dbnode-data-disk-att, module.jumpbox.prepare-rti, module.jumpbox.vm-windows]
+  depends_on = [module.output_files.ansible-inventory, module.output_files.output-json]
 
   triggers = {
     hosts  = sha1(local.file_hosts)
@@ -37,7 +37,16 @@ resource "null_resource" "prepare-rti-files" {
 
 resource "null_resource" "ansible_playbook" {
   count      = var.options.ansible_execution ? 1 : 0
-  depends_on = [null_resource.prepare-rti-files]
+  depends_on = [null_resource.prepare-rti-files, module.hdb_node.dbnode-data-disk-att, module.jumpbox.prepare-rti, module.jumpbox.vm-windows]
+
+  connection {
+    type        = "ssh"
+    host        = module.jumpbox.rti-info.public_ip_address
+    user        = module.jumpbox.rti-info.authentication.username
+    private_key = module.jumpbox.rti-info.authentication.type == "key" ? file(var.sshkey.path_to_private_key) : null
+    password    = lookup(module.jumpbox.rti-info.authentication, "password", null)
+    timeout     = var.ssh-timeout
+  }
 
   # Run Ansible Playbook on jumpbox if ansible_execution set to true
   provisioner "remote-exec" {

--- a/deploy/terraform/ansible.tf
+++ b/deploy/terraform/ansible.tf
@@ -4,7 +4,7 @@
     2. ansible_playbook: run playbook
 +--------------------------------------4--------------------------------------*/
 resource "null_resource" "prepare_rti_files" {
-  depends_on = [module.output_files.ansible-inventory, module.output_files.output-json]
+  depends_on = [module.output_files.ansible-inventory, module.output_files.output-json, module.jumpbox.prepare-rti]
 
   triggers = {
     hosts  = sha1(local.file_hosts)
@@ -37,7 +37,7 @@ resource "null_resource" "prepare_rti_files" {
 
 resource "null_resource" "ansible_playbook" {
   count      = var.options.ansible_execution ? 1 : 0
-  depends_on = [null_resource.prepare_rti_files, module.hdb_node.dbnode-data-disk-att, module.jumpbox.prepare-rti, module.jumpbox.vm-windows]
+  depends_on = [null_resource.prepare_rti_files, module.hdb_node.dbnode-data-disk-att, module.jumpbox.vm-windows]
 
   connection {
     type        = "ssh"


### PR DESCRIPTION
## Problem:
- `prepare-rti-files` only require the copied file to be ready.
- `ansible_playbook` is where require resources to be ready for ansible
- connection section is missing from `ansible_playbook`

## Solution:
- Move dependency to right location
- Add connection back to `ansible_playbook`
- This should also improve the success ratio of pipeline

## Test:
- Deployment with `ansible_execution` set to `true` successful.

```
null_resource.ansible_playbook[0] (remote-exec): PLAY RECAP *********************************************************************
null_resource.ansible_playbook[0] (remote-exec): 10.1.1.10                  : ok=52   changed=30   unreachable=0    failed=0    skipped=106  rescued=0    ignored=0
null_resource.ansible_playbook[0] (remote-exec): localhost                  : ok=13   changed=6    unreachable=0    failed=0    skipped=5    rescued=0    ignored=0

null_resource.ansible_playbook[0]: Creation complete after 10m35s [id=2804361254810806688]

Apply complete! Resources: 56 added, 0 changed, 0 destroyed.

Outputs:

ansible-jumpbox-public-ip-address = 52.152.166.24
ansible-jumpbox-username = azureadm
```