### PR TITLE
Fix the wrong rg location assignment when existing rg is used

### DIFF
--- a/deploy/terraform/modules/common_infrastructure/admin-nsg.tf
+++ b/deploy/terraform/modules/common_infrastructure/admin-nsg.tf
@@ -10,7 +10,7 @@
 resource "azurerm_network_security_group" "nsg-mgmt" {
   count               = var.infrastructure.vnets.management.subnet_mgmt.nsg.is_existing ? 0 : 1
   name                = var.infrastructure.vnets.management.subnet_mgmt.nsg.name
-  location            = var.infrastructure.region
+  location            = var.infrastructure.resource_group.is_existing ? data.azurerm_resource_group.resource-group[0].location : azurerm_resource_group.resource-group[0].location
   resource_group_name = var.infrastructure.resource_group.is_existing ? data.azurerm_resource_group.resource-group[0].name : azurerm_resource_group.resource-group[0].name
 }
 

--- a/deploy/terraform/modules/common_infrastructure/infrastructure.tf
+++ b/deploy/terraform/modules/common_infrastructure/infrastructure.tf
@@ -23,7 +23,7 @@ data "azurerm_resource_group" "resource-group" {
 resource "azurerm_virtual_network" "vnet-management" {
   count               = var.infrastructure.vnets.management.is_existing ? 0 : 1
   name                = var.infrastructure.vnets.management.name
-  location            = var.infrastructure.region
+  location            = var.infrastructure.resource_group.is_existing ? data.azurerm_resource_group.resource-group[0].location : azurerm_resource_group.resource-group[0].location
   resource_group_name = var.infrastructure.resource_group.is_existing ? data.azurerm_resource_group.resource-group[0].name : azurerm_resource_group.resource-group[0].name
   address_space       = [var.infrastructure.vnets.management.address_space]
 }
@@ -32,7 +32,7 @@ resource "azurerm_virtual_network" "vnet-management" {
 resource "azurerm_virtual_network" "vnet-sap" {
   count               = var.infrastructure.vnets.sap.is_existing ? 0 : 1
   name                = var.infrastructure.vnets.sap.name
-  location            = var.infrastructure.region
+  location            = var.infrastructure.resource_group.is_existing ? data.azurerm_resource_group.resource-group[0].location : azurerm_resource_group.resource-group[0].location
   resource_group_name = var.infrastructure.resource_group.is_existing ? data.azurerm_resource_group.resource-group[0].name : azurerm_resource_group.resource-group[0].name
   address_space       = [var.infrastructure.vnets.sap.address_space]
 }
@@ -116,7 +116,7 @@ resource "azurerm_storage_account" "storage-sapbits" {
   count                     = var.software.storage_account_sapbits.is_existing ? 0 : 1
   name                      = lookup(var.software.storage_account_sapbits, "name", false) ? var.software.storage_account_sapbits.name : "sapbits${random_id.random-id.hex}"
   resource_group_name       = var.infrastructure.resource_group.is_existing ? data.azurerm_resource_group.resource-group[0].name : azurerm_resource_group.resource-group[0].name
-  location                  = var.infrastructure.region
+  location                  = var.infrastructure.resource_group.is_existing ? data.azurerm_resource_group.resource-group[0].location : azurerm_resource_group.resource-group[0].location
   account_replication_type  = "LRS"
   account_tier              = var.software.storage_account_sapbits.account_tier
   account_kind              = var.software.storage_account_sapbits.account_kind
@@ -149,7 +149,7 @@ data "azurerm_storage_account" "storage-sapbits" {
 resource "azurerm_storage_account" "storage-bootdiag" {
   name                      = lookup(var.infrastructure, "boot_diagnostics_account_name", false) == false ? "sabootdiag${random_id.random-id.hex}" : var.infrastructure.boot_diagnostics_account_name
   resource_group_name       = var.infrastructure.resource_group.is_existing ? data.azurerm_resource_group.resource-group[0].name : azurerm_resource_group.resource-group[0].name
-  location                  = var.infrastructure.region
+  location                  = var.infrastructure.resource_group.is_existing ? data.azurerm_resource_group.resource-group[0].location : azurerm_resource_group.resource-group[0].location
   account_replication_type  = "LRS"
   account_tier              = "Standard"
   enable_https_traffic_only = var.options.enable_secure_transfer == "" ? true : var.options.enable_secure_transfer

--- a/deploy/terraform/modules/common_infrastructure/iscsi.tf
+++ b/deploy/terraform/modules/common_infrastructure/iscsi.tf
@@ -32,7 +32,7 @@ data "azurerm_subnet" "iscsi" {
 resource "azurerm_network_security_group" "iscsi" {
   count               = local.iscsi.iscsi_count == 0 ? 0 : (local.subnet_iscsi.nsg.is_existing ? 0 : 1)
   name                = local.subnet_iscsi.nsg.name
-  location            = var.infrastructure.region
+  location            = var.infrastructure.resource_group.is_existing ? data.azurerm_resource_group.resource-group[0].location : azurerm_resource_group.resource-group[0].location
   resource_group_name = var.infrastructure.resource_group.is_existing ? data.azurerm_resource_group.resource-group[0].name : azurerm_resource_group.resource-group[0].name
 }
 

--- a/deploy/terraform/modules/common_infrastructure/iscsi.tf
+++ b/deploy/terraform/modules/common_infrastructure/iscsi.tf
@@ -66,7 +66,7 @@ iSCSI device IP address range: .4 -
 resource "azurerm_network_interface" "iscsi" {
   count               = local.iscsi.iscsi_count
   name                = "iscsi-${format("%02d", count.index)}-nic"
-  location            = var.infrastructure.region
+  location            = var.infrastructure.resource_group.is_existing ? data.azurerm_resource_group.resource-group[0].location : azurerm_resource_group.resource-group[0].location
   resource_group_name = var.infrastructure.resource_group.is_existing ? data.azurerm_resource_group.resource-group[0].name : azurerm_resource_group.resource-group[0].name
 
   ip_configuration {
@@ -88,7 +88,7 @@ resource "azurerm_network_interface_security_group_association" "iscsi" {
 resource "azurerm_linux_virtual_machine" "iscsi" {
   count                           = local.iscsi.iscsi_count
   name                            = "iscsi-${format("%02d", count.index)}"
-  location                        = var.infrastructure.region
+  location                        = var.infrastructure.resource_group.is_existing ? data.azurerm_resource_group.resource-group[0].location : azurerm_resource_group.resource-group[0].location
   resource_group_name             = var.infrastructure.resource_group.is_existing ? data.azurerm_resource_group.resource-group[0].name : azurerm_resource_group.resource-group[0].name
   network_interface_ids           = [azurerm_network_interface.iscsi[count.index].id]
   size                            = local.iscsi.size


### PR DESCRIPTION
## Problem
Fix issue #545 

## Solution
Always take the location of the rg regardless new rg or existing rg is used.

## Test
1. Create rg in westus2.
1. Deploy with rg location eastus in JSON.
1. All resources are correctly deployed in westus2.
