### PR TITLE
Set secondary site with readaccess

### DIFF
--- a/deploy/ansible/roles/hana-system-replication/tasks/pre_checks.yml
+++ b/deploy/ansible/roles/hana-system-replication/tasks/pre_checks.yml
@@ -28,34 +28,37 @@
   failed_when: hana_process_list_result.rc != 3
   changed_when: false
 
-- name: Check whether HANA has been installed as a single container (no SYSTEMDB)
-  become_user: "{{ sid_admin_user }}"
-  shell: >
-    source ~/.bashrc ;
-    {{ hdbsql_systemdb_command }} "SELECT DATABASE_NAME FROM SYS.M_DATABASES"
-  register: hana_container_status
-  changed_when: false
-  failed_when: false
+- name: Check on the primary node whether installed HANA is single container or multi-container
+  when: ansible_hostname == hana_database.nodes[0].dbname
+  block:
+  - name: Check whether HANA has been installed as a single container (no SYSTEMDB)
+    become_user: "{{ sid_admin_user }}"
+    shell: >
+      source ~/.bashrc ;
+      {{ hdbsql_systemdb_command }} "SELECT DATABASE_NAME FROM SYS.M_DATABASES"
+    register: hana_container_status
+    changed_when: false
+    failed_when: false
 
-- name: Ensure systemdb fact is set
-  set_fact:
-    hana_has_system_db: "{{ ('SYSTEMDB' in hana_container_status.stdout) | bool }}"
+  - name: Ensure systemdb fact is set
+    set_fact:
+      hana_has_system_db: "{{ ('SYSTEMDB' in hana_container_status.stdout) | bool }}"
 
-- name: Ensure tenant db fact is set
-  set_fact:
-    hana_has_tenant_db: "{{ (sid_upper in hana_container_status.stdout) | bool }}"
-  vars:
-    sid_upper: "{{ sid | upper }}"
+  - name: Ensure tenant db fact is set
+    set_fact:
+      hana_has_tenant_db: "{{ (sid_upper in hana_container_status.stdout) | bool }}"
+    vars:
+      sid_upper: "{{ sid | upper }}"
 
-- name: Ensure failure with meaningful message if no {{ sid | upper }} tenant db
-  fail:
-    msg: |
-      Automated HANA System Replication configuration is only supported for systems with a SYSTEMDB
-      and multi-container systems where the tenant database is named as {{ sid | upper }}.
-      If your requirements differ, please raise a GitHub issue: https://github.com/Azure/sap-hana/issues/new/choose
-  # At the moment it's sufficient to check for a missing SYSTEMDB, since the
-  # code will cope with a missing tenant DB.
-  when: not hana_has_system_db
+  - name: Ensure failure with meaningful message if no {{ sid | upper }} tenant db
+    fail:
+      msg: |
+        Automated HANA System Replication configuration is only supported for systems with a SYSTEMDB
+        and multi-container systems where the tenant database is named as {{ sid | upper }}.
+        If your requirements differ, please raise a GitHub issue: https://github.com/Azure/sap-hana/issues/new/choose
+    # At the moment it's sufficient to check for a missing SYSTEMDB, since the
+    # code will cope with a missing tenant DB.
+    when: not hana_has_system_db
 
 - name: Check whether replication has already been set up
   become_user: "{{ sid_admin_user }}"

--- a/deploy/ansible/roles/hana-system-replication/tasks/pre_checks.yml
+++ b/deploy/ansible/roles/hana-system-replication/tasks/pre_checks.yml
@@ -28,8 +28,22 @@
   failed_when: hana_process_list_result.rc != 3
   changed_when: false
 
+- name: Check whether replication has already been set up
+  become_user: "{{ sid_admin_user }}"
+  shell: >
+    source ~/.bashrc ;
+    {{ hdbnsutil_command }} -sr_state
+  register: hana_replication_status
+  changed_when: false
+  failed_when: false
+
+- name: Ensure current replication status is known
+  set_fact:
+    hana_system_replication_enabled: "{{ 'mode: none' not in hana_replication_status.stdout }}"
+
 - name: Check on the primary node whether installed HANA is single container or multi-container
-  when: ansible_hostname == hana_database.nodes[0].dbname
+  # If HSR is already enabled, we cannot read from the secondary node
+  when: ansible_hostname == hana_database.nodes[0].dbname or not hana_system_replication_enabled
   block:
   - name: Check whether HANA has been installed as a single container (no SYSTEMDB)
     become_user: "{{ sid_admin_user }}"
@@ -60,19 +74,6 @@
     # code will cope with a missing tenant DB.
     when: not hana_has_system_db
 
-- name: Check whether replication has already been set up
-  become_user: "{{ sid_admin_user }}"
-  shell: >
-    source ~/.bashrc ;
-    {{ hdbnsutil_command }} -sr_state
-  register: hana_replication_status
-  changed_when: false
-  failed_when: false
-
-- name: Ensure current replication status is known
-  set_fact:
-    hana_system_replication_enabled: "{{ 'mode: none' not in hana_replication_status.stdout }}"
-
 - name: Check that HANA DB SYSTEM user can access the SYSTEM database
   # If HSR is already enabled, we cannot read from the secondary node
   when: (ansible_hostname == hana_database.nodes[0].dbname) or not hana_system_replication_enabled
@@ -85,7 +86,7 @@
 - name: Check that HANA DB SYSTEM user can access the tenant database {{ hana_tenant_database_name }}
   # If HSR is already enabled, we cannot read from the secondary node
   when:
-    - hana_has_tenant_db
+    - hana_has_tenant_db is defined and hana_has_tenant_db
     - (ansible_hostname == hana_database.nodes[0].dbname) or not hana_system_replication_enabled
   become_user: "{{ sid_admin_user }}"
   shell: >


### PR DESCRIPTION
## Problem
If we run the HSR configuration for the second time, it failed because secondary is already configured with HSR and do not have read access.

```
TASK [hana-system-replication : Ensure failure with meaningful message if no HN1 tenant db] ***
task path: /home/azureadm/sap-hana/deploy/ansible/roles/hana-system-replication/tasks/pre_checks.yml:50
Read vars_file 'vars/ha-packages.yml'
skipping: [10.1.1.10] => {
    "changed": false,
    "skip_reason": "Conditional result was False"
}
fatal: [10.1.1.11]: FAILED! => {
    "changed": false,
    "msg": "Automated HANA System Replication configuration is only supported for systems with a SYSTEMDB\nand multi-container systems where the tenant database is named as HN1.\nIf your requirements differ, please raise a GitHub issue: https://github.com/Azure/sap-hana/issues/new/choose\n"
}
```

## Solution
One option would be to change the `logmode` to `logreplay_readaccess`, however the HSR won't be able to repeat for other `logmode`.
Therefore the below change has been made:
- make sure the single/multiple container check only performs on primary node is HSR has been configured - meaning secondary node may not have read access.
- make sure `hana_has_tenant_db` is validated before use in condition - when HSR has been configured, `hana_has_tenant_db` will be undefined for secondary node hence fail the play.

## Test
Run playbook on an HSR configured cluster and no error.