### PR TITLE
[HOTFIX] Fix code when platform type NONE

### DIFF
--- a/deploy/terraform/modules/output_files/inventory.tf
+++ b/deploy/terraform/modules/output_files/inventory.tf
@@ -32,7 +32,7 @@ resource "local_file" "output-json" {
         }
       ]
     },
-    "databases" = [for database in var.databases : {
+    "databases" = [for database in local.databases : {
       platform          = database.platform,
       db_version        = database.db_version,
       os                = database.os,

--- a/deploy/terraform/modules/output_files/variables_local.tf
+++ b/deploy/terraform/modules/output_files/variables_local.tf
@@ -58,6 +58,10 @@ locals {
   public-ips-jumpboxes-linux   = var.public-ips-jumpboxes-linux[*].ip_address
   ips-dbnodes-admin            = [for key, value in var.nics-dbnodes-admin : value.private_ip_address]
   ips-dbnodes-db               = [for key, value in var.nics-dbnodes-db : value.private_ip_address]
+  databases = [
+    for database in var.databases : database
+    if contains(["HANA"], database.platform)
+  ]
   dbnodes = flatten([
     for database in var.databases : flatten([
       [


### PR DESCRIPTION
## Problem:
To fix issue #575 

## Solution:
1. Create databases as local variable by accepting supported database type (currently "HANA")

## Test:
Successfully deploy without HANA resources when `"platform": "NONE"`.