### PR TITLE
Allow multiple data disks for SCS and App VMs

### DIFF
--- a/deploy/app_sizes.json
+++ b/deploy/app_sizes.json
@@ -5,12 +5,13 @@
         "vm_size": "Standard_D4s_v3",
         "accelerated_networking": false
       },
-      "storage": {
+      "storage": [{
+        "name": "data",
         "disk_type": "Premium_LRS",
         "size_gb": 512,
         "caching": "None",
         "write_accelerator": false
-      }
+      }]
     }
   },
   "scs": {
@@ -19,12 +20,13 @@
         "vm_size": "Standard_D4s_v3",
         "accelerated_networking": false
       },
-      "storage": {
+      "storage": [{
+        "name": "data",
         "disk_type": "Premium_LRS",
         "size_gb": 512,
         "caching": "None",
         "write_accelerator": false
-      }
+      }]
     }
   },
   "web": {
@@ -33,12 +35,13 @@
         "vm_size": "Standard_D4s_v3",
         "accelerated_networking": false
       },
-      "storage": {
+      "storage": [{
+        "name": "data",
         "disk_type": "Premium_LRS",
         "size_gb": 512,
         "caching": "None",
         "write_accelerator": false
-      }
+      }]
     }
   }
 }

--- a/deploy/terraform/modules/app_tier/variables_local.tf
+++ b/deploy/terraform/modules/app_tier/variables_local.tf
@@ -177,7 +177,7 @@ locals {
         disk_type         = lookup(disk_spec, "disk_type", "Premium_LRS")
         size_gb           = lookup(disk_spec, "size_gb", 512)
         caching           = lookup(disk_spec, "caching", false)
-        write_accelerator = lookup(disk_spec, "wriate_accelerator", false)
+        write_accelerator = lookup(disk_spec, "write_accelerator", false)
       }
     ]
   ])

--- a/deploy/terraform/modules/app_tier/variables_local.tf
+++ b/deploy/terraform/modules/app_tier/variables_local.tf
@@ -190,7 +190,7 @@ locals {
         disk_type         = lookup(disk_spec, "disk_type", "Premium_LRS")
         size_gb           = lookup(disk_spec, "size_gb", 512)
         caching           = lookup(disk_spec, "caching", false)
-        write_accelerator = lookup(disk_spec, "wriate_accelerator", false)
+        write_accelerator = lookup(disk_spec, "write_accelerator", false)
       }
     ]
   ])

--- a/deploy/terraform/modules/app_tier/variables_local.tf
+++ b/deploy/terraform/modules/app_tier/variables_local.tf
@@ -52,12 +52,13 @@ locals {
       "vm_size": "Standard_D4s_v3",
       "accelerated_networking": false
     },
-    "storage": {
+    "storage": [{
+      "name": "data",
       "disk_type": "Premium_LRS",
       "size_gb": 512,
       "caching": "None",
       "write_accelerator": false
-    }
+    }]
   })
 
   scs_sizing = lookup(local.sizes.scs, local.vm_sizing, {
@@ -65,12 +66,13 @@ locals {
       "vm_size": "Standard_D4s_v3",
       "accelerated_networking": false
     },
-    "storage": {
+    "storage": [{
+      "name": "data",
       "disk_type": "Premium_LRS",
       "size_gb": 512,
       "caching": "None",
       "write_accelerator": false
-    }
+    }]
   })
 
   web_sizing = lookup(local.sizes.web, local.vm_sizing, {
@@ -78,12 +80,13 @@ locals {
       "vm_size": "Standard_D4s_v3",
       "accelerated_networking": false
     },
-    "storage": {
+    "storage": [{
+      "name": "data",
       "disk_type": "Premium_LRS",
       "size_gb": 512,
       "caching": "None",
       "write_accelerator": false
-    }
+    }]
   })
 
   # Ports used for specific ASCS, ERS and Web dispatcher
@@ -151,4 +154,44 @@ locals {
     62000 + tonumber(local.scs_instance_number),
     62100 + tonumber(local.ers_instance_number)
   ]
+
+  # Create list of disks per VM
+  app-data-disks = flatten([
+    for vm_count in range(var.application.application_server_count) : [
+      for disk_spec in local.app_sizing.storage : {
+        vm_index          = vm_count
+        name              = "${upper(var.application.sid)}_app${format("%02d", vm_count)}-${disk_spec.name}"
+        disk_type         = lookup(disk_spec, "disk_type", "Premium_LRS")
+        size_gb           = lookup(disk_spec, "size_gb", 512)
+        caching           = lookup(disk_spec, "caching", false)
+        write_accelerator = lookup(disk_spec, "wriate_accelerator", false)
+      }
+    ]
+  ])
+
+  scs-data-disks = flatten([
+    for vm_count in (var.application.scs_high_availability ? range(2) : range(1)) : [
+      for disk_spec in local.scs_sizing.storage : {
+        vm_index          = vm_count
+        name              = "${upper(var.application.sid)}_scs${format("%02d", vm_count)}-${disk_spec.name}"
+        disk_type         = lookup(disk_spec, "disk_type", "Premium_LRS")
+        size_gb           = lookup(disk_spec, "size_gb", 512)
+        caching           = lookup(disk_spec, "caching", false)
+        write_accelerator = lookup(disk_spec, "wriate_accelerator", false)
+      }
+    ]
+  ])
+
+  web-data-disks = flatten([
+    for vm_count in range(var.application.webdispatcher_count) : [
+      for disk_spec in local.web_sizing.storage : {
+        vm_index          = vm_count
+        name              = "${upper(var.application.sid)}_web${format("%02d", vm_count)}-${disk_spec.name}"
+        disk_type         = lookup(disk_spec, "disk_type", "Premium_LRS")
+        size_gb           = lookup(disk_spec, "size_gb", 512)
+        caching           = lookup(disk_spec, "caching", false)
+        write_accelerator = lookup(disk_spec, "wriate_accelerator", false)
+      }
+    ]
+  ])
 }

--- a/deploy/terraform/modules/app_tier/variables_local.tf
+++ b/deploy/terraform/modules/app_tier/variables_local.tf
@@ -164,7 +164,7 @@ locals {
         disk_type         = lookup(disk_spec, "disk_type", "Premium_LRS")
         size_gb           = lookup(disk_spec, "size_gb", 512)
         caching           = lookup(disk_spec, "caching", false)
-        write_accelerator = lookup(disk_spec, "wriate_accelerator", false)
+        write_accelerator = lookup(disk_spec, "write_accelerator", false)
       }
     ]
   ])

--- a/deploy/terraform/modules/app_tier/vm-app.tf
+++ b/deploy/terraform/modules/app_tier/vm-app.tf
@@ -55,20 +55,20 @@ resource "azurerm_linux_virtual_machine" "app" {
 
 # Creates managed data disk
 resource "azurerm_managed_disk" "app" {
-  count                = local.enable_deployment ? var.application.application_server_count : 0
-  name                 = "${upper(var.application.sid)}_app${format("%02d", count.index)}-data"
+  count                = local.enable_deployment ? length(local.app-data-disks) : 0
+  name                 = local.app-data-disks[count.index].name
   location             = var.resource-group[0].location
   resource_group_name  = var.resource-group[0].name
   create_option        = "Empty"
-  storage_account_type = local.app_sizing.storage.disk_type
-  disk_size_gb         = local.app_sizing.storage.size_gb
+  storage_account_type = local.app-data-disks[count.index].disk_type
+  disk_size_gb         = local.app-data-disks[count.index].size_gb
 }
 
 resource "azurerm_virtual_machine_data_disk_attachment" "app" {
   count                     = local.enable_deployment ? length(azurerm_managed_disk.app) : 0
   managed_disk_id           = azurerm_managed_disk.app[count.index].id
-  virtual_machine_id        = azurerm_linux_virtual_machine.app[count.index].id
-  caching                   = local.app_sizing.storage.caching
-  write_accelerator_enabled = local.app_sizing.storage.write_accelerator
-  lun                       = 1
+  virtual_machine_id        = azurerm_linux_virtual_machine.app[local.app-data-disks[count.index].vm_index].id
+  caching                   = local.app-data-disks[count.index].caching
+  write_accelerator_enabled = local.app-data-disks[count.index].write_accelerator
+  lun                       = count.index
 }

--- a/deploy/terraform/modules/app_tier/vm-scs.tf
+++ b/deploy/terraform/modules/app_tier/vm-scs.tf
@@ -64,20 +64,20 @@ resource "azurerm_linux_virtual_machine" "scs" {
 
 # Creates managed data disk
 resource "azurerm_managed_disk" "scs" {
-  count                = local.enable_deployment ? (var.application.scs_high_availability ? 2 : 1) : 0
-  name                 = "${upper(var.application.sid)}_scs${format("%02d", count.index)}-data"
+  count                = local.enable_deployment ? length(local.scs-data-disks) : 0
+  name                 = local.scs-data-disks[count.index].name
   location             = var.resource-group[0].location
   resource_group_name  = var.resource-group[0].name
   create_option        = "Empty"
-  storage_account_type = local.scs_sizing.storage.disk_type
-  disk_size_gb         = local.scs_sizing.storage.size_gb
+  storage_account_type = local.scs-data-disks[count.index].disk_type
+  disk_size_gb         = local.scs-data-disks[count.index].size_gb
 }
 
 resource "azurerm_virtual_machine_data_disk_attachment" "scs" {
-  count                     = local.enable_deployment ? length(azurerm_managed_disk.scs) : 0
+  count                     = local.enable_deployment ? length(azurerm_managed_disk.app) : 0
   managed_disk_id           = azurerm_managed_disk.scs[count.index].id
-  virtual_machine_id        = azurerm_linux_virtual_machine.scs[count.index].id
-  caching                   = local.scs_sizing.storage.caching
-  write_accelerator_enabled = local.scs_sizing.storage.write_accelerator
-  lun                       = 1
+  virtual_machine_id        = azurerm_linux_virtual_machine.scs[local.scs-data-disks[count.index].vm_index].id
+  caching                   = local.scs-data-disks[count.index].caching
+  write_accelerator_enabled = local.scs-data-disks[count.index].write_accelerator
+  lun                       = count.index
 }


### PR DESCRIPTION
# Problem

Disks for the Application Tier VM sizing should allow multiple disks to be added, even though the expected configuration is 1.  This is to allow customers the ability to update it if they so desire.

See #586 

## Description

Updates the app_sizes.json file to use an array for storage descriptions. Adds a name field. Updates the logic for the App and SCS VM disk creation and attachment.

Closes #586