### PR TITLE
[HOTFIX] Add data disk to webdispatcher

### DIFF
--- a/deploy/terraform/modules/app_tier/vm-scs.tf
+++ b/deploy/terraform/modules/app_tier/vm-scs.tf
@@ -32,7 +32,7 @@ resource "azurerm_linux_virtual_machine" "scs" {
   resource_group_name          = var.resource-group[0].name
   availability_set_id          = azurerm_availability_set.scs[0].id
   proximity_placement_group_id = lookup(var.infrastructure, "ppg", false) != false ? (var.ppg[0].id) : null
-  network_interface_ids        = [
+  network_interface_ids = [
     azurerm_network_interface.scs[count.index].id
   ]
   size                            = local.scs_sizing.compute.vm_size
@@ -74,7 +74,7 @@ resource "azurerm_managed_disk" "scs" {
 }
 
 resource "azurerm_virtual_machine_data_disk_attachment" "scs" {
-  count                     = local.enable_deployment ? length(azurerm_managed_disk.app) : 0
+  count                     = local.enable_deployment ? length(azurerm_managed_disk.scs) : 0
   managed_disk_id           = azurerm_managed_disk.scs[count.index].id
   virtual_machine_id        = azurerm_linux_virtual_machine.scs[local.scs-data-disks[count.index].vm_index].id
   caching                   = local.scs-data-disks[count.index].caching


### PR DESCRIPTION
## Problem
No data disk is attached to webdispatcher.
Wrong disk assignment for scs causes deployment to fail when multiple app server is required.

## Solution
1. Use app sizing json to get the data disk information and create accordingly.
1. Fixed a small typo for scs disk attachment. [HOTFIX]

## Test
Deploy webdispatcher with below section in input JSON - no error:

```
  "application": {
    "sid": "HN1",
    "enable_deployment": true,
    "scs_instance_number": "01",
    "ers_instance_number": "02",
    "scs_high_availability": false,
    "application_server_count": 1,
    "webdispatcher_count": 1,
    "authentication": {
      "type": "key",
      "username": "azureadm"
    },
    "os": {
      "publisher": "suse",
      "offer": "sles-sap-12-sp5",
      "sku": "gen1"
    }
  },
```