### PR TITLE
Remove excessive defaults for vm sizing

### DIFF
--- a/deploy/terraform/modules/app_tier/variables_local.tf
+++ b/deploy/terraform/modules/app_tier/variables_local.tf
@@ -47,47 +47,11 @@ locals {
   }))
 
   # Default VM config should be merged with any the user passes in
-  app_sizing = lookup(local.sizes.app, local.vm_sizing, {
-    "compute": {
-      "vm_size": "Standard_D4s_v3",
-      "accelerated_networking": false
-    },
-    "storage": [{
-      "name": "data",
-      "disk_type": "Premium_LRS",
-      "size_gb": 512,
-      "caching": "None",
-      "write_accelerator": false
-    }]
-  })
+  app_sizing = lookup(local.sizes.app, local.vm_sizing, {})
 
-  scs_sizing = lookup(local.sizes.scs, local.vm_sizing, {
-    "compute": {
-      "vm_size": "Standard_D4s_v3",
-      "accelerated_networking": false
-    },
-    "storage": [{
-      "name": "data",
-      "disk_type": "Premium_LRS",
-      "size_gb": 512,
-      "caching": "None",
-      "write_accelerator": false
-    }]
-  })
+  scs_sizing = lookup(local.sizes.scs, local.vm_sizing, {})
 
-  web_sizing = lookup(local.sizes.web, local.vm_sizing, {
-    "compute": {
-      "vm_size": "Standard_D4s_v3",
-      "accelerated_networking": false
-    },
-    "storage": [{
-      "name": "data",
-      "disk_type": "Premium_LRS",
-      "size_gb": 512,
-      "caching": "None",
-      "write_accelerator": false
-    }]
-  })
+  web_sizing = lookup(local.sizes.web, local.vm_sizing, {})
 
   # Ports used for specific ASCS, ERS and Web dispatcher
   lb-ports = {


### PR DESCRIPTION
# Problem

See #590 and [this comment thread from #583](https://github.com/Azure/sap-hana/pull/583#discussion_r444435335)

Having extra defaults from the lookup functions for the app, scs, and web sizing local variables allows deployments with potentially unexpected configuration to be deployed.

## Description

Removes the final defaults, so if a user specifies an unknown size (as per the app_sizes.json file) then plan and deployment should fail without creating any resources.

Closes #590