### PR TITLE
Adjust default logic in app tier

### DIFF
--- a/deploy/template_samples/application_with_ha.json
+++ b/deploy/template_samples/application_with_ha.json
@@ -65,62 +65,23 @@
     "windows": [],
     "linux": []
   },
-  "databases": [
-    {
-      "platform": "HANA",
-      "db_version": "2.00.043",
-      "os": {
-        "publisher": "suse",
-        "offer": "sles-sap-12-sp5",
-        "sku": "gen1"
-      },
-      "size": "Demo",
-      "filesystem": "xfs",
-      "high_availability": false,
-      "authentication": {
-        "type": "key",
-        "username": "azureadm"
-      },
-      "instance": {
-        "sid": "HN1",
-        "instance_number": "00"
-      },
-      "credentials": {
-        "db_systemdb_password": "Manager1",
-        "os_sidadm_password": "Help4you",
-        "os_sapadm_password": "Help4you",
-        "xsa_admin_password": "Manager1",
-        "cockpit_admin_password": "Manager1",
-        "ha_cluster_password": ""
-      },
-      "components": {
-        "hana_database": [],
-        "hana_client_linux": [],
-        "xs": [
-          "xsac_alm_pi_ui",
-          "xsac_portal_serv",
-          "xsac_services",
-          "xsac_ui5_fesv5",
-          "xsac_ui5_sb",
-          "xsac_xsa_cockpit"
-        ],
-        "shine": []
-      },
-      "xsa": {
-        "routing": "ports"
-      },
-      "shine": {
-        "email": "shinedemo@microsoft.com"
-      },
-      "dbnodes": [
-        {
-          "name": "hdb1",
-          "role": "worker"
-        }
-      ],
-      "loadbalancer": {}
+  "application": {
+    "enable_deployment": true,
+    "scs_instance_number": "01",
+    "ers_instance_number": "02",
+    "scs_high_availability": true,
+    "application_server_count": 1,
+    "webdispatcher_count": 1,
+    "authentication": {
+      "type": "key",
+      "username": "azureadm"
+    },
+    "os": {
+      "publisher": "suse",
+      "offer": "sles-sap-12-sp5",
+      "sku": "gen1"
     }
-  ],
+  },
   "software": {
     "storage_account_sapbits": {
       "is_existing": false,

--- a/deploy/template_samples/application_wo_ha.json
+++ b/deploy/template_samples/application_wo_ha.json
@@ -65,62 +65,23 @@
     "windows": [],
     "linux": []
   },
-  "databases": [
-    {
-      "platform": "HANA",
-      "db_version": "2.00.043",
-      "os": {
-        "publisher": "suse",
-        "offer": "sles-sap-12-sp5",
-        "sku": "gen1"
-      },
-      "size": "Demo",
-      "filesystem": "xfs",
-      "high_availability": false,
-      "authentication": {
-        "type": "key",
-        "username": "azureadm"
-      },
-      "instance": {
-        "sid": "HN1",
-        "instance_number": "00"
-      },
-      "credentials": {
-        "db_systemdb_password": "Manager1",
-        "os_sidadm_password": "Help4you",
-        "os_sapadm_password": "Help4you",
-        "xsa_admin_password": "Manager1",
-        "cockpit_admin_password": "Manager1",
-        "ha_cluster_password": ""
-      },
-      "components": {
-        "hana_database": [],
-        "hana_client_linux": [],
-        "xs": [
-          "xsac_alm_pi_ui",
-          "xsac_portal_serv",
-          "xsac_services",
-          "xsac_ui5_fesv5",
-          "xsac_ui5_sb",
-          "xsac_xsa_cockpit"
-        ],
-        "shine": []
-      },
-      "xsa": {
-        "routing": "ports"
-      },
-      "shine": {
-        "email": "shinedemo@microsoft.com"
-      },
-      "dbnodes": [
-        {
-          "name": "hdb1",
-          "role": "worker"
-        }
-      ],
-      "loadbalancer": {}
+  "application": {
+    "enable_deployment": true,
+    "scs_instance_number": "01",
+    "ers_instance_number": "02",
+    "scs_high_availability": false,
+    "application_server_count": 1,
+    "webdispatcher_count": 1,
+    "authentication": {
+      "type": "key",
+      "username": "azureadm"
+    },
+    "os": {
+      "publisher": "suse",
+      "offer": "sles-sap-12-sp5",
+      "sku": "gen1"
     }
-  ],
+  },
   "software": {
     "storage_account_sapbits": {
       "is_existing": false,

--- a/deploy/template_samples/clustered_hana.json
+++ b/deploy/template_samples/clustered_hana.json
@@ -7,8 +7,7 @@
     },
     "ppg": {
       "is_existing": "false",
-      "name": "test-ppg",
-      "arm_id": ""
+      "name": "test-ppg"
     },
     "vnets": {
       "management": {
@@ -63,66 +62,8 @@
     }
   },
   "jumpboxes": {
-    "windows": [
-      {
-        "name": "jumpbox-windows",
-        "destroy_after_deploy": "false",
-        "size": "Standard_D2s_v3",
-        "disk_type": "StandardSSD_LRS",
-        "os": {
-          "publisher": "MicrosoftWindowsServer",
-          "offer": "WindowsServer",
-          "sku": "2016-Datacenter"
-        },
-        "authentication": {
-          "type": "password",
-          "username": "azureadm",
-          "password": "Sap@hana2019!"
-        },
-        "components": [
-          "hana_studio_windows"
-        ]
-      }
-    ],
-    "linux": [
-      {
-        "name": "jumpbox-linux",
-        "destroy_after_deploy": "false",
-        "size": "Standard_D2s_v3",
-        "disk_type": "StandardSSD_LRS",
-        "os": {
-          "publisher": "Canonical",
-          "offer": "UbuntuServer",
-          "sku": "16.04-LTS"
-        },
-        "authentication": {
-          "type": "password",
-          "username": "azureadm",
-          "password": "Sap@hana2019!"
-        },
-        "components": [
-          "hana_studio_linux"
-        ]
-      },
-      {
-        "name": "rti",
-        "destroy_after_deploy": "true",
-        "size": "Standard_D2s_v3",
-        "disk_type": "StandardSSD_LRS",
-        "os": {
-          "publisher": "Canonical",
-          "offer": "UbuntuServer",
-          "sku": "18.04-LTS"
-        },
-        "authentication": {
-          "type": "key",
-          "username": "azureadm"
-        },
-        "components": [
-          "ansible"
-        ]
-      }
-    ]
+    "windows": [],
+    "linux": []
   },
   "databases": [
     {
@@ -153,17 +94,7 @@
         "ha_cluster_password": ""
       },
       "components": {
-        "hana_database": [],
-        "hana_client_linux": [],
-        "xs": [
-          "xsac_alm_pi_ui",
-          "xsac_portal_serv",
-          "xsac_services",
-          "xsac_ui5_fesv5",
-          "xsac_ui5_sb",
-          "xsac_xsa_cockpit"
-        ],
-        "shine": []
+        "hana_database": []
       },
       "xsa": {
         "routing": "ports"
@@ -180,25 +111,6 @@
       "loadbalancer": {}
     }
   ],
-  "application": {
-    "sid": "HN1",
-    "enable_deployment": true,
-    "scs_instance_number": "01",
-    "ers_instance_number": "02",
-    "scs_high_availability": true,
-    "application_server_count": 1,
-    "webdispatcher_count": 1,
-    "vm_sizing": "Default",
-    "authentication": {
-      "type": "key",
-      "username": "azureadm"
-    },
-    "os": {
-      "publisher": "suse",
-      "offer": "sles-sap-12-sp5",
-      "sku": "gen1"
-    }
-  },
   "software": {
     "storage_account_sapbits": {
       "is_existing": false,

--- a/deploy/template_samples/clustered_hana_with_sbd.json
+++ b/deploy/template_samples/clustered_hana_with_sbd.json
@@ -7,8 +7,7 @@
     },
     "ppg": {
       "is_existing": "false",
-      "name": "test-ppg",
-      "arm_id" :""
+      "name": "test-ppg"
     },
     "vnets": {
       "management": {
@@ -85,28 +84,8 @@
     }
   },
   "jumpboxes": {
-    "windows": [
-    ],
-    "linux": [
-      {
-        "name": "rti",
-        "destroy_after_deploy": "true",
-        "size": "Standard_D2s_v3",
-        "disk_type": "StandardSSD_LRS",
-        "os": {
-          "publisher": "Canonical",
-          "offer": "UbuntuServer",
-          "sku": "18.04-LTS"
-        },
-        "authentication": {
-          "type": "key",
-          "username": "azureadm"
-        },
-        "components": [
-          "ansible"
-        ]
-      }
-    ]
+    "windows": [],
+    "linux": []
   },
   "databases": [
     {
@@ -153,25 +132,6 @@
       "loadbalancer": {}
     }
   ],
-  "application": {
-    "sid": "HN1",
-    "enable_deployment": true,
-    "scs_instance_number": "01",
-    "ers_instance_number": "02",
-    "scs_high_availability": true,
-    "application_server_count": 1,
-    "webdispatcher_count": 1,
-    "vm_sizing": "Default",
-    "authentication": {
-      "type": "key",
-      "username": "azureadm"
-    },
-    "os": {
-      "publisher": "suse",
-      "offer": "sles-sap-12-sp5",
-      "sku": "gen1"
-    }
-  },
   "software": {
     "storage_account_sapbits": {
       "is_existing": false,

--- a/deploy/template_samples/clustered_hana_with_sbd_in_existing_subnet.json
+++ b/deploy/template_samples/clustered_hana_with_sbd_in_existing_subnet.json
@@ -7,8 +7,7 @@
     },
     "ppg": {
       "is_existing": "false",
-      "name": "test-ppg",
-      "arm_id" :""
+      "name": "test-ppg"
     },
     "vnets": {
       "management": {
@@ -122,17 +121,7 @@
         "cockpit_admin_password": "Manager1"
       },
       "components": {
-        "hana_database": [],
-        "hana_client_linux": [],
-        "xs": [
-          "xsac_alm_pi_ui",
-          "xsac_portal_serv",
-          "xsac_services",
-          "xsac_ui5_fesv5",
-          "xsac_ui5_sb",
-          "xsac_xsa_cockpit"
-        ],
-        "shine": []
+        "hana_database": []
       },
       "xsa": {
         "routing": "ports"
@@ -154,25 +143,6 @@
       }
     }
   ],
-  "application": {
-    "sid": "HN1",
-    "enable_deployment": true,
-    "scs_instance_number": "01",
-    "ers_instance_number": "02",
-    "scs_high_availability": true,
-    "application_server_count": 1,
-    "webdispatcher_count": 1,
-    "vm_sizing": "Default",
-    "authentication": {
-      "type": "key",
-      "username": "azureadm"
-    },
-    "os": {
-      "publisher": "suse",
-      "offer": "sles-sap-12-sp5",
-      "sku": "gen1"
-    }
-  },
   "software": {
     "storage_account_sapbits": {
       "is_existing": false,

--- a/deploy/template_samples/rti_only.json
+++ b/deploy/template_samples/rti_only.json
@@ -85,25 +85,6 @@
       }
     ]
   },
-  "application": {
-    "sid": "HN1",
-    "enable_deployment": false,
-    "scs_instance_number": "01",
-    "ers_instance_number": "02",
-    "scs_high_availability": false,
-    "application_server_count": 1,
-    "webdispatcher_count": 1,
-    "vm_sizing": "Default",
-    "authentication": {
-      "type": "key",
-      "username": "azureadm"
-    },
-    "os": {
-      "publisher": "suse",
-      "offer": "sles-sap-12-sp5",
-      "sku": "gen1"
-    }
-  },
   "software": {
     "storage_account_sapbits": {
       "is_existing": false,

--- a/deploy/template_samples/saplandscaperunner.json
+++ b/deploy/template_samples/saplandscaperunner.json
@@ -7,8 +7,7 @@
         },
         "ppg": {
           "is_existing": "false",
-          "name": "test-ppg",
-          "arm_id": ""
+          "name": "test-ppg"
         },
         "vnets": {
             "management": {
@@ -77,26 +76,7 @@
     },
     "jumpboxes": {
         "windows": [],
-        "linux": [
-            {
-                "name": "rti",
-                "destroy_after_deploy": "true",
-                "size": "Standard_D2s_v3",
-                "disk_type": "StandardSSD_LRS",
-                "os": {
-                    "publisher": "Canonical",
-                    "offer": "UbuntuServer",
-                    "sku": "18.04-LTS"
-                },
-                "authentication": {
-                    "type": "key",
-                    "username": "azureadm"
-                },
-                "components": [
-                    "ansible"
-                ]
-            }
-        ]
+        "linux": []
     },
     "databases": [
         {
@@ -144,25 +124,6 @@
             ]
         }
     ],
-    "application": {
-        "sid": "HN1",
-        "enable_deployment": false,
-        "scs_instance_number": "01",
-        "ers_instance_number": "02",
-        "scs_high_availability": true,
-        "application_server_count": 1,
-        "webdispatcher_count": 1,
-        "vm_sizing": "Default",
-        "authentication": {
-            "type": "key",
-            "username": "azureadm"
-        },
-        "os": {
-            "publisher": "suse",
-            "offer": "sles-sap-12-sp5",
-            "sku": "gen1"
-        }
-    },
     "software": {
         "storage_account_sapbits": {
             "file_share_name": "bits",

--- a/deploy/template_samples/single_node_hana_single_container.json
+++ b/deploy/template_samples/single_node_hana_single_container.json
@@ -7,8 +7,7 @@
     },
     "ppg": {
       "is_existing": "false",
-      "name": "test-ppg",
-      "arm_id": ""
+      "name": "test-ppg"
     },
     "vnets": {
       "management": {
@@ -63,65 +62,8 @@
     }
   },
   "jumpboxes": {
-    "windows": [
-      {
-        "name": "jumpbox-windows",
-        "destroy_after_deploy": "false",
-        "size": "Standard_D2s_v3",
-        "disk_type": "StandardSSD_LRS",
-        "os": {
-          "publisher": "MicrosoftWindowsServer",
-          "offer": "WindowsServer",
-          "sku": "2016-Datacenter"
-        },
-        "authentication": {
-          "type": "password",
-          "username": "azureadm",
-          "password": "Sap@hana2019!"
-        },
-        "components": [
-          "hana_studio_windows"
-        ]
-      }
-    ],
-    "linux": [
-      {
-        "name": "jumpbox-linux",
-        "destroy_after_deploy": "false",
-        "size": "Standard_D2s_v3",
-        "disk_type": "StandardSSD_LRS",
-        "os": {
-          "publisher": "Canonical",
-          "offer": "UbuntuServer",
-          "sku": "16.04-LTS"
-        },
-        "authentication": {
-          "type": "key",
-          "username": "azureadm"
-        },
-        "components": [
-          "hana_studio_linux"
-        ]
-      },
-      {
-        "name": "rti",
-        "destroy_after_deploy": "true",
-        "size": "Standard_D2s_v3",
-        "disk_type": "StandardSSD_LRS",
-        "os": {
-          "publisher": "Canonical",
-          "offer": "UbuntuServer",
-          "sku": "16.04-LTS"
-        },
-        "authentication": {
-          "type": "key",
-          "username": "azureadm"
-        },
-        "components": [
-          "ansible"
-        ]
-      }
-    ]
+    "windows": [],
+    "linux": []
   },
   "databases": [
     {
@@ -153,17 +95,7 @@
         "ha_cluster_password": ""
       },
       "components": {
-        "hana_database": [],
-        "hana_client_linux": [],
-        "xs": [
-          "xsac_alm_pi_ui",
-          "xsac_portal_serv",
-          "xsac_services",
-          "xsac_ui5_fesv5",
-          "xsac_ui5_sb",
-          "xsac_xsa_cockpit"
-        ],
-        "shine": []
+        "hana_database": []
       },
       "xsa": {
         "routing": "ports"
@@ -180,25 +112,6 @@
       "loadbalancer": {}
     }
   ],
-  "application": {
-    "sid": "HN1",
-    "enable_deployment": true,
-    "scs_instance_number": "01",
-    "ers_instance_number": "02",
-    "scs_high_availability": false,
-    "application_server_count": 1,
-    "webdispatcher_count": 1,
-    "vm_sizing": "Default",
-    "authentication": {
-      "type": "key",
-      "username": "azureadm"
-    },
-    "os": {
-      "publisher": "suse",
-      "offer": "sles-sap-12-sp5",
-      "sku": "gen1"
-    }
-  },
   "software": {
     "storage_account_sapbits": {
       "is_existing": false,

--- a/deploy/template_samples/single_node_hana_with_jumpboxes.json
+++ b/deploy/template_samples/single_node_hana_with_jumpboxes.json
@@ -62,8 +62,48 @@
     }
   },
   "jumpboxes": {
-    "windows": [],
-    "linux": []
+    "windows": [
+      {
+        "name": "jumpbox-windows",
+        "destroy_after_deploy": "false",
+        "size": "Standard_D2s_v3",
+        "disk_type": "StandardSSD_LRS",
+        "os": {
+          "publisher": "MicrosoftWindowsServer",
+          "offer": "WindowsServer",
+          "sku": "2016-Datacenter"
+        },
+        "authentication": {
+          "type": "password",
+          "username": "azureadm",
+          "password": "Sap@hana2019!"
+        },
+        "components": [
+          "hana_studio_windows"
+        ]
+      }
+    ],
+    "linux": [
+      {
+        "name": "jumpbox-linux",
+        "destroy_after_deploy": "false",
+        "size": "Standard_D2s_v3",
+        "disk_type": "StandardSSD_LRS",
+        "os": {
+          "publisher": "Canonical",
+          "offer": "UbuntuServer",
+          "sku": "16.04-LTS"
+        },
+        "authentication": {
+          "type": "password",
+          "username": "azureadm",
+          "password": "Sap@hana2019!"
+        },
+        "components": [
+          "hana_studio_linux"
+        ]
+      }
+    ]
   },
   "databases": [
     {
@@ -94,17 +134,7 @@
         "ha_cluster_password": ""
       },
       "components": {
-        "hana_database": [],
-        "hana_client_linux": [],
-        "xs": [
-          "xsac_alm_pi_ui",
-          "xsac_portal_serv",
-          "xsac_services",
-          "xsac_ui5_fesv5",
-          "xsac_ui5_sb",
-          "xsac_xsa_cockpit"
-        ],
-        "shine": []
+        "hana_database": []
       },
       "xsa": {
         "routing": "ports"
@@ -174,8 +204,8 @@
     "path_to_private_key": "~/.ssh/id_rsa"
   },
   "options": {
-    "enable_secure_transfer": true,
     "ansible_execution": false,
+    "enable_secure_transfer": true,
     "enable_prometheus": true
   }
 }

--- a/deploy/template_samples/single_node_hana_with_xsa.json
+++ b/deploy/template_samples/single_node_hana_with_xsa.json
@@ -174,8 +174,8 @@
     "path_to_private_key": "~/.ssh/id_rsa"
   },
   "options": {
-    "enable_secure_transfer": true,
     "ansible_execution": false,
+    "enable_secure_transfer": true,
     "enable_prometheus": true
   }
 }

--- a/deploy/terraform/modules/app_tier/variables_local.tf
+++ b/deploy/terraform/modules/app_tier/variables_local.tf
@@ -16,15 +16,15 @@ variable "ppg" {
 
 # Set defaults
 locals {
-  application_sid          = lookup(var.application, "sid", "HN1")
-  enable_deployment        = lookup(var.application, "enable_deployment", false)
-  scs_instance_number      = lookup(var.application, "scs_instance_number", "01")
-  ers_instance_number      = lookup(var.application, "ers_instance_number", "02")
-  scs_high_availability    = lookup(var.application, "scs_high_availability", false)
-  application_server_count = lookup(var.application, "application_server_count", 0)
-  webdispatcher_count      = lookup(var.application, "webdispatcher_count", 0)
-  vm_sizing                = lookup(var.application, "vm_sizing", "Default")
-  authentication = lookup(var.application, "authentication",
+  application_sid          = try(var.application.sid, "HN1")
+  enable_deployment        = try(var.application.enable_deployment, false)
+  scs_instance_number      = try(var.application.scs_instance_number, "01")
+  ers_instance_number      = try(var.application.ers_instance_number, "02")
+  scs_high_availability    = try(var.application.scs_high_availability, false)
+  application_server_count = try(var.application.application_server_count, 0)
+  webdispatcher_count      = try(var.application.webdispatcher_count, 0)
+  vm_sizing                = try(var.application.vm_sizing, "Default")
+  authentication = try(var.application.authentication,
     {
       "type"     = "key"
       "username" = "azureadm"
@@ -32,7 +32,7 @@ locals {
   # OS image for all Application Tier VMs
   os = merge({
     version = "latest"
-    }, lookup(var.application, "os", {
+    }, try(var.application.os, {
       publisher = "suse"
       offer     = "sles-sap-12-sp5"
       sku       = "gen1"


### PR DESCRIPTION
## Problem
1. `try()` is more straight forward than lookup, also will work with [`raise()`](https://github.com/hashicorp/terraform/pull/25088) very soon. Therefore replace the lookup with try.
2. Current templates under `deploy/template_samples` has too much unnecessary information.

## Solution
1. Update defaults in app tier with `try()`
1. Simplify the app parts in the `deploy/template_samples` when it is HANA only
1. Add templates for app tier only

## Test
1. Run terraform plan on the `deploy/template_samples` on all except `clustered_hana_with_sbd_in_existing_subnet.json`.

## Future work
1. Continue to simply the templates when defaults in other modules are set.