### PR TITLE
Always have 2 feip on the SCS load balancer

### DIFF
--- a/deploy/terraform/modules/app_tier/infrastructure.tf
+++ b/deploy/terraform/modules/app_tier/infrastructure.tf
@@ -27,14 +27,18 @@ resource "azurerm_lb" "scs" {
   resource_group_name = var.resource-group[0].name
   location            = var.resource-group[0].location
 
-  dynamic "frontend_ip_configuration" {
-    for_each = range(var.application.scs_high_availability ? 2 : 1)
-    content {
-      name                          = "${upper(var.application.sid)}_${frontend_ip_configuration.value == 0 ? "scs" : "ers"}-feip"
-      subnet_id                     = var.infrastructure.vnets.sap.subnet_app.is_existing ? data.azurerm_subnet.subnet-sap-app[0].id : azurerm_subnet.subnet-sap-app[0].id
-      private_ip_address_allocation = "Static"
-      private_ip_address            = cidrhost(var.infrastructure.vnets.sap.subnet_app.prefix, tonumber(frontend_ip_configuration.value) + local.ip_offsets.scs_lb)
-    }
+  frontend_ip_configuration {
+    name                          = "${upper(var.application.sid)}_scs-feip"
+    subnet_id                     = var.infrastructure.vnets.sap.subnet_app.is_existing ? data.azurerm_subnet.subnet-sap-app[0].id : azurerm_subnet.subnet-sap-app[0].id
+    private_ip_address_allocation = "Static"
+    private_ip_address            = cidrhost(var.infrastructure.vnets.sap.subnet_app.prefix, 0 + local.ip_offsets.scs_lb)
+  }
+
+  frontend_ip_configuration {
+    name                          = "${upper(var.application.sid)}_ers-feip"
+    subnet_id                     = var.infrastructure.vnets.sap.subnet_app.is_existing ? data.azurerm_subnet.subnet-sap-app[0].id : azurerm_subnet.subnet-sap-app[0].id
+    private_ip_address_allocation = "Static"
+    private_ip_address            = cidrhost(var.infrastructure.vnets.sap.subnet_app.prefix, 1 + local.ip_offsets.scs_lb)
   }
 }
 


### PR DESCRIPTION
# Problem

Terraform fails first time if SCS HA is changed from true to false. See #581 

## Description

Updates the SCS Load Balancer to permanently have two front end IPs instead of a dynamic block based on the SCS HA variable.

Adding `depends_on: [azurerm_lb.scs]` to the rules did not allow Terraform to detect the dynamic `frontend_ip_configuration` block change.

This change allows the SCS HA components (e.g. ERS instance and all related configuration) bar the FrontEnd IP configuration chang to be added/destroyed by the SCS HA flag.

Closes #581