### PR TITLE
Add SID to inventory yml file

### DIFF
--- a/deploy/ansible/roles/inventory-validation/tasks/repo_validation.yml
+++ b/deploy/ansible/roles/inventory-validation/tasks/repo_validation.yml
@@ -27,4 +27,3 @@
   block:
     - name: Check yum repo on HANA VMs
       command: yum repolist
-

--- a/deploy/terraform/module.tf
+++ b/deploy/terraform/module.tf
@@ -89,6 +89,7 @@ module "output_files" {
   loadbalancers                = module.hdb_node.loadbalancers
   hdb-sid                      = module.hdb_node.hdb-sid
   hana-database-info           = module.hdb_node.hana-database-info
+  app-sid                      = module.app_tier.app-sid
   nics-scs                     = module.app_tier.nics-scs
   nics-app                     = module.app_tier.nics-app
   nics-web                     = module.app_tier.nics-web

--- a/deploy/terraform/modules/app_tier/outputs.tf
+++ b/deploy/terraform/modules/app_tier/outputs.tf
@@ -9,3 +9,7 @@ output "nics-app" {
 output "nics-web" {
   value = azurerm_network_interface.web
 }
+
+output "app-sid" {
+  value = local.application_sid
+}

--- a/deploy/terraform/modules/output_files/ansible_inventory.yml.tmpl
+++ b/deploy/terraform/modules/output_files/ansible_inventory.yml.tmpl
@@ -5,11 +5,8 @@ all:
 %{~ for ip-iscsi in ips-iscsi }
         ${ip-iscsi}:
           ansible_connection:  "ssh"
-%{~ if iscsi.authentication.type == "key" }
           ansible_user:        "${iscsi.authentication.username}"
-%{~ endif }
 %{~ if iscsi.authentication.type == "password" }
-          ansible_user:        "${iscsi.authentication.username}"
           ansible_ssh_pass:    "${iscsi.authentication.password}"
           ansible_become_pass: "${iscsi.authentication.password}"
 %{~ endif }
@@ -33,11 +30,8 @@ all:
 %{~ if jumpbox-linux.destroy_after_deploy != "true"}
         ${ips-jumpboxes-linux[index(jumpboxes-linux, jumpbox-linux)]}:
           ansible_connection:  "ssh"
-%{~ if jumpbox-linux.authentication.type == "key" }
           ansible_user:        "${jumpbox-linux.authentication.username}"
-%{~ endif }
 %{~ if jumpbox-linux.authentication.type == "password" }
-          ansible_user:        "${jumpbox-linux.authentication.username}"
           ansible_ssh_pass:    "${jumpbox-linux.authentication.password}"
           ansible_become_pass: "${jumpbox-linux.authentication.password}"
 %{~ endif }
@@ -45,42 +39,55 @@ all:
 %{~ endfor }
 
     hanadbnodes:
-      hosts:
-%{~ for ip-dbnode-admin in ips-dbnodes-admin }
-        ${ip-dbnode-admin}:
-          ansible_connection:  "ssh"
-%{~ if dbnodes[index(ips-dbnodes-admin, ip-dbnode-admin)].authentication.type == "key" }
-          ansible_user:        "${dbnodes[index(ips-dbnodes-admin, ip-dbnode-admin)].authentication.username}"
+      children:     
+%{~ if length(ips-dbnodes-admin) > 0 }
+        ${hdb-sid}_HDB:
+          hosts:
 %{~ endif }
+%{~ for ip-dbnode-admin in ips-dbnodes-admin }     
+            ${ip-dbnode-admin}:
+              ansible_connection:  "ssh"
+              ansible_user:        "${dbnodes[index(ips-dbnodes-admin, ip-dbnode-admin)].authentication.username}"
 %{~ if dbnodes[index(ips-dbnodes-admin, ip-dbnode-admin)].authentication.type == "password" }
-          ansible_user:        "${dbnodes[index(ips-dbnodes-admin, ip-dbnode-admin)].authentication.username}"
-          ansible_ssh_pass:    "${dbnodes[index(ips-dbnodes-admin, ip-dbnode-admin)].authentication.password}"
-          ansible_become_pass: "${dbnodes[index(ips-dbnodes-admin, ip-dbnode-admin)].authentication.password}"
+              ansible_ssh_pass:    "${dbnodes[index(ips-dbnodes-admin, ip-dbnode-admin)].authentication.password}"
+              ansible_become_pass: "${dbnodes[index(ips-dbnodes-admin, ip-dbnode-admin)].authentication.password}"
 %{~ endif }
 %{~ endfor }
 
     scs:
-      hosts:
+      children:
+%{~ if length(ips-scs) > 0 }
+        ${app-sid}_SCS:
+          hosts:
+%{~ endif }          
 %{~ for ip-scs in ips-scs }
-        ${ip-scs}:
-          ansible_connection: "ssh"
-          ansible_user:       "${application.authentication.username}"
+            ${ip-scs}:
+              ansible_connection: "ssh"
+              ansible_user:       "${application.authentication.username}"
 %{~ endfor }
 
     app:
-      hosts:
+      children:
+%{~ if length(ips-app) > 0 }
+        ${app-sid}_APP:
+          hosts:
+%{~ endif }  
 %{~ for ip-app in ips-app }
-        ${ip-app}:
-          ansible_connection: "ssh"
-          ansible_user:       "${application.authentication.username}"
+            ${ip-app}:
+              ansible_connection: "ssh"
+              ansible_user:       "${application.authentication.username}"
 %{~ endfor }
 
     web:
-      hosts:
+      children:
+%{~ if length(ips-web) > 0 }
+        ${app-sid}_WEB:
+          hosts:
+%{~ endif }        
 %{~ for ip-web in ips-web }
-        ${ip-web}:
-          ansible_connection: "ssh"
-          ansible_user:       "${application.authentication.username}"
+            ${ip-web}:
+              ansible_connection: "ssh"
+              ansible_user:       "${application.authentication.username}"
 %{~ endfor }
 
     # Groups below are collections of the above groups for easier reference

--- a/deploy/terraform/modules/output_files/inventory.tf
+++ b/deploy/terraform/modules/output_files/inventory.tf
@@ -88,13 +88,15 @@ resource "local_file" "ansible-inventory" {
     application           = var.application,
     ips-scs               = local.ips-scs,
     ips-app               = local.ips-app,
-    ips-web               = local.ips-web
+    ips-web               = local.ips-web,
+    hdb-sid               = local.hdb-sid,
+    app-sid               = local.app-sid
     }
   )
   filename = "${terraform.workspace}/ansible_config_files/hosts"
 }
 
-# Generates the Ansible Inventory file
+# Generates the Ansible Inventory yml file
 resource "local_file" "ansible-inventory-yml" {
   content = templatefile("${path.module}/ansible_inventory.yml.tmpl", {
     iscsi                 = lookup(var.infrastructure, "iscsi", {}),
@@ -110,6 +112,8 @@ resource "local_file" "ansible-inventory-yml" {
     ips-scs               = local.ips-scs,
     ips-app               = local.ips-app,
     ips-web               = local.ips-web
+    hdb-sid               = local.hdb-sid,
+    app-sid               = local.app-sid
     }
   )
   filename = "${terraform.workspace}/ansible_config_files/hosts.yml"

--- a/deploy/terraform/modules/output_files/variables_local.tf
+++ b/deploy/terraform/modules/output_files/variables_local.tf
@@ -46,6 +46,10 @@ variable "hana-database-info" {
   description = "Updated hana database json"
 }
 
+variable "app-sid" {
+  description = "SID used when generating App tier"
+}
+
 variable "nics-scs" {
   description = "List of NICs for the SCS Application VMs"
 }
@@ -59,6 +63,8 @@ variable "nics-web" {
 }
 
 locals {
+  hdb-sid                      = var.hdb-sid
+  app-sid                      = var.app-sid
   ips-iscsi                    = var.nics-iscsi[*].private_ip_address
   ips-jumpboxes-windows        = var.nics-jumpboxes-windows[*].private_ip_address
   ips-jumpboxes-linux          = var.nics-jumpboxes-linux[*].private_ip_address


### PR DESCRIPTION
This pr is to include SID to Inventory file. See #492 

### Test
1. Currently we don't have the requirement that multiple Hana databases installed at one execution, but we want to make our codes extensible -- support multiple SIDs under one product. To test this feature, I manually change hosts.yml to the following configuration and test it. 
It shows what our hosts.yml may look like and proves the change is compatible with current Ansible script.
hosts.yml
![image](https://user-images.githubusercontent.com/62584551/85816328-de51e680-b71f-11ea-91fb-735e8d11d190.png)


PLAY [hanadbnodes] **************************************************************************************************************

TASK [Gathering Facts] **********************************************************************************************************
ok: [10.1.1.11]
ok: [10.1.1.10]
fatal: [10.1.1.13]: UNREACHABLE! => {"changed": false, "msg": "Failed to connect to the host via ssh: ssh: connect to host 10.1.1.13 port 22: Connection timed out", "unreachable": true}
fatal: [10.1.1.12]: UNREACHABLE! => {"changed": false, "msg": "Failed to connect to the host via ssh: ssh: connect to host 10.1.1.12 port 22: Connection timed out", "unreachable": true}

The reason why it fail on 13 and 12 is because these two hosts don't exist. This doesn't matter because this test case is only used to show what our inventory file look like and prove our Ansible script is working fine with the change.
