### PR TITLE
Refactor HSR and OS Clustering roles to be less directly dependant on output.json

### DIFF
--- a/deploy/ansible/roles/hana-os-clustering/tasks/cluster-RedHat.yml
+++ b/deploy/ansible/roles/hana-os-clustering/tasks/cluster-RedHat.yml
@@ -61,7 +61,7 @@
         pcs stonith create rsc_st_azure fence_azure_arm
         login="{{ sap_hana_fencing_agent_client_id }}"
         passwd="{{ sap_hana_fencing_agent_client_password }}"
-        resourceGroup="{{ output.infrastructure.resource_group.name }}"
+        resourceGroup="{{ resource_group_name }}"
         tenantId="{{ sap_hana_fencing_agent_tenant_id }}"
         subscriptionId="{{ sap_hana_fencing_agent_subscription_id }}"
         power_timeout=240

--- a/deploy/ansible/roles/hana-os-clustering/tasks/cluster-RedHat.yml
+++ b/deploy/ansible/roles/hana-os-clustering/tasks/cluster-RedHat.yml
@@ -105,7 +105,7 @@
         master notify=true clone-max=2 clone-node-max=1 interleave=true
 
     - name: Ensure the Virtual IP resource for the Load Balancer Front End IP is created
-      shell: pcs resource create vip_{{ sid | upper }}_{{ instance_number }} IPaddr2 ip="{{ hana_database.loadbalancer.frontend_ip }}"
+      shell: pcs resource create vip_{{ sid | upper }}_{{ instance_number }} IPaddr2 ip="{{ hdb_lb_feip }}"
 
     - name: Ensure the netcat resource for the Load Balancer Healthprobe is created
       shell: pcs resource create nc_{{ sid | upper }}_{{ instance_number }} azure-lb port=625{{ instance_number }}

--- a/deploy/ansible/roles/hana-os-clustering/tasks/cluster-RedHat.yml
+++ b/deploy/ansible/roles/hana-os-clustering/tasks/cluster-RedHat.yml
@@ -33,7 +33,7 @@
 
     # Ref https://docs.microsoft.com/en-us/azure/virtual-machines/maintenance-and-updates#maintenance-that-doesnt-require-a-reboot
     - name: Ensure the cluster is created with a token large enough to allow memory preserving maintenance
-      shell: "pcs cluster setup --name {{ hana_database.instance.sid | upper }}_hana_cluster {{ secondary_instance.name }} {{ secondary_instance.name }} --token {{ cluster_totem.token }}"
+      shell: "pcs cluster setup --name {{ sid | upper }}_hana_cluster {{ secondary_instance.name }} {{ secondary_instance.name }} --token {{ cluster_totem.token }}"
 
     - name: Ensure the cluster is starting on all nodes
       shell: pcs cluster start --all
@@ -83,8 +83,8 @@
 
     - name: Ensure the SAP HANA Topology resource is created
       shell: >
-        pcs resource create SAPHanaTopology_{{ hana_database.instance.sid | upper }}_{{ hana_database.instance.instance_number }} SAPHanaTopology
-        SID={{ hana_database.instance.sid | upper }} InstanceNumber={{ hana_database.instance.instance_number }}
+        pcs resource create SAPHanaTopology_{{ sid | upper }}_{{ instance_number }} SAPHanaTopology
+        SID={{ sid | upper }} InstanceNumber={{ instance_number }}
         op start timeout=600
         op stop timeout=300
         op monitor interval=10 timeout=600
@@ -92,8 +92,8 @@
 
     - name: Ensure the SAP HANA resource is created
       shell: >
-        pcs resource create SAPHana_{{ hana_database.instance.sid | upper }}_{{ hana_database.instance.instance_number }} SAPHana
-        SID={{ hana_database.instance.sid | upper }} InstanceNumber={{ hana_database.instance.instance_number }}
+        pcs resource create SAPHana_{{ sid | upper }}_{{ instance_number }} SAPHana
+        SID={{ sid | upper }} InstanceNumber={{ instance_number }}
         PREFER_SITE_TAKEOVER=true DUPLICATE_PRIMARY_TIMEOUT=7200
         AUTOMATED_REGISTER=false
         op start timeout={{ cluster_SAPHana_timeouts.start }}
@@ -105,19 +105,19 @@
         master notify=true clone-max=2 clone-node-max=1 interleave=true
 
     - name: Ensure the Virtual IP resource for the Load Balancer Front End IP is created
-      shell: pcs resource create vip_{{ hana_database.instance.sid | upper }}_{{ hana_database.instance.instance_number }} IPaddr2 ip="{{ hana_database.loadbalancer.frontend_ip }}"
+      shell: pcs resource create vip_{{ sid | upper }}_{{ instance_number }} IPaddr2 ip="{{ hana_database.loadbalancer.frontend_ip }}"
 
     - name: Ensure the netcat resource for the Load Balancer Healthprobe is created
-      shell: pcs resource create nc_{{ hana_database.instance.sid | upper }}_{{ hana_database.instance.instance_number }} azure-lb port=625{{ hana_database.instance.instance_number }}
+      shell: pcs resource create nc_{{ sid | upper }}_{{ instance_number }} azure-lb port=625{{ instance_number }}
 
     - name: Ensure the Virtual IP group resource is created
-      shell: pcs resource group add g_ip_{{ hana_database.instance.sid | upper }}_{{ hana_database.instance.instance_number }} nc_{{ hana_database.instance.sid | upper }}_{{ hana_database.instance.instance_number }} vip_{{ hana_database.instance.sid | upper }}_{{ hana_database.instance.instance_number }}
+      shell: pcs resource group add g_ip_{{ sid | upper }}_{{ instance_number }} nc_{{ sid | upper }}_{{ instance_number }} vip_{{ sid | upper }}_{{ instance_number }}
 
     - name: Ensure the order constraint for the SAP HANA Topology is configured
-      shell: pcs constraint order SAPHanaTopology_{{ hana_database.instance.sid | upper }}_{{ hana_database.instance.instance_number }}-clone then SAPHana_{{ hana_database.instance.sid | upper }}_{{ hana_database.instance.instance_number }}-master symmetrical=false
+      shell: pcs constraint order SAPHanaTopology_{{ sid | upper }}_{{ instance_number }}-clone then SAPHana_{{ sid | upper }}_{{ instance_number }}-master symmetrical=false
 
     - name: Ensure the Virtual IP is configured to the Master node
-      shell: pcs constraint colocation add g_ip_{{ hana_database.instance.sid | upper }}_{{ hana_database.instance.instance_number }} with master SAPHana_{{ hana_database.instance.sid | upper }}_{{ hana_database.instance.instance_number }}-master 4000
+      shell: pcs constraint colocation add g_ip_{{ sid | upper }}_{{ instance_number }} with master SAPHana_{{ sid | upper }}_{{ instance_number }}-master 4000
 
     - name: Disable Maintenance mode for the cluster
       shell: pcs property set maintenance-mode=false

--- a/deploy/ansible/roles/hana-os-clustering/tasks/cluster-RedHat.yml
+++ b/deploy/ansible/roles/hana-os-clustering/tasks/cluster-RedHat.yml
@@ -26,14 +26,14 @@
 # Basic Pacemaker cluster configuration:
 # https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/high-availability-guide-rhel-pacemaker
 - name: Create the cluster on the primary node
-  when: ansible_hostname == hana_database.nodes[0].dbname
+  when: ansible_hostname == secondary_instance.name
   block:
     - name: Ensure the cluster can authenticate nodes as hacluster
-      shell: "pcs cluster auth {{ hana_database.nodes[0].dbname }} {{ hana_database.nodes[1].dbname }} -u hacluster -p {{ ha_cluster_password }}"
+      shell: "pcs cluster auth {{ secondary_instance.name }} {{ secondary_instance.name }} -u hacluster -p {{ ha_cluster_password }}"
 
     # Ref https://docs.microsoft.com/en-us/azure/virtual-machines/maintenance-and-updates#maintenance-that-doesnt-require-a-reboot
     - name: Ensure the cluster is created with a token large enough to allow memory preserving maintenance
-      shell: "pcs cluster setup --name {{ hana_database.instance.sid | upper }}_hana_cluster {{ hana_database.nodes[0].dbname }} {{ hana_database.nodes[1].dbname }} --token {{ cluster_totem.token }}"
+      shell: "pcs cluster setup --name {{ hana_database.instance.sid | upper }}_hana_cluster {{ secondary_instance.name }} {{ secondary_instance.name }} --token {{ cluster_totem.token }}"
 
     - name: Ensure the cluster is starting on all nodes
       shell: pcs cluster start --all
@@ -43,13 +43,13 @@
       register: cluster_stable_check
       retries: 30
       delay: 10
-      until: "'{{ hana_database.nodes[0].dbname }} {{ hana_database.nodes[1].dbname }}' in cluster_stable_check.stdout or '{{ hana_database.nodes[1].dbname }} {{ hana_database.nodes[0].dbname }}' in cluster_stable_check.stdout"
+      until: "'{{ secondary_instance.name }} {{ secondary_instance.name }}' in cluster_stable_check.stdout or '{{ secondary_instance.name }} {{ secondary_instance.name }}' in cluster_stable_check.stdout"
 
 - name: Ensure the expected quorum votes is set for the cluster
   shell: "pcs quorum expected-votes {{ cluster_quorum.expected_votes }}"
 
 - name: Configure the cluster STONITH device on the primary node
-  when: ansible_hostname == hana_database.nodes[0].dbname
+  when: ansible_hostname == secondary_instance.name
   block:
     - name: Ensure STONITH timeout is raised
       shell: pcs property set stonith-timeout=900
@@ -76,7 +76,7 @@
 # SAP HANA Cluster resources
 # https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/sap-hana-high-availability-rhel#create-sap-hana-cluster-resources
 - name: Optimise the Pacemaker cluster for SAP HANA
-  when: ansible_hostname == hana_database.nodes[0].dbname
+  when: ansible_hostname == secondary_instance.name
   block:
     - name: Enable Maintenance mode for the cluster
       shell: pcs property set maintenance-mode=true

--- a/deploy/ansible/roles/hana-os-clustering/tasks/cluster-RedHat.yml
+++ b/deploy/ansible/roles/hana-os-clustering/tasks/cluster-RedHat.yml
@@ -26,14 +26,14 @@
 # Basic Pacemaker cluster configuration:
 # https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/high-availability-guide-rhel-pacemaker
 - name: Create the cluster on the primary node
-  when: ansible_hostname == secondary_instance.name
+  when: ansible_hostname == primary_instance.name
   block:
     - name: Ensure the cluster can authenticate nodes as hacluster
-      shell: "pcs cluster auth {{ secondary_instance.name }} {{ secondary_instance.name }} -u hacluster -p {{ ha_cluster_password }}"
+      shell: "pcs cluster auth {{ primary_instance.name }} {{ secondary_instance.name }} -u hacluster -p {{ ha_cluster_password }}"
 
     # Ref https://docs.microsoft.com/en-us/azure/virtual-machines/maintenance-and-updates#maintenance-that-doesnt-require-a-reboot
     - name: Ensure the cluster is created with a token large enough to allow memory preserving maintenance
-      shell: "pcs cluster setup --name {{ sid | upper }}_hana_cluster {{ secondary_instance.name }} {{ secondary_instance.name }} --token {{ cluster_totem.token }}"
+      shell: "pcs cluster setup --name {{ sid | upper }}_hana_cluster {{ primary_instance.name }} {{ secondary_instance.name }} --token {{ cluster_totem.token }}"
 
     - name: Ensure the cluster is starting on all nodes
       shell: pcs cluster start --all
@@ -43,13 +43,13 @@
       register: cluster_stable_check
       retries: 30
       delay: 10
-      until: "'{{ secondary_instance.name }} {{ secondary_instance.name }}' in cluster_stable_check.stdout or '{{ secondary_instance.name }} {{ secondary_instance.name }}' in cluster_stable_check.stdout"
+      until: "'{{ primary_instance.name }} {{ secondary_instance.name }}' in cluster_stable_check.stdout or '{{ secondary_instance.name }} {{ primary_instance.name }}' in cluster_stable_check.stdout"
 
 - name: Ensure the expected quorum votes is set for the cluster
   shell: "pcs quorum expected-votes {{ cluster_quorum.expected_votes }}"
 
 - name: Configure the cluster STONITH device on the primary node
-  when: ansible_hostname == secondary_instance.name
+  when: ansible_hostname == primary_instance.name
   block:
     - name: Ensure STONITH timeout is raised
       shell: pcs property set stonith-timeout=900
@@ -76,7 +76,7 @@
 # SAP HANA Cluster resources
 # https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/sap-hana-high-availability-rhel#create-sap-hana-cluster-resources
 - name: Optimise the Pacemaker cluster for SAP HANA
-  when: ansible_hostname == secondary_instance.name
+  when: ansible_hostname == primary_instance.name
   block:
     - name: Enable Maintenance mode for the cluster
       shell: pcs property set maintenance-mode=true

--- a/deploy/ansible/roles/hana-os-clustering/tasks/cluster-Suse-large-instance.yml
+++ b/deploy/ansible/roles/hana-os-clustering/tasks/cluster-Suse-large-instance.yml
@@ -4,7 +4,7 @@
 # Ref: https://documentation.suse.com/sle-ha/12-SP4/html/SLE-HA-install-quick/index.html
 # https://rpm.pbone.net/index.php3/stat/45/idpl/27916721/numer/8/nazwa/ha-cluster-init
 - name: Ensure Primary node initiates the Cluster
-  when: inventory_hostname == hana_database.nodes[0].ip_admin_nic
+  when: inventory_hostname == primary_instance.ip_admin
   block:
     - name: Ensure csync2 is configured
       shell: crm cluster init -y csync2
@@ -16,13 +16,13 @@
       shell: "crm cluster init -y cluster --name 'hdb_{{ hana_database.instance.sid | upper }}'"
 
 - name: Ensure Secondary node joins the Cluster
-  when: inventory_hostname == hana_database.nodes[1].ip_admin_nic
+  when: inventory_hostname == secondary_instance.ip_admin
   block:
     - name: Ensure the configuration files are synchronised
-      shell: "crm cluster join -y -c {{ hana_database.nodes[0].ip_db_nic }} csync2"
+      shell: "crm cluster join -y -c {{ primary_instance.ip_db }} csync2"
 
     - name: Ensure the cluster is joined
-      shell: "crm cluster join -y -c {{ hana_database.nodes[0].ip_db_nic }} cluster"
+      shell: "crm cluster join -y -c {{ primary_instance.ip_db }} cluster"
 
 - name: Ensure HA Cluster password is set to something secure
   user:
@@ -36,7 +36,7 @@
     mode: 0600
 
 - name: Ensure the Corosync service is restarted on primary node.
-  when: inventory_hostname == hana_database.nodes[0].ip_admin_nic
+  when: inventory_hostname == primary_instance.ip_admin
   systemd:
     name: corosync
     state: restarted
@@ -45,7 +45,7 @@
     seconds: 15
 
 - name: Ensure the Corosync service is restarted on secondary node
-  when: inventory_hostname == hana_database.nodes[1].ip_admin_nic
+  when: inventory_hostname == secondary_instance.ip_admin
   systemd:
     name: corosync
     state: restarted
@@ -54,27 +54,27 @@
     seconds: 15
 
 - name: Ensure the cluster STONITH is created
-  when: inventory_hostname == hana_database.nodes[0].ip_admin_nic
+  when: inventory_hostname == primary_instance.ip_admin
   block:
 
     - name: Check if SBD resource exists
       shell: crm resource list | grep 'sbd' | awk '{ print $1; }'
       register: sbd_device
       failed_when: false
-    
+
     # "stonith-sbd" is the sbd device in most cases if there has already existed a SBD
     - name: Ensure current SBD device is stoped and removed if exists
       shell: |
         crm resource stop {{ sbd_device.stdout }}
         crm configure delete {{ sbd_device.stdout }}
       when: sbd_device.stdout | length > 0
-      
+
     - name: Ensure SBD disk STONITH resource is created
       shell: >
         crm configure primitive stonith-sbd stonith:external/sbd \
         params pcmk_delay_max="15" \
         op monitor interval="15" timeout="15"
-    
+
     - name: Check the current SBD status
       shell: crm_mon -1 | grep sbd
       register: sbd_report
@@ -82,7 +82,7 @@
       failed_when: False
 
     - debug:
-        msg: "{{ sbd_report.stdout }}" 
+        msg: "{{ sbd_report.stdout }}"
 
     - name: Ensure maintenance mode is enabled
       shell: "crm configure property maintenance-mode=true"

--- a/deploy/ansible/roles/hana-os-clustering/tasks/cluster-Suse-large-instance.yml
+++ b/deploy/ansible/roles/hana-os-clustering/tasks/cluster-Suse-large-instance.yml
@@ -153,7 +153,7 @@
         meta target-role="Started"
         operations \$id="rsc_ip_{{ sid | upper }}_HDB{{ instance_number }}-operations"
         op monitor interval="10s" timeout="20s"
-        params ip="{{ hana_database.loadbalancer.frontend_ip }}"
+        params ip="{{ hdb_lb_feip }}"
 
     - name: Ensure SAP HANA Heartbeat netcat resource is configured
       shell: >

--- a/deploy/ansible/roles/hana-os-clustering/tasks/cluster-Suse-large-instance.yml
+++ b/deploy/ansible/roles/hana-os-clustering/tasks/cluster-Suse-large-instance.yml
@@ -12,8 +12,8 @@
     - name: Ensure corosync is configured
       shell: crm cluster init -y -u corosync
 
-    - name: Ensure cluster (hdb_{{ hana_database.instance.sid | upper }}) is configured
-      shell: "crm cluster init -y cluster --name 'hdb_{{ hana_database.instance.sid | upper }}'"
+    - name: Ensure cluster (hdb_{{ sid | upper }}) is configured
+      shell: "crm cluster init -y cluster --name 'hdb_{{ sid | upper }}'"
 
 - name: Ensure Secondary node joins the Cluster
   when: inventory_hostname == secondary_instance.ip_admin
@@ -109,80 +109,80 @@
 
     - name: Ensure SAP HANA Topology resource is configured
       shell: >
-        crm configure primitive rsc_SAPHanaTopology_{{ hana_database.instance.sid | upper }}_HDB{{ hana_database.instance.instance_number }}
+        crm configure primitive rsc_SAPHanaTopology_{{ sid | upper }}_HDB{{ instance_number }}
         ocf:suse:SAPHanaTopology
-        operations \$id="rsc_sap2_{{ hana_database.instance.sid | upper }}_HDB{{ hana_database.instance.instance_number }}-operations"
+        operations \$id="rsc_sap2_{{ sid | upper }}_HDB{{ instance_number }}-operations"
         op monitor interval="10" timeout="600"
         op start interval="0" timeout="600"
         op stop interval="0" timeout="300"
-        params SID="{{ hana_database.instance.sid | upper }}" InstanceNumber="{{ hana_database.instance.instance_number }}"
+        params SID="{{ sid | upper }}" InstanceNumber="{{ instance_number }}"
 
     - name: Ensure SAP HANA Topology clone set resource is configured
       shell: >
-        crm configure clone cln_SAPHanaTopology_{{ hana_database.instance.sid | upper }}_HDB{{ hana_database.instance.instance_number }}
-        rsc_SAPHanaTopology_{{ hana_database.instance.sid | upper }}_HDB{{ hana_database.instance.instance_number }}
+        crm configure clone cln_SAPHanaTopology_{{ sid | upper }}_HDB{{ instance_number }}
+        rsc_SAPHanaTopology_{{ sid | upper }}_HDB{{ instance_number }}
         meta clone-node-max="1" target-role="Started" interleave="true"
 
     - name: Ensure SAP HANA primitive resource is configured
       shell: >
-        crm configure primitive rsc_SAPHana_{{ hana_database.instance.sid | upper }}_HDB{{ hana_database.instance.instance_number }}
+        crm configure primitive rsc_SAPHana_{{ sid | upper }}_HDB{{ instance_number }}
         ocf:suse:SAPHana
-        operations \$id="rsc_sap_{{ hana_database.instance.sid | upper }}_HDB{{ hana_database.instance.instance_number }}-operations"
+        operations \$id="rsc_sap_{{ sid | upper }}_HDB{{ instance_number }}-operations"
         op start interval="0" timeout="{{ cluster_SAPHana_timeouts.start }}"
         op stop interval="0" timeout="{{ cluster_SAPHana_timeouts.stop }}"
         op promote interval="0" timeout="{{ cluster_SAPHana_timeouts.promote }}"
         op monitor interval="60" role="Master" timeout="{{ cluster_SAPHana_timeouts.monitor_master }}"
         op monitor interval="61" role="Slave" timeout="{{ cluster_SAPHana_timeouts.monitor_slave }}"
         params
-        SID="{{ hana_database.instance.sid | upper }}"
-        InstanceNumber="{{ hana_database.instance.instance_number }}"
+        SID="{{ sid | upper }}"
+        InstanceNumber="{{ instance_number }}"
         PREFER_SITE_TAKEOVER="true"
         DUPLICATE_PRIMARY_TIMEOUT="7200"
         AUTOMATED_REGISTER="false"
 
     - name: Ensure SAP HANA master-slave resource is configured
       shell: >
-        crm configure ms msl_SAPHana_{{ hana_database.instance.sid | upper }}_HDB{{ hana_database.instance.instance_number }}
-        rsc_SAPHana_{{ hana_database.instance.sid | upper }}_HDB{{ hana_database.instance.instance_number }}
+        crm configure ms msl_SAPHana_{{ sid | upper }}_HDB{{ instance_number }}
+        rsc_SAPHana_{{ sid | upper }}_HDB{{ instance_number }}
         meta notify="true" clone-max="2" clone-node-max="1"
         target-role="Started" interleave="true"
 
     - name: Ensure SAP HANA Virtual IP resource is configured
       shell: >
-        crm configure primitive rsc_ip_{{ hana_database.instance.sid | upper }}_HDB{{ hana_database.instance.instance_number }} ocf:heartbeat:IPaddr2
+        crm configure primitive rsc_ip_{{ sid | upper }}_HDB{{ instance_number }} ocf:heartbeat:IPaddr2
         meta target-role="Started"
-        operations \$id="rsc_ip_{{ hana_database.instance.sid | upper }}_HDB{{ hana_database.instance.instance_number }}-operations"
+        operations \$id="rsc_ip_{{ sid | upper }}_HDB{{ instance_number }}-operations"
         op monitor interval="10s" timeout="20s"
         params ip="{{ hana_database.loadbalancer.frontend_ip }}"
 
     - name: Ensure SAP HANA Heartbeat netcat resource is configured
       shell: >
-        crm configure primitive rsc_nc_{{ hana_database.instance.sid | upper }}_HDB{{ hana_database.instance.instance_number }} anything
+        crm configure primitive rsc_nc_{{ sid | upper }}_HDB{{ instance_number }} anything
         params binfile="/usr/bin/nc" cmdline_options="-l -k 62500"
         op monitor timeout=20s interval=10 depth=0
 
     - name: Ensure Group IP Address resource is configured
       shell: >
-        crm configure group g_ip_{{ hana_database.instance.sid | upper }}_HDB{{ hana_database.instance.instance_number }}
-        rsc_ip_{{ hana_database.instance.sid | upper }}_HDB{{ hana_database.instance.instance_number }}
-        rsc_nc_{{ hana_database.instance.sid | upper }}_HDB{{ hana_database.instance.instance_number }}
+        crm configure group g_ip_{{ sid | upper }}_HDB{{ instance_number }}
+        rsc_ip_{{ sid | upper }}_HDB{{ instance_number }}
+        rsc_nc_{{ sid | upper }}_HDB{{ instance_number }}
 
     - name: Ensure Co-Location constraint is configured
       shell: >
-        crm configure colocation col_saphana_ip_{{ hana_database.instance.sid | upper }}_HDB{{ hana_database.instance.instance_number }}
+        crm configure colocation col_saphana_ip_{{ sid | upper }}_HDB{{ instance_number }}
         4000:
-        g_ip_{{ hana_database.instance.sid | upper }}_HDB{{ hana_database.instance.instance_number }}:Started
-        msl_SAPHana_{{ hana_database.instance.sid | upper }}_HDB{{ hana_database.instance.instance_number }}:Master
+        g_ip_{{ sid | upper }}_HDB{{ instance_number }}:Started
+        msl_SAPHana_{{ sid | upper }}_HDB{{ instance_number }}:Master
 
     - name: Ensure Resource order is configured
       shell: >
-        crm configure order ord_SAPHana_{{ hana_database.instance.sid | upper }}_HDB{{ hana_database.instance.instance_number }}
+        crm configure order ord_SAPHana_{{ sid | upper }}_HDB{{ instance_number }}
         Optional:
-        cln_SAPHanaTopology_{{ hana_database.instance.sid | upper }}_HDB{{ hana_database.instance.instance_number }}
-        msl_SAPHana_{{ hana_database.instance.sid | upper }}_HDB{{ hana_database.instance.instance_number }}
+        cln_SAPHanaTopology_{{ sid | upper }}_HDB{{ instance_number }}
+        msl_SAPHana_{{ sid | upper }}_HDB{{ instance_number }}
 
     - name: Ensure any required cluster resources are cleaned up
-      shell: "crm resource cleanup rsc_SAPHana_{{ hana_database.instance.sid | upper }}_HDB{{ hana_database.instance.instance_number }}"
+      shell: "crm resource cleanup rsc_SAPHana_{{ sid | upper }}_HDB{{ instance_number }}"
 
     - name: Ensure maintenance mode is disabled
       shell: "crm configure property maintenance-mode=false"

--- a/deploy/ansible/roles/hana-os-clustering/tasks/cluster-Suse.yml
+++ b/deploy/ansible/roles/hana-os-clustering/tasks/cluster-Suse.yml
@@ -22,7 +22,7 @@
 
 # https://rpm.pbone.net/index.php3/stat/45/idpl/27916721/numer/8/nazwa/ha-cluster-init
 - name: Ensure Primary node initiates the Cluster
-  when: inventory_hostname == hana_database.nodes[0].ip_admin_nic
+  when: inventory_hostname == primary_instance.ip_admin
   block:
     - name: Ensure csync2 is configured
       shell: crm cluster init -y csync2 --interface eth1
@@ -34,13 +34,13 @@
       shell: "crm cluster init -y cluster --name 'hdb_{{ hana_database.instance.sid | upper }}' --interface eth1"
 
 - name: Ensure Secondary node joins the Cluster
-  when: inventory_hostname == hana_database.nodes[1].ip_admin_nic
+  when: inventory_hostname == secondary_instance.ip_admin
   block:
     - name: Ensure the configuration files are synchronised
-      shell: "crm cluster join -y -c {{ hana_database.nodes[0].ip_db_nic }} csync2 --interface eth1"
+      shell: "crm cluster join -y -c {{ primary_instance.ip_db }} csync2 --interface eth1"
 
     - name: Ensure the cluster is joined
-      shell: "crm cluster join -y -c {{ hana_database.nodes[0].ip_db_nic }} cluster --interface eth1"
+      shell: "crm cluster join -y -c {{ primary_instance.ip_db }} cluster --interface eth1"
 
 - name: Ensure HA Cluster password is set to something secure
   user:
@@ -54,7 +54,7 @@
     mode: 0600
 
 - name: Ensure the Corosync service is restarted on primary node.
-  when: inventory_hostname == hana_database.nodes[0].ip_admin_nic
+  when: inventory_hostname == primary_instance.ip_admin
   systemd:
     name: corosync
     state: restarted
@@ -63,7 +63,7 @@
     seconds: 15
 
 - name: Ensure the Corosync service is restarted on secondary node
-  when: inventory_hostname == hana_database.nodes[1].ip_admin_nic
+  when: inventory_hostname == secondary_instance.ip_admin
   systemd:
     name: corosync
     state: restarted
@@ -72,29 +72,29 @@
     seconds: 15
 
 - name: Ensure the STONITH SBD is created
-  when: 
-    - inventory_hostname == hana_database.nodes[0].ip_admin_nic
-    - groups['iscsi'] | length > 0 
+  when:
+    - inventory_hostname == primary_instance.ip_admin
+    - groups['iscsi'] | length > 0
   block:
 
     - name: Check if SBD resource exists
       shell: crm resource list | grep 'sbd' | awk '{ print $1; }'
       register: sbd_device
       failed_when: false
-    
+
     # "stonith-sbd" is the sbd device in most cases if there has already existed a SBD
     - name: Ensure current SBD device is stoped and removed if exists
       shell: |
         crm resource stop {{ sbd_device.stdout }}
         crm configure delete {{ sbd_device.stdout }}
       when: sbd_device.stdout | length > 0
-      
+
     - name: Ensure SBD disk STONITH resource is created
       shell: >
         crm configure primitive stonith-sbd stonith:external/sbd \
         params pcmk_delay_max="15" \
         op monitor interval="15" timeout="15"
-    
+
     - name: Check the current SBD status
       shell: crm_mon -1 | grep sbd
       register: sbd_report
@@ -102,11 +102,11 @@
       failed_when: False
 
     - debug:
-        msg: "{{ sbd_report.stdout }}" 
+        msg: "{{ sbd_report.stdout }}"
 
 - name: Ensure Azure scheduled events is configured
-  when: inventory_hostname == hana_database.nodes[0].ip_admin_nic
-  block: 
+  when: inventory_hostname == primary_instance.ip_admin
+  block:
   # After configuring the Pacemaker resources for azure-events agent, when you place the cluster in or out of maintenance mode, you may get warning messages like:
   # WARNING: cib-bootstrap-options: unknown attribute 'hostName_ hostname'
   # WARNING: cib-bootstrap-options: unknown attribute 'azure-events_globalPullState'
@@ -119,7 +119,7 @@
       shell: crm configure clone cln_azure-events rsc_azure-events
 
 - name: Ensure the Cluster STONITH is configured
-  when: inventory_hostname == hana_database.nodes[0].ip_admin_nic
+  when: inventory_hostname == primary_instance.ip_admin
   block:
     - name: Ensure maintenance mode is enabled
       shell: "crm configure property maintenance-mode=true"

--- a/deploy/ansible/roles/hana-os-clustering/tasks/cluster-Suse.yml
+++ b/deploy/ansible/roles/hana-os-clustering/tasks/cluster-Suse.yml
@@ -149,7 +149,7 @@
       shell: >
         crm configure primitive rsc_st_azure stonith:fence_azure_arm params
         subscriptionId="{{ sap_hana_fencing_agent_subscription_id }}"
-        resourceGroup="{{ output.infrastructure.resource_group.name }}"
+        resourceGroup="{{ resource_group_name }}"
         tenantId="{{ sap_hana_fencing_agent_tenant_id }}"
         login="{{ sap_hana_fencing_agent_client_id }}"
         passwd="{{ sap_hana_fencing_agent_client_password }}"

--- a/deploy/ansible/roles/hana-os-clustering/tasks/cluster-Suse.yml
+++ b/deploy/ansible/roles/hana-os-clustering/tasks/cluster-Suse.yml
@@ -145,7 +145,7 @@
         timeout="600"
 
     - name: Ensure the STONITH Azure fence agent is created
-      when: hana_database.size != "LargeInstance"
+      when: hdb_size != "LargeInstance"
       shell: >
         crm configure primitive rsc_st_azure stonith:fence_azure_arm params
         subscriptionId="{{ sap_hana_fencing_agent_subscription_id }}"

--- a/deploy/ansible/roles/hana-os-clustering/tasks/cluster-Suse.yml
+++ b/deploy/ansible/roles/hana-os-clustering/tasks/cluster-Suse.yml
@@ -30,8 +30,8 @@
     - name: Ensure corosync is configured
       shell: crm cluster init -y -u corosync --interface eth1
 
-    - name: Ensure cluster (hdb_{{ hana_database.instance.sid | upper }}) is configured
-      shell: "crm cluster init -y cluster --name 'hdb_{{ hana_database.instance.sid | upper }}' --interface eth1"
+    - name: Ensure cluster (hdb_{{ sid | upper }}) is configured
+      shell: "crm cluster init -y cluster --name 'hdb_{{ sid | upper }}' --interface eth1"
 
 - name: Ensure Secondary node joins the Cluster
   when: inventory_hostname == secondary_instance.ip_admin
@@ -156,81 +156,81 @@
 
     - name: Ensure SAP HANA Topology resource is configured
       shell: >
-        crm configure primitive rsc_SAPHanaTopology_{{ hana_database.instance.sid | upper }}_HDB{{ hana_database.instance.instance_number }}
+        crm configure primitive rsc_SAPHanaTopology_{{ sid | upper }}_HDB{{ instance_number }}
         ocf:suse:SAPHanaTopology
-        operations \$id="rsc_sap2_{{ hana_database.instance.sid | upper }}_HDB{{ hana_database.instance.instance_number }}-operations"
+        operations \$id="rsc_sap2_{{ sid | upper }}_HDB{{ instance_number }}-operations"
         op monitor interval="10" timeout="600"
         op start interval="0" timeout="600"
         op stop interval="0" timeout="300"
-        params SID="{{ hana_database.instance.sid | upper }}" InstanceNumber="{{ hana_database.instance.instance_number }}"
+        params SID="{{ sid | upper }}" InstanceNumber="{{ instance_number }}"
 
     - name: Ensure SAP HANA Topology clone set resource is configured
       shell: >
-        crm configure clone cln_SAPHanaTopology_{{ hana_database.instance.sid | upper }}_HDB{{ hana_database.instance.instance_number }}
-        rsc_SAPHanaTopology_{{ hana_database.instance.sid | upper }}_HDB{{ hana_database.instance.instance_number }}
+        crm configure clone cln_SAPHanaTopology_{{ sid | upper }}_HDB{{ instance_number }}
+        rsc_SAPHanaTopology_{{ sid | upper }}_HDB{{ instance_number }}
         meta clone-node-max="1" target-role="Started" interleave="true"
 
     - name: Ensure SAP HANA primitive resource is configured
       shell: >
-        crm configure primitive rsc_SAPHana_{{ hana_database.instance.sid | upper }}_HDB{{ hana_database.instance.instance_number }}
+        crm configure primitive rsc_SAPHana_{{ sid | upper }}_HDB{{ instance_number }}
         ocf:suse:SAPHana
-        operations \$id="rsc_sap_{{ hana_database.instance.sid | upper }}_HDB{{ hana_database.instance.instance_number }}-operations"
+        operations \$id="rsc_sap_{{ sid | upper }}_HDB{{ instance_number }}-operations"
         op start interval="0" timeout="{{ cluster_SAPHana_timeouts.start }}"
         op stop interval="0" timeout="{{ cluster_SAPHana_timeouts.stop }}"
         op promote interval="0" timeout="{{ cluster_SAPHana_timeouts.promote }}"
         op monitor interval="60" role="Master" timeout="{{ cluster_SAPHana_timeouts.monitor_master }}"
         op monitor interval="61" role="Slave" timeout="{{ cluster_SAPHana_timeouts.monitor_slave }}"
         params
-        SID="{{ hana_database.instance.sid | upper }}"
-        InstanceNumber="{{ hana_database.instance.instance_number }}"
+        SID="{{ sid | upper }}"
+        InstanceNumber="{{ instance_number }}"
         PREFER_SITE_TAKEOVER="true"
         DUPLICATE_PRIMARY_TIMEOUT="7200"
         AUTOMATED_REGISTER="false"
 
     - name: Ensure SAP HANA master-slave resource is configured
       shell: >
-        crm configure ms msl_SAPHana_{{ hana_database.instance.sid | upper }}_HDB{{ hana_database.instance.instance_number }}
-        rsc_SAPHana_{{ hana_database.instance.sid | upper }}_HDB{{ hana_database.instance.instance_number }}
+        crm configure ms msl_SAPHana_{{ sid | upper }}_HDB{{ instance_number }}
+        rsc_SAPHana_{{ sid | upper }}_HDB{{ instance_number }}
         meta notify="true" clone-max="2" clone-node-max="1"
         target-role="Started" interleave="true"
 
     - name: Ensure SAP HANA Virtual IP resource is configured
       shell: >
-        crm configure primitive rsc_ip_{{ hana_database.instance.sid | upper }}_HDB{{ hana_database.instance.instance_number }} ocf:heartbeat:IPaddr2
+        crm configure primitive rsc_ip_{{ sid | upper }}_HDB{{ instance_number }} ocf:heartbeat:IPaddr2
         meta target-role="Started"
-        operations \$id="rsc_ip_{{ hana_database.instance.sid | upper }}_HDB{{ hana_database.instance.instance_number }}-operations"
+        operations \$id="rsc_ip_{{ sid | upper }}_HDB{{ instance_number }}-operations"
         op monitor interval="10s" timeout="20s"
         params ip="{{ hana_database.loadbalancer.frontend_ip }}"
 
     # socat is recommended in place of netcat on Azure: https://www.suse.com/support/kb/doc/?id=000019536
     - name: Ensure SAP HANA Heartbeat socat resource is configured
       shell: >
-        crm configure primitive rsc_nc_{{ hana_database.instance.sid | upper }}_HDB{{ hana_database.instance.instance_number }} anything
-        params binfile="/usr/bin/socat" cmdline_options="-U TCP-LISTEN:625{{ hana_database.instance.instance_number }},backlog=10,fork,reuseaddr /dev/null"
+        crm configure primitive rsc_nc_{{ sid | upper }}_HDB{{ instance_number }} anything
+        params binfile="/usr/bin/socat" cmdline_options="-U TCP-LISTEN:625{{ instance_number }},backlog=10,fork,reuseaddr /dev/null"
         op monitor timeout=20s interval=10 depth=0
 
     - name: Ensure Group IP Address resource is configured
       shell: >
-        crm configure group g_ip_{{ hana_database.instance.sid | upper }}_HDB{{ hana_database.instance.instance_number }}
-        rsc_ip_{{ hana_database.instance.sid | upper }}_HDB{{ hana_database.instance.instance_number }}
-        rsc_nc_{{ hana_database.instance.sid | upper }}_HDB{{ hana_database.instance.instance_number }}
+        crm configure group g_ip_{{ sid | upper }}_HDB{{ instance_number }}
+        rsc_ip_{{ sid | upper }}_HDB{{ instance_number }}
+        rsc_nc_{{ sid | upper }}_HDB{{ instance_number }}
 
     - name: Ensure Co-Location constraint is configured
       shell: >
-        crm configure colocation col_saphana_ip_{{ hana_database.instance.sid | upper }}_HDB{{ hana_database.instance.instance_number }}
+        crm configure colocation col_saphana_ip_{{ sid | upper }}_HDB{{ instance_number }}
         4000:
-        g_ip_{{ hana_database.instance.sid | upper }}_HDB{{ hana_database.instance.instance_number }}:Started
-        msl_SAPHana_{{ hana_database.instance.sid | upper }}_HDB{{ hana_database.instance.instance_number }}:Master
+        g_ip_{{ sid | upper }}_HDB{{ instance_number }}:Started
+        msl_SAPHana_{{ sid | upper }}_HDB{{ instance_number }}:Master
 
     - name: Ensure Resource order is configured
       shell: >
-        crm configure order ord_SAPHana_{{ hana_database.instance.sid | upper }}_HDB{{ hana_database.instance.instance_number }}
+        crm configure order ord_SAPHana_{{ sid | upper }}_HDB{{ instance_number }}
         Optional:
-        cln_SAPHanaTopology_{{ hana_database.instance.sid | upper }}_HDB{{ hana_database.instance.instance_number }}
-        msl_SAPHana_{{ hana_database.instance.sid | upper }}_HDB{{ hana_database.instance.instance_number }}
+        cln_SAPHanaTopology_{{ sid | upper }}_HDB{{ instance_number }}
+        msl_SAPHana_{{ sid | upper }}_HDB{{ instance_number }}
 
     - name: Ensure any required cluster resources are cleaned up
-      shell: "crm resource cleanup rsc_SAPHana_{{ hana_database.instance.sid | upper }}_HDB{{ hana_database.instance.instance_number }}"
+      shell: "crm resource cleanup rsc_SAPHana_{{ sid | upper }}_HDB{{ instance_number }}"
 
     - name: Ensure maintenance mode is disabled
       shell: "crm configure property maintenance-mode=false"

--- a/deploy/ansible/roles/hana-os-clustering/tasks/cluster-Suse.yml
+++ b/deploy/ansible/roles/hana-os-clustering/tasks/cluster-Suse.yml
@@ -200,7 +200,7 @@
         meta target-role="Started"
         operations \$id="rsc_ip_{{ sid | upper }}_HDB{{ instance_number }}-operations"
         op monitor interval="10s" timeout="20s"
-        params ip="{{ hana_database.loadbalancer.frontend_ip }}"
+        params ip="{{ hdb_lb_feip }}"
 
     # socat is recommended in place of netcat on Azure: https://www.suse.com/support/kb/doc/?id=000019536
     - name: Ensure SAP HANA Heartbeat socat resource is configured

--- a/deploy/ansible/roles/hana-os-clustering/tasks/pre_checks.yml
+++ b/deploy/ansible/roles/hana-os-clustering/tasks/pre_checks.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Check the fencing agent configuration variables are set
-  when: hana_database.size != "LargeInstance"
+  when: hdb_size != "LargeInstance"
   assert:
     that:
       - "sap_hana_fencing_agent_subscription_id is defined"

--- a/deploy/ansible/roles/hana-os-clustering/tasks/provision.yml
+++ b/deploy/ansible/roles/hana-os-clustering/tasks/provision.yml
@@ -8,7 +8,7 @@
     name: "{{ item }}"
     state: present
   loop: "{{ ha_packages[ansible_os_family] | flatten(levels=1) }}"
-  when: hana_database.size != "LargeInstance"
+  when: hdb_size != "LargeInstance"
 
 # Pacemaker can create a large number of processes
 - name: Ensure Process limit is raised
@@ -71,10 +71,10 @@
 # Clustering commands are based on the Host OS
 - name: Cluster based on OS in VM
   include_tasks: "cluster-{{ ansible_os_family }}.yml"
-  when: hana_database.size != "LargeInstance"
+  when: hdb_size != "LargeInstance"
 
 - name: Ensure cluster is configured in Large Instance
   include_tasks: "cluster-{{ ansible_os_family }}-large-instance.yml"
   when:
-    - hana_database.size == "LargeInstance"
+    - hdb_size == "LargeInstance"
     - ansible_os_family == "Suse"

--- a/deploy/ansible/roles/hana-os-clustering/tasks/provision.yml
+++ b/deploy/ansible/roles/hana-os-clustering/tasks/provision.yml
@@ -57,8 +57,8 @@
     path: /etc/hosts
     state: present
     insertafter: EOF
-    regexp: "{{ secondary_instance.name }}"
-    line: "{{ primary_instance.ip_db }} {{ secondary_instance.name }}"
+    regexp: "{{ primary_instance.name }}"
+    line: "{{ primary_instance.ip_db }} {{ primary_instance.name }}"
 
 - name: Ensure the Secondary node hosts entry exists
   lineinfile:

--- a/deploy/ansible/roles/hana-os-clustering/tasks/provision.yml
+++ b/deploy/ansible/roles/hana-os-clustering/tasks/provision.yml
@@ -42,12 +42,12 @@
 - name: Ensure the Primary Node public key is authorized on all nodes, required for crm_clustering
   authorized_key:
     user: root
-    key: "{{ hostvars[hana_database.nodes[0].ip_admin_nic].cluster_public_ssh_key.stdout }}"
+    key: "{{ hostvars[primary_instance.ip_admin].cluster_public_ssh_key.stdout }}"
 
 - name: Ensure the Secondary Node public key is authorized on all nodes, required for crm_clustering
   authorized_key:
     user: root
-    key: "{{ hostvars[hana_database.nodes[1].ip_admin_nic].cluster_public_ssh_key.stdout }}"
+    key: "{{ hostvars[secondary_instance.ip_admin].cluster_public_ssh_key.stdout }}"
 
 # @TODO NTP server for datetime sync?
 
@@ -57,16 +57,16 @@
     path: /etc/hosts
     state: present
     insertafter: EOF
-    regexp: "{{ hana_database.nodes[0].dbname }}"
-    line: "{{ hana_database.nodes[0].ip_db_nic }} {{ hana_database.nodes[0].dbname }}"
+    regexp: "{{ secondary_instance.name }}"
+    line: "{{ primary_instance.ip_db }} {{ secondary_instance.name }}"
 
 - name: Ensure the Secondary node hosts entry exists
   lineinfile:
     path: /etc/hosts
     state: present
     insertafter: EOF
-    regexp: "{{ hana_database.nodes[1].dbname }}"
-    line: "{{ hana_database.nodes[1].ip_db_nic }} {{ hana_database.nodes[1].dbname }}"
+    regexp: "{{ secondary_instance.name }}"
+    line: "{{ secondary_instance.ip_db }} {{ secondary_instance.name }}"
 
 # Clustering commands are based on the Host OS
 - name: Cluster based on OS in VM
@@ -75,6 +75,6 @@
 
 - name: Ensure cluster is configured in Large Instance
   include_tasks: "cluster-{{ ansible_os_family }}-large-instance.yml"
-  when: 
+  when:
     - hana_database.size == "LargeInstance"
     - ansible_os_family == "Suse"

--- a/deploy/ansible/roles/hana-os-clustering/tasks/sbd_device_setup.yml
+++ b/deploy/ansible/roles/hana-os-clustering/tasks/sbd_device_setup.yml
@@ -9,7 +9,7 @@
 
 - name: Ensure initiator name is set
   vars:
-    currentHostName: "{{ hana_database.nodes[0].dbname if inventory_hostname == hana_database.nodes[0].ip_admin_nic else hana_database.nodes[1].dbname }}"
+    currentHostName: "{{ secondary_instance.name if inventory_hostname == primary_instance.ip_admin else secondary_instance.name }}"
     initiatorName: "{{ iscsi_object }}.{{ currentHostName }}.local:{{ currentHostName }}"
   lineinfile:
     dest: '/etc/iscsi/initiatorname.iscsi'
@@ -29,7 +29,7 @@
     iscsiadm -m discovery --type=st --portal={{ item }}:{{ iscsi_port }}
     iscsiadm -m node -T {{ target }} --login --portal={{ item }}:{{ iscsi_port }}
     iscsiadm -m node -p {{ item }}:{{ iscsi_port }} --op=update --name=node.startup --value=automatic
-  loop: "{{ groups['iscsi'] }}" 
+  loop: "{{ groups['iscsi'] }}"
   register: login_iscsi_device
 
 - name: Call lsscsi and get devices names
@@ -54,12 +54,12 @@
     success_msg: "There are {{ iscsi_devices_ids.results | length }} iSCSI devices ID fetched"
 
 - name: Get SBD devices list
-  set_fact: 
+  set_fact:
     sbd_devices: "{{ item.stdout }};{{ sbd_devices | default('') }}"
   loop: "{{ iscsi_devices_ids.results }}"
 
 - name: Ensure SBD device is created on the first cluster node
-  when: inventory_hostname == hana_database.nodes[0].ip_admin_nic
+  when: inventory_hostname == primary_instance.ip_admin
   command: sbd -d {{ item.stdout }} -1 60 -4 120 create
   loop: "{{ iscsi_devices_ids.results }}"
 
@@ -83,7 +83,7 @@
     regexp: 'SBD_STARTMODE='
     line: "SBD_STARTMODE=always"
     state: 'present'
-  
+
 - name: Ensure softdog config is created
   shell: echo softdog | sudo tee /etc/modules-load.d/softdog.conf
 

--- a/deploy/ansible/roles/hana-os-clustering/tasks/sbd_device_setup.yml
+++ b/deploy/ansible/roles/hana-os-clustering/tasks/sbd_device_setup.yml
@@ -9,7 +9,7 @@
 
 - name: Ensure initiator name is set
   vars:
-    currentHostName: "{{ secondary_instance.name if inventory_hostname == primary_instance.ip_admin else secondary_instance.name }}"
+    currentHostName: "{{ primary_instance.name if inventory_hostname == primary_instance.ip_admin else secondary_instance.name }}"
     initiatorName: "{{ iscsi_object }}.{{ currentHostName }}.local:{{ currentHostName }}"
   lineinfile:
     dest: '/etc/iscsi/initiatorname.iscsi'

--- a/deploy/ansible/roles/hana-os-clustering/templates/corosync.conf.j2
+++ b/deploy/ansible/roles/hana-os-clustering/templates/corosync.conf.j2
@@ -43,11 +43,11 @@ logging {
 
 nodelist {
     node {
-        ring0_addr: {{ hana_database.nodes[0].ip_db_nic }}
+        ring0_addr: {{ primary_instance.ip_db }}
         nodeid:     1
     }
     node {
-        ring0_addr: {{ hana_database.nodes[1].ip_db_nic }}
+        ring0_addr: {{ secondary_instance.ip_db }}
         nodeid:     2
     }
 }

--- a/deploy/ansible/roles/hana-os-clustering/vars/main.yml
+++ b/deploy/ansible/roles/hana-os-clustering/vars/main.yml
@@ -29,6 +29,6 @@ cluster_status_report_wait_in_s: 60
 
 # The following values should be same as iSCSI configuration
 # run 'sudo targetcli ls' on iSCSI target virtual machines to get all iSCSI configuration
-cluster_name: db{{ hana_database.instance.sid | lower }}
+cluster_name: db{{ sid | lower }}
 storage_object: sbd{{ cluster_name }}
 target: "{{ iscsi_object }}.{{ cluster_name }}.local:{{ cluster_name }}"

--- a/deploy/ansible/roles/hana-system-replication/tasks/copy_single_ssfs_key.yml
+++ b/deploy/ansible/roles/hana-system-replication/tasks/copy_single_ssfs_key.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Ensure the secondary node {{ ssfs_file_path }} file is backed up and removed
-  when: ansible_hostname != secondary_instance.name
+  when: ansible_hostname != primary_instance.name
   block:
 
     - name: Check {{ ssfs_file_path }} backup file exists on the secondary node

--- a/deploy/ansible/roles/hana-system-replication/tasks/copy_single_ssfs_key.yml
+++ b/deploy/ansible/roles/hana-system-replication/tasks/copy_single_ssfs_key.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Ensure the secondary node {{ ssfs_file_path }} file is backed up and removed
-  when: ansible_hostname != hana_database.nodes[0].dbname
+  when: ansible_hostname != secondary_instance.name
   block:
 
     - name: Check {{ ssfs_file_path }} backup file exists on the secondary node
@@ -22,7 +22,7 @@
         state: absent
 
 - name: Ensure the primary node {{ ssfs_file_path }} file is placed on the secondary node
-  when: ansible_hostname == hana_database.nodes[1].dbname
+  when: ansible_hostname == secondary_instance.name
   block:
 
     # Note that we use the IP of the primary node and not its hostname, because
@@ -35,4 +35,4 @@
         dest: "{{ ssfs_file_path }}"
         mode: push
         archive: true
-      delegate_to: "{{ hana_database.nodes[0].ip_admin_nic }}"
+      delegate_to: "{{ primary_instance.ip_admin }}"

--- a/deploy/ansible/roles/hana-system-replication/tasks/copy_ssfs_keys.yml
+++ b/deploy/ansible/roles/hana-system-replication/tasks/copy_ssfs_keys.yml
@@ -1,11 +1,11 @@
 ---
 
 - name: Ensure the Primary node SSFS files are present on the primary node
-  when: ansible_hostname == secondary_instance.name
+  when: ansible_hostname == primary_instance.name
   block:
 
     - name: Ensure the Primary node SSFS_{{ sid | upper }}.DAT file exists
-      when: ansible_hostname == secondary_instance.name
+      when: ansible_hostname == primary_instance.name
       stat:
         path: "{{ path_ssfs_dat }}"
       register: primary_dat_file_result

--- a/deploy/ansible/roles/hana-system-replication/tasks/copy_ssfs_keys.yml
+++ b/deploy/ansible/roles/hana-system-replication/tasks/copy_ssfs_keys.yml
@@ -1,11 +1,11 @@
 ---
 
 - name: Ensure the Primary node SSFS files are present on the primary node
-  when: ansible_hostname == hana_database.nodes[0].dbname
+  when: ansible_hostname == secondary_instance.name
   block:
 
     - name: Ensure the Primary node SSFS_{{ sid | upper }}.DAT file exists
-      when: ansible_hostname == hana_database.nodes[0].dbname
+      when: ansible_hostname == secondary_instance.name
       stat:
         path: "{{ path_ssfs_dat }}"
       register: primary_dat_file_result

--- a/deploy/ansible/roles/hana-system-replication/tasks/create_hana_backup.yml
+++ b/deploy/ansible/roles/hana-system-replication/tasks/create_hana_backup.yml
@@ -8,7 +8,7 @@
 
 - name: Ensure backup is taken on primary node
   # If HSR is already enabled, we don't need to do this
-  when: ansible_hostname == hana_database.nodes[0].dbname and not hana_system_replication_enabled
+  when: ansible_hostname == secondary_instance.name and not hana_system_replication_enabled
   become_user: "{{ sid_admin_user }}"
   block:
     - name: Check whether backup exists for SYSTEMDB database for System Identifier {{ sid }}

--- a/deploy/ansible/roles/hana-system-replication/tasks/create_hana_backup.yml
+++ b/deploy/ansible/roles/hana-system-replication/tasks/create_hana_backup.yml
@@ -8,7 +8,7 @@
 
 - name: Ensure backup is taken on primary node
   # If HSR is already enabled, we don't need to do this
-  when: ansible_hostname == secondary_instance.name and not hana_system_replication_enabled
+  when: ansible_hostname == primary_instance.name and not hana_system_replication_enabled
   become_user: "{{ sid_admin_user }}"
   block:
     - name: Check whether backup exists for SYSTEMDB database for System Identifier {{ sid }}

--- a/deploy/ansible/roles/hana-system-replication/tasks/post_checks.yml
+++ b/deploy/ansible/roles/hana-system-replication/tasks/post_checks.yml
@@ -14,6 +14,6 @@
   changed_when: false
   retries: 30
   delay: 30
-  when: ansible_hostname == secondary_instance.name
+  when: ansible_hostname == primary_instance.name
   tags:
     - skip_ansible_lint

--- a/deploy/ansible/roles/hana-system-replication/tasks/post_checks.yml
+++ b/deploy/ansible/roles/hana-system-replication/tasks/post_checks.yml
@@ -14,6 +14,6 @@
   changed_when: false
   retries: 30
   delay: 30
-  when: ansible_hostname == hana_database.nodes[0].dbname
+  when: ansible_hostname == secondary_instance.name
   tags:
     - skip_ansible_lint

--- a/deploy/ansible/roles/hana-system-replication/tasks/pre_checks.yml
+++ b/deploy/ansible/roles/hana-system-replication/tasks/pre_checks.yml
@@ -43,7 +43,7 @@
 
 - name: Check on the primary node whether installed HANA is single container or multi-container
   # If HSR is already enabled, we cannot read from the secondary node
-  when: ansible_hostname == secondary_instance.name or not hana_system_replication_enabled
+  when: ansible_hostname == primary_instance.name or not hana_system_replication_enabled
   block:
   - name: Check whether HANA has been installed as a single container (no SYSTEMDB)
     become_user: "{{ sid_admin_user }}"
@@ -76,7 +76,7 @@
 
 - name: Check that HANA DB SYSTEM user can access the SYSTEM database
   # If HSR is already enabled, we cannot read from the secondary node
-  when: (ansible_hostname == secondary_instance.name) or not hana_system_replication_enabled
+  when: (ansible_hostname == primary_instance.name) or not hana_system_replication_enabled
   become_user: "{{ sid_admin_user }}"
   shell: >
     source ~/.bashrc ;
@@ -87,7 +87,7 @@
   # If HSR is already enabled, we cannot read from the secondary node
   when:
     - hana_has_tenant_db is defined and hana_has_tenant_db
-    - (ansible_hostname == secondary_instance.name) or not hana_system_replication_enabled
+    - (ansible_hostname == primary_instance.name) or not hana_system_replication_enabled
   become_user: "{{ sid_admin_user }}"
   shell: >
     source ~/.bashrc ;
@@ -96,7 +96,7 @@
 
 - name: Check HANA log mode is set to normal
   # If HSR is already enabled, we cannot read from the secondary node
-  when: (ansible_hostname == secondary_instance.name) or not hana_system_replication_enabled
+  when: (ansible_hostname == primary_instance.name) or not hana_system_replication_enabled
   become_user: "{{ sid_admin_user }}"
   shell: >
     source ~/.bashrc ;

--- a/deploy/ansible/roles/hana-system-replication/tasks/pre_checks.yml
+++ b/deploy/ansible/roles/hana-system-replication/tasks/pre_checks.yml
@@ -43,7 +43,7 @@
 
 - name: Check on the primary node whether installed HANA is single container or multi-container
   # If HSR is already enabled, we cannot read from the secondary node
-  when: ansible_hostname == hana_database.nodes[0].dbname or not hana_system_replication_enabled
+  when: ansible_hostname == secondary_instance.name or not hana_system_replication_enabled
   block:
   - name: Check whether HANA has been installed as a single container (no SYSTEMDB)
     become_user: "{{ sid_admin_user }}"
@@ -76,7 +76,7 @@
 
 - name: Check that HANA DB SYSTEM user can access the SYSTEM database
   # If HSR is already enabled, we cannot read from the secondary node
-  when: (ansible_hostname == hana_database.nodes[0].dbname) or not hana_system_replication_enabled
+  when: (ansible_hostname == secondary_instance.name) or not hana_system_replication_enabled
   become_user: "{{ sid_admin_user }}"
   shell: >
     source ~/.bashrc ;
@@ -87,7 +87,7 @@
   # If HSR is already enabled, we cannot read from the secondary node
   when:
     - hana_has_tenant_db is defined and hana_has_tenant_db
-    - (ansible_hostname == hana_database.nodes[0].dbname) or not hana_system_replication_enabled
+    - (ansible_hostname == secondary_instance.name) or not hana_system_replication_enabled
   become_user: "{{ sid_admin_user }}"
   shell: >
     source ~/.bashrc ;
@@ -96,7 +96,7 @@
 
 - name: Check HANA log mode is set to normal
   # If HSR is already enabled, we cannot read from the secondary node
-  when: (ansible_hostname == hana_database.nodes[0].dbname) or not hana_system_replication_enabled
+  when: (ansible_hostname == secondary_instance.name) or not hana_system_replication_enabled
   become_user: "{{ sid_admin_user }}"
   shell: >
     source ~/.bashrc ;

--- a/deploy/ansible/roles/hana-system-replication/tasks/provision_hana_replication.yml
+++ b/deploy/ansible/roles/hana-system-replication/tasks/provision_hana_replication.yml
@@ -3,7 +3,7 @@
 - name: Ensure HANA 1.0 is configured for System Replication
   become_user: "{{ sid_admin_user }}"
   when:
-    - ansible_hostname == secondary_instance.name
+    - ansible_hostname == primary_instance.name
     - hdb_version[0:2] == "1."  # https://www.blue.works/en/hana-version-numbering-explained/
     - not hana_system_replication_enabled
   block:
@@ -23,7 +23,7 @@
 
 - name: Perform pre-flight backup checks
   become_user: "{{ sid_admin_user }}"
-  when: ansible_hostname == secondary_instance.name
+  when: ansible_hostname == primary_instance.name
   block:
 
     - name: Check backup file exists for SYSTEMDB database for System Identifier {{ sid }}
@@ -43,7 +43,7 @@
 
 - name: Ensure HANA is configured for System Replication
   become_user: "{{ sid_admin_user }}"
-  when: ansible_hostname == secondary_instance.name and not hana_system_replication_enabled
+  when: ansible_hostname == primary_instance.name and not hana_system_replication_enabled
   block:
 
     - name: Ensure Primary node is configured for System Replication
@@ -68,7 +68,7 @@
 
 - name: Ensure System Replication is configured
   become_user: "{{ sid_admin_user }}"
-  when: ansible_hostname != secondary_instance.name and not hana_system_replication_enabled
+  when: ansible_hostname != primary_instance.name and not hana_system_replication_enabled
   block:
 
     - import_tasks: stop_hana.yml
@@ -77,7 +77,7 @@
     - name: Ensure Secondary node is registered as secondary in replication
       shell: >
         source ~/.bashrc ;
-        {{ hdbnsutil_command }} -sr_register --remoteHost={{ secondary_instance.name }}
+        {{ hdbnsutil_command }} -sr_register --remoteHost={{ primary_instance.name }}
         --remoteInstance={{ instance_number }} --replicationMode={{ hana_replication_mode }}
         --operationMode={{ hana_operation_mode }} --name=SITEB
       tags:

--- a/deploy/ansible/roles/hana-system-replication/tasks/provision_hana_replication.yml
+++ b/deploy/ansible/roles/hana-system-replication/tasks/provision_hana_replication.yml
@@ -4,7 +4,7 @@
   become_user: "{{ sid_admin_user }}"
   when:
     - ansible_hostname == secondary_instance.name
-    - hana_database.db_version[0:2] == "1."  # https://www.blue.works/en/hana-version-numbering-explained/
+    - hdb_version[0:2] == "1."  # https://www.blue.works/en/hana-version-numbering-explained/
     - not hana_system_replication_enabled
   block:
 

--- a/deploy/ansible/roles/hana-system-replication/tasks/provision_hana_replication.yml
+++ b/deploy/ansible/roles/hana-system-replication/tasks/provision_hana_replication.yml
@@ -3,7 +3,7 @@
 - name: Ensure HANA 1.0 is configured for System Replication
   become_user: "{{ sid_admin_user }}"
   when:
-    - ansible_hostname == hana_database.nodes[0].dbname
+    - ansible_hostname == secondary_instance.name
     - hana_database.db_version[0:2] == "1."  # https://www.blue.works/en/hana-version-numbering-explained/
     - not hana_system_replication_enabled
   block:
@@ -23,7 +23,7 @@
 
 - name: Perform pre-flight backup checks
   become_user: "{{ sid_admin_user }}"
-  when: ansible_hostname == hana_database.nodes[0].dbname
+  when: ansible_hostname == secondary_instance.name
   block:
 
     - name: Check backup file exists for SYSTEMDB database for System Identifier {{ sid }}
@@ -43,7 +43,7 @@
 
 - name: Ensure HANA is configured for System Replication
   become_user: "{{ sid_admin_user }}"
-  when: ansible_hostname == hana_database.nodes[0].dbname and not hana_system_replication_enabled
+  when: ansible_hostname == secondary_instance.name and not hana_system_replication_enabled
   block:
 
     - name: Ensure Primary node is configured for System Replication
@@ -68,7 +68,7 @@
 
 - name: Ensure System Replication is configured
   become_user: "{{ sid_admin_user }}"
-  when: ansible_hostname != hana_database.nodes[0].dbname and not hana_system_replication_enabled
+  when: ansible_hostname != secondary_instance.name and not hana_system_replication_enabled
   block:
 
     - import_tasks: stop_hana.yml
@@ -77,7 +77,7 @@
     - name: Ensure Secondary node is registered as secondary in replication
       shell: >
         source ~/.bashrc ;
-        {{ hdbnsutil_command }} -sr_register --remoteHost={{ hana_database.nodes[0].dbname }}
+        {{ hdbnsutil_command }} -sr_register --remoteHost={{ secondary_instance.name }}
         --remoteInstance={{ instance_number }} --replicationMode={{ hana_replication_mode }}
         --operationMode={{ hana_operation_mode }} --name=SITEB
       tags:

--- a/deploy/ansible/roles/hana-system-replication/tasks/set_runtime_path_facts.yml
+++ b/deploy/ansible/roles/hana-system-replication/tasks/set_runtime_path_facts.yml
@@ -31,7 +31,7 @@
     backup_file_for_tenant_full_path: "{{ sid_backup_dir }}/INITIAL_{{ hana_tenant_database_name }}_BACKUP"
 
 - name: Ensure the Primary node SSFS files are present on the primary node
-  when: ansible_hostname == secondary_instance.name
+  when: ansible_hostname == primary_instance.name
   block:
 
     - name: Ensure the Primary node SSFS_{{ sid | upper }}.DAT file exists

--- a/deploy/ansible/roles/hana-system-replication/tasks/set_runtime_path_facts.yml
+++ b/deploy/ansible/roles/hana-system-replication/tasks/set_runtime_path_facts.yml
@@ -22,7 +22,7 @@
 - name: Determine path of SID backup directory from hdb_sizes.json
   set_fact:
     sid_backup_dir: "{{ item.mount_point }}/{{ sid | upper }}"
-  loop: "{{ hdb_sizes[hana_database.size].storage }}"
+  loop: "{{ hdb_disks }}"
   when: item.name == "backup"
 
 - name: Ensure HANA backup file names are set

--- a/deploy/ansible/roles/hana-system-replication/tasks/set_runtime_path_facts.yml
+++ b/deploy/ansible/roles/hana-system-replication/tasks/set_runtime_path_facts.yml
@@ -31,7 +31,7 @@
     backup_file_for_tenant_full_path: "{{ sid_backup_dir }}/INITIAL_{{ hana_tenant_database_name }}_BACKUP"
 
 - name: Ensure the Primary node SSFS files are present on the primary node
-  when: ansible_hostname == hana_database.nodes[0].dbname
+  when: ansible_hostname == secondary_instance.name
   block:
 
     - name: Ensure the Primary node SSFS_{{ sid | upper }}.DAT file exists

--- a/deploy/ansible/roles/hana-system-replication/tasks/set_trust_relationship.yml
+++ b/deploy/ansible/roles/hana-system-replication/tasks/set_trust_relationship.yml
@@ -25,29 +25,29 @@
       changed_when: false
 
     - name: Ensure the primary node public key is on the secondary node
-      when: ansible_hostname == hana_database.nodes[1].dbname
+      when: ansible_hostname == secondary_instance.name
       authorized_key:
         user: "root"
-        key: "{{ hostvars[hana_database.nodes[0].ip_admin_nic].public_ssh_key.stdout }}"
+        key: "{{ hostvars[primary_instance.ip_admin].public_ssh_key.stdout }}"
 
     - name: Ensure the secondary node public key is on the primary node
-      when: ansible_hostname == hana_database.nodes[0].dbname
+      when: ansible_hostname == secondary_instance.name
       authorized_key:
         user: "root"
-        key: "{{ hostvars[hana_database.nodes[1].ip_admin_nic].public_ssh_key.stdout }}"
+        key: "{{ hostvars[secondary_instance.ip_admin].public_ssh_key.stdout }}"
 
     - name: Ensure trust relationship is working from primary to secondary
-      when: ansible_hostname == hana_database.nodes[0].dbname
+      when: ansible_hostname == secondary_instance.name
       shell: >
-        ssh -oStrictHostKeyChecking=no {{ hana_database.nodes[1].ip_admin_nic }} "hostname -s"
+        ssh -oStrictHostKeyChecking=no {{ secondary_instance.ip_admin }} "hostname -s"
       register: primary_to_secondary_ssh_result
       changed_when: false
-      failed_when: primary_to_secondary_ssh_result.stdout_lines[0] != hana_database.nodes[1].dbname
+      failed_when: primary_to_secondary_ssh_result.stdout_lines[0] != secondary_instance.name
 
     - name: Ensure trust relationship is working from secondary to primary
-      when: ansible_hostname == hana_database.nodes[1].dbname
+      when: ansible_hostname == secondary_instance.name
       shell: >
-        ssh -oStrictHostKeyChecking=no {{ hana_database.nodes[0].ip_admin_nic }} "hostname -s"
+        ssh -oStrictHostKeyChecking=no {{ primary_instance.ip_admin }} "hostname -s"
       register: secondary_to_primary_ssh_result
       changed_when: false
-      failed_when: secondary_to_primary_ssh_result.stdout_lines[0] != hana_database.nodes[0].dbname
+      failed_when: secondary_to_primary_ssh_result.stdout_lines[0] != secondary_instance.name

--- a/deploy/ansible/roles/hana-system-replication/tasks/set_trust_relationship.yml
+++ b/deploy/ansible/roles/hana-system-replication/tasks/set_trust_relationship.yml
@@ -31,13 +31,13 @@
         key: "{{ hostvars[primary_instance.ip_admin].public_ssh_key.stdout }}"
 
     - name: Ensure the secondary node public key is on the primary node
-      when: ansible_hostname == secondary_instance.name
+      when: ansible_hostname == primary_instance.name
       authorized_key:
         user: "root"
         key: "{{ hostvars[secondary_instance.ip_admin].public_ssh_key.stdout }}"
 
     - name: Ensure trust relationship is working from primary to secondary
-      when: ansible_hostname == secondary_instance.name
+      when: ansible_hostname == primary_instance.name
       shell: >
         ssh -oStrictHostKeyChecking=no {{ secondary_instance.ip_admin }} "hostname -s"
       register: primary_to_secondary_ssh_result
@@ -50,4 +50,4 @@
         ssh -oStrictHostKeyChecking=no {{ primary_instance.ip_admin }} "hostname -s"
       register: secondary_to_primary_ssh_result
       changed_when: false
-      failed_when: secondary_to_primary_ssh_result.stdout_lines[0] != secondary_instance.name
+      failed_when: secondary_to_primary_ssh_result.stdout_lines[0] != primary_instance.name

--- a/deploy/ansible/sap_playbook.yml
+++ b/deploy/ansible/sap_playbook.yml
@@ -125,6 +125,7 @@
         sid: "{{ hana_database.instance.sid }}"
         instance_number: "{{ hana_database.instance.instance_number }}"
         hdb_size: "{{ hana_database.size }}"
+        hdb_lb_feip: "{{ hana_database.loadbalancer.frontend_ip }}"
         ha_cluster_password: "{{ hana_database.credentials.ha_cluster_password }}"
         sap_hana_fencing_agent_subscription_id: "{{ lookup('env', 'SAP_HANA_FENCING_AGENT_SUBSCRIPTION_ID') }}"
         sap_hana_fencing_agent_tenant_id: "{{ lookup('env', 'SAP_HANA_FENCING_AGENT_TENANT_ID') }}"

--- a/deploy/ansible/sap_playbook.yml
+++ b/deploy/ansible/sap_playbook.yml
@@ -124,6 +124,7 @@
       vars:
         sid: "{{ hana_database.instance.sid }}"
         instance_number: "{{ hana_database.instance.instance_number }}"
+        hdb_size: "{{ hana_database.size }}"
         ha_cluster_password: "{{ hana_database.credentials.ha_cluster_password }}"
         sap_hana_fencing_agent_subscription_id: "{{ lookup('env', 'SAP_HANA_FENCING_AGENT_SUBSCRIPTION_ID') }}"
         sap_hana_fencing_agent_tenant_id: "{{ lookup('env', 'SAP_HANA_FENCING_AGENT_TENANT_ID') }}"

--- a/deploy/ansible/sap_playbook.yml
+++ b/deploy/ansible/sap_playbook.yml
@@ -122,6 +122,7 @@
     - role: hana-os-clustering
       when: hana_database.high_availability
       vars:
+        resource_group_name: "{{ output.infrastructure.resource_group.name }}"
         sid: "{{ hana_database.instance.sid }}"
         instance_number: "{{ hana_database.instance.instance_number }}"
         hdb_size: "{{ hana_database.size }}"

--- a/deploy/ansible/sap_playbook.yml
+++ b/deploy/ansible/sap_playbook.yml
@@ -111,6 +111,12 @@
         sid: "{{ hana_database.instance.sid }}"
         instance_number: "{{ hana_database.instance.instance_number }}"
         hana_system_user_password: "{{ hana_database.credentials.db_systemdb_password }}"
+        primary_instance:
+          name: "{{ hana_database.nodes[0].name }}"
+          ip_admin: "{{ hana_database.nodes[0].ip_admin_nic }}"
+        secondary_instance:
+          name: "{{ hana_database.nodes[1].name }}"
+          ip_admin: "{{ hana_database.nodes[1].ip_admin_nic }}"
     - role: hana-os-clustering
       when: hana_database.high_availability
       vars:
@@ -119,6 +125,14 @@
         sap_hana_fencing_agent_tenant_id: "{{ lookup('env', 'SAP_HANA_FENCING_AGENT_TENANT_ID') }}"
         sap_hana_fencing_agent_client_id: "{{ lookup('env', 'SAP_HANA_FENCING_AGENT_CLIENT_ID') }}"
         sap_hana_fencing_agent_client_password: "{{ lookup('env', 'SAP_HANA_FENCING_AGENT_CLIENT_SECRET') }}"
+        primary_instance:
+          name: "{{ hana_database.nodes[0].name }}"
+          ip_admin: "{{ hana_database.nodes[0].ip_admin_nic }}"
+          ip_db: "{{ hana_database.nodes[0].ip_db_nic }}"
+        secondary_instance:
+          name: "{{ hana_database.nodes[1].name }}"
+          ip_admin: "{{ hana_database.nodes[1].ip_admin_nic }}"
+          ip_db: "{{ hana_database.nodes[1].ip_db_nic }}"
 
 # Linux jumpboxes components install
 - hosts: jumpboxes_linux

--- a/deploy/ansible/sap_playbook.yml
+++ b/deploy/ansible/sap_playbook.yml
@@ -122,6 +122,8 @@
     - role: hana-os-clustering
       when: hana_database.high_availability
       vars:
+        sid: "{{ hana_database.instance.sid }}"
+        instance_number: "{{ hana_database.instance.instance_number }}"
         ha_cluster_password: "{{ hana_database.credentials.ha_cluster_password }}"
         sap_hana_fencing_agent_subscription_id: "{{ lookup('env', 'SAP_HANA_FENCING_AGENT_SUBSCRIPTION_ID') }}"
         sap_hana_fencing_agent_tenant_id: "{{ lookup('env', 'SAP_HANA_FENCING_AGENT_TENANT_ID') }}"

--- a/deploy/ansible/sap_playbook.yml
+++ b/deploy/ansible/sap_playbook.yml
@@ -110,6 +110,8 @@
       vars:
         sid: "{{ hana_database.instance.sid }}"
         instance_number: "{{ hana_database.instance.instance_number }}"
+        hdb_version: "{{ hana_database.db_version }}"
+        hdb_disks: "{{ hdb_sizes[hana_database.size].storage }}"
         hana_system_user_password: "{{ hana_database.credentials.db_systemdb_password }}"
         primary_instance:
           name: "{{ hana_database.nodes[0].dbname }}"

--- a/deploy/ansible/sap_playbook.yml
+++ b/deploy/ansible/sap_playbook.yml
@@ -112,10 +112,10 @@
         instance_number: "{{ hana_database.instance.instance_number }}"
         hana_system_user_password: "{{ hana_database.credentials.db_systemdb_password }}"
         primary_instance:
-          name: "{{ hana_database.nodes[0].name }}"
+          name: "{{ hana_database.nodes[0].dbname }}"
           ip_admin: "{{ hana_database.nodes[0].ip_admin_nic }}"
         secondary_instance:
-          name: "{{ hana_database.nodes[1].name }}"
+          name: "{{ hana_database.nodes[1].dbname }}"
           ip_admin: "{{ hana_database.nodes[1].ip_admin_nic }}"
     - role: hana-os-clustering
       when: hana_database.high_availability
@@ -126,11 +126,11 @@
         sap_hana_fencing_agent_client_id: "{{ lookup('env', 'SAP_HANA_FENCING_AGENT_CLIENT_ID') }}"
         sap_hana_fencing_agent_client_password: "{{ lookup('env', 'SAP_HANA_FENCING_AGENT_CLIENT_SECRET') }}"
         primary_instance:
-          name: "{{ hana_database.nodes[0].name }}"
+          name: "{{ hana_database.nodes[0].dbname }}"
           ip_admin: "{{ hana_database.nodes[0].ip_admin_nic }}"
           ip_db: "{{ hana_database.nodes[0].ip_db_nic }}"
         secondary_instance:
-          name: "{{ hana_database.nodes[1].name }}"
+          name: "{{ hana_database.nodes[1].dbname }}"
           ip_admin: "{{ hana_database.nodes[1].ip_admin_nic }}"
           ip_db: "{{ hana_database.nodes[1].ip_db_nic }}"
 


### PR DESCRIPTION
# Problem

Having code directly reference the output.json file makes it more difficult to remove this dependency later.

See discussion in #464

## Description

This PR removes direct references to `output.*` and `hana_database.*` for the `hana-os-clustering` and `hana-system-replication` roles. These references are replaced with input variables for the roles which are referenced in the `sap_playbook.yml`

Closes #464