### PR TITLE
[BUG] Fix issue with NSG trying to update when reuse NSG for app subnet

### DIFF
--- a/deploy/terraform/modules/app_tier/nsg-webdisp.tf
+++ b/deploy/terraform/modules/app_tier/nsg-webdisp.tf
@@ -1,6 +1,6 @@
 # NSG rule to deny internet access
 resource azurerm_network_security_rule webRule_internet {
-  count                       = local.enable_deployment ? 1 : 0
+  count                       = local.enable_deployment ? (var.infrastructure.vnets.sap.subnet_app.nsg.is_existing ? 0 : 1) : 0
   name                        = "Internet"
   priority                    = 100
   direction                   = "Inbound"
@@ -16,7 +16,7 @@ resource azurerm_network_security_rule webRule_internet {
 
 # NSG rule to open ports for Web dispatcher
 resource azurerm_network_security_rule web {
-  count                       = local.enable_deployment ? length(local.nsg-ports.web) : 0
+  count                       = local.enable_deployment ? (var.infrastructure.vnets.sap.subnet_app.nsg.is_existing ? 0 : length(local.nsg-ports.web)) : 0
   name                        = local.nsg-ports.web[count.index].name
   priority                    = local.nsg-ports.web[count.index].priority
   direction                   = "Inbound"


### PR DESCRIPTION
## Problem
When using existing app subnet and existing NSG, the NSG shouldn't be touched.

## Solution
Add condition to skip NSG rule creating if existing NSG used.

## Test
1. Deploy everything with app
1. Deploy into a new rg with existing vnet/subnet using existing nsg*

*Need to adjust the code due to issue #600

## Followup
This code need to be updated in #589 once in master.