### PR TITLE
Modify nsg rules of HDB

### DIFF
--- a/deploy/terraform/modules/hdb_node/hdb-nsg.tf
+++ b/deploy/terraform/modules/hdb_node/hdb-nsg.tf
@@ -35,19 +35,3 @@ resource "azurerm_network_security_rule" "nsr-external-db" {
   source_address_prefix       = "*"
   destination_address_prefix  = var.infrastructure.vnets.sap.subnet_db.prefix
 }
-
-# Creates network security rule for SAP admin subnet
-resource "azurerm_network_security_rule" "nsr-admin" {
-  count                       = local.enable_deployment ? (var.infrastructure.vnets.sap.subnet_admin.nsg.is_existing ? 0 : 1) : 0
-  name                        = "nsr-subnet-admin"
-  resource_group_name         = var.infrastructure.vnets.sap.subnet_admin.nsg.is_existing ? data.azurerm_network_security_group.nsg-admin[0].resource_group_name : azurerm_network_security_group.nsg-admin[0].resource_group_name
-  network_security_group_name = var.infrastructure.vnets.sap.subnet_admin.nsg.is_existing ? data.azurerm_network_security_group.nsg-admin[0].name : azurerm_network_security_group.nsg-admin[0].name
-  priority                    = 102
-  direction                   = "Inbound"
-  access                      = "allow"
-  protocol                    = "Tcp"
-  source_port_range           = "*"
-  destination_port_range      = "*"
-  source_address_prefix       = var.infrastructure.vnets.management.subnet_mgmt.prefix
-  destination_address_prefix  = var.infrastructure.vnets.sap.subnet_admin.prefix
-}


### PR DESCRIPTION
Simplify the nsg of hdb.
According to Azure reference:
https://docs.microsoft.com/en-us/azure/virtual-network/security-overview#allowvnetinbound

1.  "Azure creates several default security rules within each network security group. One default rule allows all traffic to flow between all resources in a virtual network." One of these rules is 

Priority | Source | Source ports | Destination | Destination ports | Protocol | Access
65000 | VirtualNetwork | 0-65535 | VirtualNetwork | 0-65535 | Any | Allow

2. The virtual network address space (all IP address ranges defined for the virtual network), all connected on-premises address spaces, **peered virtual networks**...

In conclusion, there is no need to add an allow rule between subnet-mgmt and subnet-admin.



