### PR TITLE
Add support-anydb to PR triggers

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -8,6 +8,7 @@ pr:
   branches:
     include:
     - master
+    - support-anydb
   paths:
     include:
     - deploy/*


### PR DESCRIPTION
## Problem
In order to support anydb, there will be work done and PRs created against feature branch `support-anydb`.
And we would like to have those PR go through the pipeline so it does not break anything

## Solution
Add PR trigger against branch `support-anydb`
