### PR TITLE
Use targetBranchName to conditionally run anydb testcase

### DIFF
--- a/templates/ansible-deployment-steps.yaml
+++ b/templates/ansible-deployment-steps.yaml
@@ -21,7 +21,7 @@ steps:
       ssh -i /tmp/sshkey -o StrictHostKeyChecking=no "${rti_user}"@"${rti_public_ip}" '
       ansible-playbook --version
       cd sap-hana
-      git checkout $(System.PullRequest.SourceBranch)
+      git checkout $(branchName)
       cd ~
       export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
       export ANSIBLE_HOST_KEY_CHECKING=False

--- a/templates/job-template-allReuseCases.yaml
+++ b/templates/job-template-allReuseCases.yaml
@@ -75,7 +75,7 @@ jobs:
       testCaseName: $(testcase)
 - job: createAllNew_AnyDB_SN_${{parameters.osVersion}}
   timeoutInMinutes: 60
-  condition: eq(variables['branchName'], 'feature/anydb')
+  condition: eq(variables['targetBranchName'], 'feature/anydb')
   variables:
     scenario: sap-allNew-AnyDB-SN
     testcase: $(scenario)-${{parameters.osVersion}}-$(Build.BuildId)
@@ -92,7 +92,7 @@ jobs:
       osImage: ${{parameters.osImage}}
 - job: createAllNew_AnyDB_HA_${{parameters.osVersion}}
   timeoutInMinutes: 60
-  condition: eq(variables['branchName'], 'feature/anydb')
+  condition: eq(variables['targetBranchName'], 'feature/anydb')
   variables:
     scenario: sap-allNew-AnyDB-HA
     testcase: $(scenario)-${{parameters.osVersion}}-$(Build.BuildId)

--- a/templates/variables.yaml
+++ b/templates/variables.yaml
@@ -3,3 +3,7 @@ variables:
     branchName: $[ replace(variables['Build.SourceBranch'], 'refs/heads/', '') ]
   ${{ if startsWith(variables['Build.SourceBranch'], 'refs/pull/') }}:
     branchName: $[ replace(variables['System.PullRequest.SourceBranch'], 'refs/heads/', '') ]
+  ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+    targetBranchName: $[ variables['System.PullRequest.TargetBranch'] ]
+  ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+    targetBranchName: $[ variables['branchName'] ]


### PR DESCRIPTION
## Problem
We need target branch name to control whether we run anydb test case or not

## Solution
1. Add `targetBranchName` if it is a pull request
1. Also fix the problem with ansible part when build was not triggered by PR:
Before we see below and with the change should be gone:
`bash: line 3: System.PullRequest.SourceBranch: command not found`

## Test

- Create dummy PR #618 against feature branch and see in PR build:

1. in [pipeline](https://dev.azure.com/azuresaphana/Azure-SAP-HANA/_build/results?buildId=5833&view=results) anydb test case triggered.
2. `branchName` and `targetBranchName` looks correct:
```
  branchName:
    Parsing expression: <replace(variables['System.PullRequest.SourceBranch'], 'refs/heads/', '')>
    Evaluating: replace(variables['System.PullRequest.SourceBranch'], 'refs/heads/', '')
    Expanded: replace('nancyc-test-anydb', 'refs/heads/', '')
    Result: 'nancyc-test-anydb'
  targetBranchName:
    Parsing expression: <variables['System.PullRequest.TargetBranch']>
    Evaluating: variables['System.PullRequest.TargetBranch']
    Result: 'feature/anydb'
```
3. Ansible was executed on right branch: 
```
Branch 'nancyc-test-anydb' set up to track remote branch 'nancyc-test-anydb' from 'origin'.
Switched to a new branch 'nancyc-test-anydb'
```

- Create manual build against branch `nancyc-feature` and see:

1. in [pipeline](https://dev.azure.com/azuresaphana/Azure-SAP-HANA/_build/results?buildId=5835&view=logs&s=e77df0ec-e69f-5a3b-64bd-884394b91fe8&j=e12e19ff-2b3a-5775-4312-8edd73215eef), anydb test case not triggered:
```
Evaluating: eq(variables['targetBranchName'], 'feature/anydb')
Expanded: eq('nancyc-feature', 'feature/anydb')
```
2. `branchName` and `targetBranchName` looks correct:
```
branchName:
    Parsing expression: <replace(variables['Build.SourceBranch'], 'refs/heads/', '')>
    Evaluating: replace(variables['Build.SourceBranch'], 'refs/heads/', '')
    Expanded: replace('refs/heads/nancyc-feature', 'refs/heads/', '')
    Result: 'nancyc-feature'
  targetBranchName:
    Parsing expression: <variables['branchName']>
    Evaluating: variables['branchName']
    Result: 'nancyc-feature'
```
3. Ansible was executed on right branch:
```
Branch 'nancyc-feature' set up to track remote branch 'nancyc-feature' from 'origin'.
Switched to a new branch 'nancyc-feature' 
```