### PR TITLE
Create KV for certificate only when windows jumpbox is to be deployed

### DIFF
--- a/deploy/terraform/modules/jumpbox/certificates.tf
+++ b/deploy/terraform/modules/jumpbox/certificates.tf
@@ -12,6 +12,7 @@ data "external" "current-user" {
 
 # Creates Azure key vault
 resource "azurerm_key_vault" "key-vault" {
+  count               = length(local.vm-jump-win) > 0 ? 1 : 0
   name                = "winrm-kv-${var.random-id.hex}"
   location            = var.resource-group[0].location
   resource_group_name = var.resource-group[0].name
@@ -42,7 +43,7 @@ resource "azurerm_key_vault" "key-vault" {
 resource "azurerm_key_vault_certificate" "key-vault-cert" {
   count        = length(var.jumpboxes.windows)
   name         = "${var.jumpboxes.windows[count.index].name}-cert"
-  key_vault_id = azurerm_key_vault.key-vault.id
+  key_vault_id = try(azurerm_key_vault.key-vault[0].id, null)
 
   certificate_policy {
     issuer_parameters {

--- a/deploy/terraform/modules/jumpbox/vm-jump-win.tf
+++ b/deploy/terraform/modules/jumpbox/vm-jump-win.tf
@@ -76,7 +76,7 @@ resource "azurerm_windows_virtual_machine" "jump-win" {
       store = "My"
       url   = azurerm_key_vault_certificate.key-vault-cert[count.index].secret_id
     }
-    key_vault_id = azurerm_key_vault.key-vault.id
+    key_vault_id = try(azurerm_key_vault.key-vault[0].id, null)
   }
 
   winrm_listener {


### PR DESCRIPTION
## Problem
KV that is used to store certificates for windows jumpbox always get deployed even no windows jumpbox is deployed.

## Solution
Only deploy KV when 1 or more windows jumpbox(es) will be deployed

## Test
Deploy with 0/1/2 windows jumpbox(es) and no error.