### PR TITLE
Add SID to application templates

### DIFF
--- a/deploy/template_samples/application_with_ha.json
+++ b/deploy/template_samples/application_with_ha.json
@@ -67,6 +67,7 @@
   },
   "application": {
     "enable_deployment": true,
+    "sid": "Z01",
     "scs_instance_number": "01",
     "ers_instance_number": "02",
     "scs_high_availability": true,

--- a/deploy/template_samples/application_with_ha_in_existing_subnet.json
+++ b/deploy/template_samples/application_with_ha_in_existing_subnet.json
@@ -42,6 +42,7 @@
   },
   "application": {
     "enable_deployment": true,
+    "sid": "Z00",
     "scs_instance_number": "01",
     "ers_instance_number": "02",
     "scs_high_availability": true,

--- a/deploy/template_samples/application_wo_ha.json
+++ b/deploy/template_samples/application_wo_ha.json
@@ -67,6 +67,7 @@
   },
   "application": {
     "enable_deployment": true,
+    "sid": "Z01",
     "scs_instance_number": "01",
     "ers_instance_number": "02",
     "scs_high_availability": false,

--- a/deploy/template_samples/application_wo_ha_customimage.json
+++ b/deploy/template_samples/application_wo_ha_customimage.json
@@ -67,6 +67,7 @@
   },
   "application": {
     "enable_deployment": true,
+    "sid": "Z01",
     "scs_instance_number": "01",
     "ers_instance_number": "02",
     "scs_high_availability": false,

--- a/deploy/template_samples/application_wo_ha_windows.json
+++ b/deploy/template_samples/application_wo_ha_windows.json
@@ -67,6 +67,7 @@
   },
   "application": {
     "enable_deployment": true,
+    "sid": "Z01",
     "scs_instance_number": "01",
     "ers_instance_number": "02",
     "scs_high_availability": false,


### PR DESCRIPTION
## Problem
If `SID` is defined in `application.sid`, it will be used, otherwise use default value `HN1`.

## Solution
Specify `SID` in all application_* under `template_samples`.