### PR TITLE
Deploy NSG into resource group of the existing vnet

### DIFF
--- a/deploy/terraform/modules/hdb_node/infrastructure.tf
+++ b/deploy/terraform/modules/hdb_node/infrastructure.tf
@@ -36,16 +36,16 @@ data "azurerm_subnet" "subnet-sap-db" {
 resource "azurerm_network_security_group" "nsg-admin" {
   count               = local.enable_deployment ? (local.sub_admin_nsg_exists ? 0 : 1) : 0
   name                = local.sub_admin_nsg_name
-  location            = var.resource-group[0].location
-  resource_group_name = var.resource-group[0].name
+  resource_group_name = var.vnet-sap[0].resource_group_name
+  location            = var.vnet-sap[0].location
 }
 
 # Creates SAP db subnet nsg
 resource "azurerm_network_security_group" "nsg-db" {
   count               = local.enable_deployment ? (local.sub_db_nsg_exists ? 0 : 1) : 0
   name                = local.sub_db_nsg_name
-  location            = var.resource-group[0].location
-  resource_group_name = var.resource-group[0].name
+  resource_group_name = var.vnet-sap[0].resource_group_name
+  location            = var.vnet-sap[0].location
 }
 
 # Imports the SAP admin subnet nsg data


### PR DESCRIPTION
### Problem
The current design will create NSGs in the same resource group as the VMs. When deploying multiple SDUs and having the VNet in another resource group the subnets will end up with multiple NSGs all with the same name (as each SDU deployment creates a new one)

### Solution
Add the NSGs in the same Resource group as the VNet.