### PR TITLE
Workaround for issue with dbus-org.freedesktop.hostname1.service

### DIFF
--- a/deploy/terraform/modules/hdb_node/vm-hdb.tf
+++ b/deploy/terraform/modules/hdb_node/vm-hdb.tf
@@ -133,8 +133,9 @@ resource "azurerm_managed_disk" "data-disk" {
 
 # Manages Linux Virtual Machine for HANA DB servers
 resource "azurerm_linux_virtual_machine" "vm-dbnode" {
-  count                        = local.enable_deployment ? length(local.hdb_vms) : 0
-  name                         = local.hdb_vms[count.index].name
+  count = local.enable_deployment ? length(local.hdb_vms) : 0
+  // Workaround for issue with dbus-org.freedesktop.hostname1.service
+  name                         = replace(local.hdb_vms[count.index].name, "_", "")
   computer_name                = replace(local.hdb_vms[count.index].name, "_", "")
   location                     = var.resource-group[0].location
   resource_group_name          = var.resource-group[0].name


### PR DESCRIPTION
## Problem
When setting different names for VM resource and hostname, dbus-org.freedesktop.hostname1.service changed the hostname to VM resource name. This fails ansible playbook.

Below are from /var/log/messages:
```
2020-07-14T17:21:21.023267+00:00 linux systemd-hostnamed[1297]: Changed static host name to 'PRDWE2hdb00-0'
2020-07-14T17:21:21.023666+00:00 linux systemd-hostnamed[1297]: Changed host name to 'PRDWE2hdb00-0'
...
2020-07-14T18:04:50.715802+00:00 linux dbus[1076]: [system] Activating via systemd: service name='org.freedesktop.hostname1' unit='dbus-org.freedesktop.hostname1.service'
2020-07-14T18:04:50.719107+00:00 linux systemd[1]: Starting Hostname Service...
2020-07-14T18:04:50.726563+00:00 linux dbus[1076]: [system] Successfully activated service 'org.freedesktop.hostname1'
2020-07-14T18:04:50.733370+00:00 linux systemd-hostnamed[31462]: Changed host name to 'PRD_WE2_hdb00-0'
2020-07-14T18:04:50.740934+00:00 linux systemd-hostnamed[31462]: Changed pretty host name to 'PRD_WE2_hdb00-0'
2020-07-14T18:04:50.744910+00:00 linux systemd-hostnamed[31462]: Changed static host name to 'PRD_WE2_hdb00-0'
2020-07-14T18:04:50.747547+00:00 linux systemd[1]: Started Hostname Service.
2020-07-14T18:04:50.899314+00:00 linux sudo: pam_unix(sudo:session): session closed for user root
2020-07-14T18:04:51.345143+00:00 linux python[3242]: 2020/07/14 18:04:51.345040 INFO ExtHandler EnvMonitor: Detected hostname change: PRDWE2hdb00-0 -> PRD_WE2_hdb00-0
```

## Solution
Will use the same name for VM resource and hostname until we find a proper solution.