### PR TITLE
Add option to deploy webdispatcher in a separate subnet

### DIFF
--- a/deploy/terraform/modules/app_tier/infrastructure.tf
+++ b/deploy/terraform/modules/app_tier/infrastructure.tf
@@ -15,6 +15,23 @@ data "azurerm_subnet" "subnet-sap-app" {
   virtual_network_name = split("/", local.sub_app_arm_id)[8]
 }
 
+# Creates web dispatcher subnet of SAP VNET
+resource "azurerm_subnet" "subnet-sap-web" {
+  count                = local.enable_deployment && local.sub_web_defined ? (local.sub_web_exists ? 0 : 1) : 0
+  name                 = local.sub_web_name
+  resource_group_name  = var.vnet-sap[0].resource_group_name
+  virtual_network_name = var.vnet-sap[0].name
+  address_prefixes     = [local.sub_web_prefix]
+}
+
+# Imports data of existing SAP web dispatcher subnet
+data "azurerm_subnet" "subnet-sap-web" {
+  count                = local.enable_deployment && local.sub_web_defined ? (local.sub_web_exists ? 1 : 0) : 0
+  name                 = split("/", local.sub_web_arm_id)[10]
+  resource_group_name  = split("/", local.sub_web_arm_id)[4]
+  virtual_network_name = split("/", local.sub_web_arm_id)[8]
+}
+
 /*
  SCS Load Balancer
  SCS Availability Set
@@ -29,14 +46,14 @@ resource "azurerm_lb" "scs" {
 
   frontend_ip_configuration {
     name                          = "${upper(local.application_sid)}_scs-feip"
-    subnet_id                     = var.infrastructure.vnets.sap.subnet_app.is_existing ? data.azurerm_subnet.subnet-sap-app[0].id : azurerm_subnet.subnet-sap-app[0].id
+    subnet_id                     = local.sub_app_exists ? data.azurerm_subnet.subnet-sap-app[0].id : azurerm_subnet.subnet-sap-app[0].id
     private_ip_address_allocation = "Static"
     private_ip_address            = var.infrastructure.vnets.sap.subnet_app.is_existing ? local.scs_lb_ips[0] : cidrhost(var.infrastructure.vnets.sap.subnet_app.prefix, 0 + local.ip_offsets.scs_lb)
   }
 
   frontend_ip_configuration {
     name                          = "${upper(local.application_sid)}_ers-feip"
-    subnet_id                     = var.infrastructure.vnets.sap.subnet_app.is_existing ? data.azurerm_subnet.subnet-sap-app[0].id : azurerm_subnet.subnet-sap-app[0].id
+    subnet_id                     = local.sub_app_exists ? data.azurerm_subnet.subnet-sap-app[0].id : azurerm_subnet.subnet-sap-app[0].id
     private_ip_address_allocation = "Static"
     private_ip_address            = var.infrastructure.vnets.sap.subnet_app.is_existing ? local.scs_lb_ips[1] : cidrhost(var.infrastructure.vnets.sap.subnet_app.prefix, 1 + local.ip_offsets.scs_lb)
   }
@@ -132,9 +149,9 @@ resource "azurerm_lb" "web" {
 
   frontend_ip_configuration {
     name                          = "sap${lower(local.application_sid)}web"
-    subnet_id                     = local.sub_app_exists ? data.azurerm_subnet.subnet-sap-app[0].id : azurerm_subnet.subnet-sap-app[0].id
+    subnet_id                     = local.sub_web_defined ? local.sub_web_exists ? data.azurerm_subnet.subnet-sap-web[0].id : azurerm_subnet.subnet-sap-web[0].id : local.sub_app_exists ? data.azurerm_subnet.subnet-sap-app[0].id : azurerm_subnet.subnet-sap-app[0].id
     private_ip_address_allocation = "Static"
-    private_ip_address            = cidrhost(local.sub_app_prefix, local.ip_offsets.web_lb)
+    private_ip_address            = local.sub_web_defined ? cidrhost(local.sub_web_prefix, local.ip_offsets.web_lb) : cidrhost(local.sub_app_prefix, local.ip_offsets.web_lb)
   }
 }
 

--- a/deploy/terraform/modules/app_tier/infrastructure.tf
+++ b/deploy/terraform/modules/app_tier/infrastructure.tf
@@ -149,7 +149,7 @@ resource "azurerm_lb" "web" {
 
   frontend_ip_configuration {
     name                          = "sap${lower(local.application_sid)}web"
-    subnet_id                     = local.sub_web_defined ? local.sub_web_exists ? data.azurerm_subnet.subnet-sap-web[0].id : azurerm_subnet.subnet-sap-web[0].id : local.sub_app_exists ? data.azurerm_subnet.subnet-sap-app[0].id : azurerm_subnet.subnet-sap-app[0].id
+    subnet_id                     = sub_web_deployed.id
     private_ip_address_allocation = "Static"
     private_ip_address            = cidrhost( local.sub_web_defined ? local.sub_web_prefix : local.sub_app_prefix, local.ip_offsets.web_lb )
   }

--- a/deploy/terraform/modules/app_tier/infrastructure.tf
+++ b/deploy/terraform/modules/app_tier/infrastructure.tf
@@ -151,7 +151,7 @@ resource "azurerm_lb" "web" {
     name                          = "sap${lower(local.application_sid)}web"
     subnet_id                     = local.sub_web_defined ? local.sub_web_exists ? data.azurerm_subnet.subnet-sap-web[0].id : azurerm_subnet.subnet-sap-web[0].id : local.sub_app_exists ? data.azurerm_subnet.subnet-sap-app[0].id : azurerm_subnet.subnet-sap-app[0].id
     private_ip_address_allocation = "Static"
-    private_ip_address            = local.sub_web_defined ? cidrhost(local.sub_web_prefix, local.ip_offsets.web_lb) : cidrhost(local.sub_app_prefix, local.ip_offsets.web_lb)
+    private_ip_address            = cidrhost( local.sub_web_defined ? local.sub_web_prefix : local.sub_app_prefix, local.ip_offsets.web_lb )
   }
 }
 

--- a/deploy/terraform/modules/app_tier/infrastructure.tf
+++ b/deploy/terraform/modules/app_tier/infrastructure.tf
@@ -149,9 +149,9 @@ resource "azurerm_lb" "web" {
 
   frontend_ip_configuration {
     name                          = "sap${lower(local.application_sid)}web"
-    subnet_id                     = sub_web_deployed.id
+    subnet_id                     = local.sub_web_deployed.id
     private_ip_address_allocation = "Static"
-    private_ip_address            = cidrhost( local.sub_web_defined ? local.sub_web_prefix : local.sub_app_prefix, local.ip_offsets.web_lb )
+    private_ip_address            = cidrhost(local.sub_web_defined ? local.sub_web_prefix : local.sub_app_prefix, local.ip_offsets.web_lb)
   }
 }
 

--- a/deploy/terraform/modules/app_tier/infrastructure.tf
+++ b/deploy/terraform/modules/app_tier/infrastructure.tf
@@ -149,7 +149,9 @@ resource "azurerm_lb" "web" {
 
   frontend_ip_configuration {
     name                          = "sap${lower(local.application_sid)}web"
-    subnet_id                     = local.sub_web_deployed.id
+    subnet_id = local.sub_web_defined ? (
+      local.sub_web_exists ? data.azurerm_subnet.subnet-sap-web[0].id : azurerm_subnet.subnet-sap-web[0].id) : (
+      local.sub_app_exists ? data.azurerm_subnet.subnet-sap-app[0].id : azurerm_subnet.subnet-sap-app[0].id)
     private_ip_address_allocation = "Static"
     private_ip_address            = cidrhost(local.sub_web_defined ? local.sub_web_prefix : local.sub_app_prefix, local.ip_offsets.web_lb)
   }

--- a/deploy/terraform/modules/app_tier/infrastructure.tf
+++ b/deploy/terraform/modules/app_tier/infrastructure.tf
@@ -149,9 +149,7 @@ resource "azurerm_lb" "web" {
 
   frontend_ip_configuration {
     name                          = "sap${lower(local.application_sid)}web"
-    subnet_id = local.sub_web_defined ? (
-      local.sub_web_exists ? data.azurerm_subnet.subnet-sap-web[0].id : azurerm_subnet.subnet-sap-web[0].id) : (
-      local.sub_app_exists ? data.azurerm_subnet.subnet-sap-app[0].id : azurerm_subnet.subnet-sap-app[0].id)
+    subnet_id                     = local.sub_web_deployed.id
     private_ip_address_allocation = "Static"
     private_ip_address            = cidrhost(local.sub_web_defined ? local.sub_web_prefix : local.sub_app_prefix, local.ip_offsets.web_lb)
   }

--- a/deploy/terraform/modules/app_tier/nsg-app-subnet.tf
+++ b/deploy/terraform/modules/app_tier/nsg-app-subnet.tf
@@ -2,8 +2,8 @@
 resource "azurerm_network_security_group" "nsg-app" {
   count               = local.enable_deployment ? (local.sub_app_nsg_exists ? 0 : 1) : 0
   name                = local.sub_app_nsg_name
-  location            = var.resource-group[0].location
-  resource_group_name = var.resource-group[0].name
+  location            = var.vnet-sap[0].location
+  resource_group_name = var.vnet-sap[0].name
 }
 
 # Imports the SAP app subnet nsg data

--- a/deploy/terraform/modules/app_tier/nsg-app-subnet.tf
+++ b/deploy/terraform/modules/app_tier/nsg-app-subnet.tf
@@ -3,7 +3,7 @@ resource "azurerm_network_security_group" "nsg-app" {
   count               = local.enable_deployment ? (local.sub_app_nsg_exists ? 0 : 1) : 0
   name                = local.sub_app_nsg_name
   location            = var.vnet-sap[0].location
-  resource_group_name = var.vnet-sap[0].name
+  resource_group_name = var.vnet-sap[0].resource_group_name
 }
 
 # Imports the SAP app subnet nsg data

--- a/deploy/terraform/modules/app_tier/nsg-webdisp.tf
+++ b/deploy/terraform/modules/app_tier/nsg-webdisp.tf
@@ -2,8 +2,8 @@
 resource "azurerm_network_security_group" "nsg-web" {
   count               = local.enable_deployment && local.sub_web_defined ? (local.sub_web_nsg_exists ? 0 : 1) : 0
   name                = local.sub_app_nsg_name
-  location            = var.resource-group[0].location
-  resource_group_name = var.resource-group[0].name
+  location            = var.vnet-sap[0].location
+  resource_group_name = var.vnet-sap[0].name
 }
 
 # Imports the SAP web subnet nsg data
@@ -15,8 +15,11 @@ data "azurerm_network_security_group" "nsg-web" {
 
 # Associates SAP web nsg to SAP web subnet
 resource "azurerm_subnet_network_security_group_association" "Associate-nsg-web" {
-  count                     = local.enable_deployment && local.sub_web_defined ? (signum((local.sub_web_exists ? 0 : 1) + (local.sub_web_nsg_exists ? 0 : 1))) : 0
-  subnet_id                 = local.sub_web_deployed.id
+  count     = local.enable_deployment && local.sub_web_defined ? (signum((local.sub_web_exists ? 0 : 1) + (local.sub_web_nsg_exists ? 0 : 1))) : 0
+  subnet_id = local.sub_web_defined ? (
+    local.sub_web_exists ? data.azurerm_subnet.subnet-sap-web[0].id : azurerm_subnet.subnet-sap-web[0].id) : (
+    local.sub_app_exists ? data.azurerm_subnet.subnet-sap-app[0].id : azurerm_subnet.subnet-sap-app[0].id)
+
   network_security_group_id = local.sub_web_defined ? (
     local.sub_web_nsg_exists ? data.azurerm_network_security_group.nsg-web[0].id : azurerm_network_security_group.nsg-web[0].id) : (
     local.sub_app_nsg_exists ? data.azurerm_network_security_group.nsg-app[0].id : azurerm_network_security_group.nsg-app[0].id)
@@ -24,40 +27,40 @@ resource "azurerm_subnet_network_security_group_association" "Associate-nsg-web"
 
 # NSG rule to deny internet access
 resource "azurerm_network_security_rule" "webRule_internet" {
-  count                        = local.enable_deployment ? (local.sub_web_nsg_exists ? 0 : 1) : 0
-  name                         = "Internet"
-  priority                     = 100
-  direction                    = "Inbound"
-  access                       = "Deny"
-  protocol                     = "*"
-  source_address_prefix        = "Internet"
-  source_port_range            = "*"
+  count                 = local.enable_deployment ? (local.sub_web_nsg_exists ? 0 : 1) : 0
+  name                  = "Internet"
+  priority              = 100
+  direction             = "Inbound"
+  access                = "Deny"
+  protocol              = "*"
+  source_address_prefix = "Internet"
+  source_port_range     = "*"
   destination_address_prefixes = local.sub_web_defined ? (
     local.sub_web_exists ? data.azurerm_subnet.subnet-sap-web[0].address_prefixes : azurerm_subnet.subnet-sap-web[0].address_prefixes) : (
     local.sub_app_exists ? data.azurerm_subnet.subnet-sap-app[0].address_prefixes : azurerm_subnet.subnet-sap-app[0].address_prefixes)
-  destination_port_range       = "*"
-  resource_group_name          = var.resource-group[0].name
-  network_security_group_name  = local.sub_web_defined ? (
+  destination_port_range = "*"
+  resource_group_name    = var.resource-group[0].name
+  network_security_group_name = local.sub_web_defined ? (
     local.sub_web_nsg_exists ? data.azurerm_network_security_group.nsg-web[0].name : azurerm_network_security_group.nsg-web[0].name) : (
     local.sub_app_nsg_exists ? data.azurerm_network_security_group.nsg-app[0].name : azurerm_network_security_group.nsg-app[0].name)
 }
 
 # NSG rule to open ports for Web dispatcher
 resource "azurerm_network_security_rule" "web" {
-  count                        = local.enable_deployment ? (local.sub_web_nsg_exists ? 0 : length(local.nsg-ports.web)) : 0
-  name                         = local.nsg-ports.web[count.index].name
-  priority                     = local.nsg-ports.web[count.index].priority
-  direction                    = "Inbound"
-  access                       = "Allow"
-  protocol                     = "Tcp"
-  source_address_prefixes      = var.subnet-mgmt[0].address_prefixes
-  source_port_range            = "*"
+  count                   = local.enable_deployment ? (local.sub_web_nsg_exists ? 0 : length(local.nsg-ports.web)) : 0
+  name                    = local.nsg-ports.web[count.index].name
+  priority                = local.nsg-ports.web[count.index].priority
+  direction               = "Inbound"
+  access                  = "Allow"
+  protocol                = "Tcp"
+  source_address_prefixes = var.subnet-mgmt[0].address_prefixes
+  source_port_range       = "*"
   destination_address_prefixes = local.sub_web_defined ? (
     local.sub_web_exists ? data.azurerm_subnet.subnet-sap-web[0].address_prefixes : azurerm_subnet.subnet-sap-web[0].address_prefixes) : (
     local.sub_app_exists ? data.azurerm_subnet.subnet-sap-app[0].address_prefixes : azurerm_subnet.subnet-sap-app[0].address_prefixes)
-  destination_port_range       = local.nsg-ports.web[count.index].port
-  resource_group_name          = var.resource-group[0].name
-  network_security_group_name  = local.sub_web_defined ? (
+  destination_port_range = local.nsg-ports.web[count.index].port
+  resource_group_name    = var.resource-group[0].name
+  network_security_group_name = local.sub_web_defined ? (
     local.sub_web_nsg_exists ? data.azurerm_network_security_group.nsg-web[0].name : azurerm_network_security_group.nsg-web[0].name) : (
     local.sub_app_nsg_exists ? data.azurerm_network_security_group.nsg-app[0].name : azurerm_network_security_group.nsg-app[0].name)
 }

--- a/deploy/terraform/modules/app_tier/nsg-webdisp.tf
+++ b/deploy/terraform/modules/app_tier/nsg-webdisp.tf
@@ -3,7 +3,7 @@ resource "azurerm_network_security_group" "nsg-web" {
   count               = local.enable_deployment && local.sub_web_defined ? (local.sub_web_nsg_exists ? 0 : 1) : 0
   name                = local.sub_app_nsg_name
   location            = var.vnet-sap[0].location
-  resource_group_name = var.vnet-sap[0].name
+  resource_group_name = var.vnet-sap[0].resource_group_name
 }
 
 # Imports the SAP web subnet nsg data

--- a/deploy/terraform/modules/app_tier/nsg-webdisp.tf
+++ b/deploy/terraform/modules/app_tier/nsg-webdisp.tf
@@ -1,6 +1,6 @@
 # Creates SAP web subnet nsg
 resource "azurerm_network_security_group" "nsg-web" {
-  count               = local.enable_deployment ? (local.sub_web_defined ? (local.sub_web_nsg_exists ? 0 : 1) : 0) : 0
+  count               = local.enable_deployment  && local.sub_web_defined ? (local.sub_web_nsg_exists ? 0 : 1) : 0
   name                = local.sub_app_nsg_name
   location            = var.resource-group[0].location
   resource_group_name = var.resource-group[0].name

--- a/deploy/terraform/modules/app_tier/nsg-webdisp.tf
+++ b/deploy/terraform/modules/app_tier/nsg-webdisp.tf
@@ -1,6 +1,6 @@
 # Creates SAP web subnet nsg
 resource "azurerm_network_security_group" "nsg-web" {
-  count               = local.enable_deployment  && local.sub_web_defined ? (local.sub_web_nsg_exists ? 0 : 1) : 0
+  count               = local.enable_deployment && local.sub_web_defined ? (local.sub_web_nsg_exists ? 0 : 1) : 0
   name                = local.sub_app_nsg_name
   location            = var.resource-group[0].location
   resource_group_name = var.resource-group[0].name
@@ -8,18 +8,18 @@ resource "azurerm_network_security_group" "nsg-web" {
 
 # Imports the SAP web subnet nsg data
 data "azurerm_network_security_group" "nsg-web" {
-  count               = local.enable_deployment ? (local.sub_web_defined ? (local.sub_web_nsg_exists ? 1 : 0) : 0) : 0
+  count               = local.enable_deployment && local.sub_web_defined ? (local.sub_web_nsg_exists ? 1 : 0) : 0
   name                = split("/", local.sub_web_nsg_arm_id)[8]
   resource_group_name = split("/", local.sub_web_nsg_arm_id)[4]
 }
 
-# Associates SAP app nsg to SAP app subnet
+# Associates SAP web nsg to SAP web subnet
 resource "azurerm_subnet_network_security_group_association" "Associate-nsg-web" {
-  count = local.enable_deployment && local.sub_web_defined ? (signum((local.sub_web_exists ? 0 : 1) + (local.sub_web_nsg_exists ? 0 : 1))) : 0
-  subnet_id = local.sub_web_defined ? (
-    local.sub_web_exists ? data.azurerm_subnet.subnet-sap-web[0].id : azurerm_subnet.subnet-sap-web[0].id) : (
-  local.sub_app_exists ? data.azurerm_subnet.subnet-sap-app[0].id : azurerm_subnet.subnet-sap-app[0].id)
-  network_security_group_id = local.sub_web_defined ? (local.sub_web_nsg_exists ? data.azurerm_network_security_group.nsg-web[0].id : azurerm_network_security_group.nsg-web[0].id) : (local.sub_app_nsg_exists ? data.azurerm_network_security_group.nsg-app[0].id : azurerm_network_security_group.nsg-app[0].id)
+  count                     = local.enable_deployment && local.sub_web_defined ? (signum((local.sub_web_exists ? 0 : 1) + (local.sub_web_nsg_exists ? 0 : 1))) : 0
+  subnet_id                 = local.sub_web_deployed.id
+  network_security_group_id = local.sub_web_defined ? (
+    local.sub_web_nsg_exists ? data.azurerm_network_security_group.nsg-web[0].id : azurerm_network_security_group.nsg-web[0].id) : (
+    local.sub_app_nsg_exists ? data.azurerm_network_security_group.nsg-app[0].id : azurerm_network_security_group.nsg-app[0].id)
 }
 
 # NSG rule to deny internet access
@@ -32,10 +32,14 @@ resource "azurerm_network_security_rule" "webRule_internet" {
   protocol                     = "*"
   source_address_prefix        = "Internet"
   source_port_range            = "*"
-  destination_address_prefixes = local.sub_web_defined ? (local.sub_web_exists ? data.azurerm_subnet.subnet-sap-web[0].address_prefixes : azurerm_subnet.subnet-sap-web[0].address_prefixes) : (local.sub_app_exists ? data.azurerm_subnet.subnet-sap-app[0].address_prefixes : azurerm_subnet.subnet-sap-app[0].address_prefixes)
+  destination_address_prefixes = local.sub_web_defined ? (
+    local.sub_web_exists ? data.azurerm_subnet.subnet-sap-web[0].address_prefixes : azurerm_subnet.subnet-sap-web[0].address_prefixes) : (
+    local.sub_app_exists ? data.azurerm_subnet.subnet-sap-app[0].address_prefixes : azurerm_subnet.subnet-sap-app[0].address_prefixes)
   destination_port_range       = "*"
   resource_group_name          = var.resource-group[0].name
-  network_security_group_name  = local.sub_web_defined ? (local.sub_web_nsg_exists ? data.azurerm_network_security_group.nsg-web[0].name : azurerm_network_security_group.nsg-web[0].name) : (local.sub_app_nsg_exists ? data.azurerm_network_security_group.nsg-app[0].name : azurerm_network_security_group.nsg-app[0].name)
+  network_security_group_name  = local.sub_web_defined ? (
+    local.sub_web_nsg_exists ? data.azurerm_network_security_group.nsg-web[0].name : azurerm_network_security_group.nsg-web[0].name) : (
+    local.sub_app_nsg_exists ? data.azurerm_network_security_group.nsg-app[0].name : azurerm_network_security_group.nsg-app[0].name)
 }
 
 # NSG rule to open ports for Web dispatcher
@@ -48,8 +52,12 @@ resource "azurerm_network_security_rule" "web" {
   protocol                     = "Tcp"
   source_address_prefixes      = var.subnet-mgmt[0].address_prefixes
   source_port_range            = "*"
-  destination_address_prefixes = local.sub_web_defined ? (local.sub_web_exists ? data.azurerm_subnet.subnet-sap-web[0].address_prefixes : azurerm_subnet.subnet-sap-web[0].address_prefixes) : (local.sub_app_exists ? data.azurerm_subnet.subnet-sap-app[0].address_prefixes : azurerm_subnet.subnet-sap-app[0].address_prefixes)
+  destination_address_prefixes = local.sub_web_defined ? (
+    local.sub_web_exists ? data.azurerm_subnet.subnet-sap-web[0].address_prefixes : azurerm_subnet.subnet-sap-web[0].address_prefixes) : (
+    local.sub_app_exists ? data.azurerm_subnet.subnet-sap-app[0].address_prefixes : azurerm_subnet.subnet-sap-app[0].address_prefixes)
   destination_port_range       = local.nsg-ports.web[count.index].port
   resource_group_name          = var.resource-group[0].name
-  network_security_group_name  = local.sub_web_defined ? (local.sub_web_nsg_exists ? data.azurerm_network_security_group.nsg-web[0].name : azurerm_network_security_group.nsg-web[0].name) : (local.sub_app_nsg_exists ? data.azurerm_network_security_group.nsg-app[0].name : azurerm_network_security_group.nsg-app[0].name)
+  network_security_group_name  = local.sub_web_defined ? (
+    local.sub_web_nsg_exists ? data.azurerm_network_security_group.nsg-web[0].name : azurerm_network_security_group.nsg-web[0].name) : (
+    local.sub_app_nsg_exists ? data.azurerm_network_security_group.nsg-app[0].name : azurerm_network_security_group.nsg-app[0].name)
 }

--- a/deploy/terraform/modules/app_tier/nsg-webdisp.tf
+++ b/deploy/terraform/modules/app_tier/nsg-webdisp.tf
@@ -1,7 +1,7 @@
 # Creates SAP web subnet nsg
 resource "azurerm_network_security_group" "nsg-web" {
   count               = local.enable_deployment && local.sub_web_defined ? (local.sub_web_nsg_exists ? 0 : 1) : 0
-  name                = local.sub_app_nsg_name
+  name                = local.sub_web_nsg_name
   location            = var.vnet-sap[0].location
   resource_group_name = var.vnet-sap[0].resource_group_name
 }
@@ -15,52 +15,39 @@ data "azurerm_network_security_group" "nsg-web" {
 
 # Associates SAP web nsg to SAP web subnet
 resource "azurerm_subnet_network_security_group_association" "Associate-nsg-web" {
-  count     = local.enable_deployment && local.sub_web_defined ? (signum((local.sub_web_exists ? 0 : 1) + (local.sub_web_nsg_exists ? 0 : 1))) : 0
-  subnet_id = local.sub_web_defined ? (
-    local.sub_web_exists ? data.azurerm_subnet.subnet-sap-web[0].id : azurerm_subnet.subnet-sap-web[0].id) : (
-    local.sub_app_exists ? data.azurerm_subnet.subnet-sap-app[0].id : azurerm_subnet.subnet-sap-app[0].id)
-
-  network_security_group_id = local.sub_web_defined ? (
-    local.sub_web_nsg_exists ? data.azurerm_network_security_group.nsg-web[0].id : azurerm_network_security_group.nsg-web[0].id) : (
-    local.sub_app_nsg_exists ? data.azurerm_network_security_group.nsg-app[0].id : azurerm_network_security_group.nsg-app[0].id)
+  count                     = local.enable_deployment && local.sub_web_defined ? (signum((local.sub_web_exists ? 0 : 1) + (local.sub_web_nsg_exists ? 0 : 1))) : 0
+  subnet_id                 = local.sub_web_deployed.id
+  network_security_group_id = local.sub_web_nsg_deployed.id
 }
 
 # NSG rule to deny internet access
 resource "azurerm_network_security_rule" "webRule_internet" {
-  count                 = local.enable_deployment ? (local.sub_web_nsg_exists ? 0 : 1) : 0
-  name                  = "Internet"
-  priority              = 100
-  direction             = "Inbound"
-  access                = "Deny"
-  protocol              = "*"
-  source_address_prefix = "Internet"
-  source_port_range     = "*"
-  destination_address_prefixes = local.sub_web_defined ? (
-    local.sub_web_exists ? data.azurerm_subnet.subnet-sap-web[0].address_prefixes : azurerm_subnet.subnet-sap-web[0].address_prefixes) : (
-    local.sub_app_exists ? data.azurerm_subnet.subnet-sap-app[0].address_prefixes : azurerm_subnet.subnet-sap-app[0].address_prefixes)
-  destination_port_range = "*"
-  resource_group_name    = var.resource-group[0].name
-  network_security_group_name = local.sub_web_defined ? (
-    local.sub_web_nsg_exists ? data.azurerm_network_security_group.nsg-web[0].name : azurerm_network_security_group.nsg-web[0].name) : (
-    local.sub_app_nsg_exists ? data.azurerm_network_security_group.nsg-app[0].name : azurerm_network_security_group.nsg-app[0].name)
+  count                        = local.enable_deployment ? (local.sub_web_nsg_exists ? 0 : 1) : 0
+  name                         = "Internet"
+  priority                     = 100
+  direction                    = "Inbound"
+  access                       = "Deny"
+  protocol                     = "*"
+  source_address_prefix        = "Internet"
+  source_port_range            = "*"
+  destination_address_prefixes = local.sub_web_deployed.address_prefixes
+  destination_port_range       = "*"
+  resource_group_name          = var.resource-group[0].name
+  network_security_group_name  = local.sub_web_nsg_deployed.name
 }
 
 # NSG rule to open ports for Web dispatcher
 resource "azurerm_network_security_rule" "web" {
-  count                   = local.enable_deployment ? (local.sub_web_nsg_exists ? 0 : length(local.nsg-ports.web)) : 0
-  name                    = local.nsg-ports.web[count.index].name
-  priority                = local.nsg-ports.web[count.index].priority
-  direction               = "Inbound"
-  access                  = "Allow"
-  protocol                = "Tcp"
-  source_address_prefixes = var.subnet-mgmt[0].address_prefixes
-  source_port_range       = "*"
-  destination_address_prefixes = local.sub_web_defined ? (
-    local.sub_web_exists ? data.azurerm_subnet.subnet-sap-web[0].address_prefixes : azurerm_subnet.subnet-sap-web[0].address_prefixes) : (
-    local.sub_app_exists ? data.azurerm_subnet.subnet-sap-app[0].address_prefixes : azurerm_subnet.subnet-sap-app[0].address_prefixes)
-  destination_port_range = local.nsg-ports.web[count.index].port
-  resource_group_name    = var.resource-group[0].name
-  network_security_group_name = local.sub_web_defined ? (
-    local.sub_web_nsg_exists ? data.azurerm_network_security_group.nsg-web[0].name : azurerm_network_security_group.nsg-web[0].name) : (
-    local.sub_app_nsg_exists ? data.azurerm_network_security_group.nsg-app[0].name : azurerm_network_security_group.nsg-app[0].name)
+  count                        = local.enable_deployment ? (local.sub_web_nsg_exists ? 0 : length(local.nsg-ports.web)) : 0
+  name                         = local.nsg-ports.web[count.index].name
+  priority                     = local.nsg-ports.web[count.index].priority
+  direction                    = "Inbound"
+  access                       = "Allow"
+  protocol                     = "Tcp"
+  source_address_prefixes      = var.subnet-mgmt[0].address_prefixes
+  source_port_range            = "*"
+  destination_address_prefixes = local.sub_web_deployed.address_prefixes
+  destination_port_range       = local.nsg-ports.web[count.index].port
+  resource_group_name          = var.resource-group[0].name
+  network_security_group_name  = local.sub_web_nsg_deployed.name
 }

--- a/deploy/terraform/modules/app_tier/nsg-webdisp.tf
+++ b/deploy/terraform/modules/app_tier/nsg-webdisp.tf
@@ -1,6 +1,30 @@
+# Creates SAP web subnet nsg
+resource "azurerm_network_security_group" "nsg-web" {
+  count               = local.enable_deployment ? (local.sub_web_defined ? (local.sub_web_nsg_exists ? 0 : 1) : 0) : 0
+  name                = local.sub_app_nsg_name
+  location            = var.resource-group[0].location
+  resource_group_name = var.resource-group[0].name
+}
+
+# Imports the SAP web subnet nsg data
+data "azurerm_network_security_group" "nsg-web" {
+  count               = local.enable_deployment ? (local.sub_web_defined ? (local.sub_web_nsg_exists ? 1 : 0) : 0) : 0
+  name                = split("/", local.sub_web_nsg_arm_id)[8]
+  resource_group_name = split("/", local.sub_web_nsg_arm_id)[4]
+}
+
+# Associates SAP app nsg to SAP app subnet
+resource "azurerm_subnet_network_security_group_association" "Associate-nsg-web" {
+  count = local.enable_deployment && local.sub_web_defined ? (signum((local.sub_web_exists ? 0 : 1) + (local.sub_web_nsg_exists ? 0 : 1))) : 0
+  subnet_id = local.sub_web_defined ? (
+    local.sub_web_exists ? data.azurerm_subnet.subnet-sap-web[0].id : azurerm_subnet.subnet-sap-web[0].id) : (
+  local.sub_app_exists ? data.azurerm_subnet.subnet-sap-app[0].id : azurerm_subnet.subnet-sap-app[0].id)
+  network_security_group_id = local.sub_web_defined ? (local.sub_web_nsg_exists ? data.azurerm_network_security_group.nsg-web[0].id : azurerm_network_security_group.nsg-web[0].id) : (local.sub_app_nsg_exists ? data.azurerm_network_security_group.nsg-app[0].id : azurerm_network_security_group.nsg-app[0].id)
+}
+
 # NSG rule to deny internet access
-resource azurerm_network_security_rule webRule_internet {
-  count                        = local.enable_deployment ? (local.sub_app_nsg_exists ? 0 : 1) : 0
+resource "azurerm_network_security_rule" "webRule_internet" {
+  count                        = local.enable_deployment ? (local.sub_web_nsg_exists ? 0 : 1) : 0
   name                         = "Internet"
   priority                     = 100
   direction                    = "Inbound"
@@ -8,15 +32,15 @@ resource azurerm_network_security_rule webRule_internet {
   protocol                     = "*"
   source_address_prefix        = "Internet"
   source_port_range            = "*"
-  destination_address_prefixes = local.sub_app_exists ? data.azurerm_subnet.subnet-sap-app[0].address_prefixes : azurerm_subnet.subnet-sap-app[0].address_prefixes
+  destination_address_prefixes = local.sub_web_defined ? (local.sub_web_exists ? data.azurerm_subnet.subnet-sap-web[0].address_prefixes : azurerm_subnet.subnet-sap-web[0].address_prefixes) : (local.sub_app_exists ? data.azurerm_subnet.subnet-sap-app[0].address_prefixes : azurerm_subnet.subnet-sap-app[0].address_prefixes)
   destination_port_range       = "*"
   resource_group_name          = var.resource-group[0].name
-  network_security_group_name  = local.sub_app_nsg_exists ? data.azurerm_network_security_group.nsg-app[0].name : azurerm_network_security_group.nsg-app[0].name
+  network_security_group_name  = local.sub_web_defined ? (local.sub_web_nsg_exists ? data.azurerm_network_security_group.nsg-web[0].name : azurerm_network_security_group.nsg-web[0].name) : (local.sub_app_nsg_exists ? data.azurerm_network_security_group.nsg-app[0].name : azurerm_network_security_group.nsg-app[0].name)
 }
 
 # NSG rule to open ports for Web dispatcher
-resource azurerm_network_security_rule web {
-  count                        = local.enable_deployment ? (local.sub_app_nsg_exists ? 0 : length(local.nsg-ports.web)) : 0
+resource "azurerm_network_security_rule" "web" {
+  count                        = local.enable_deployment ? (local.sub_web_nsg_exists ? 0 : length(local.nsg-ports.web)) : 0
   name                         = local.nsg-ports.web[count.index].name
   priority                     = local.nsg-ports.web[count.index].priority
   direction                    = "Inbound"
@@ -24,8 +48,8 @@ resource azurerm_network_security_rule web {
   protocol                     = "Tcp"
   source_address_prefixes      = var.subnet-mgmt[0].address_prefixes
   source_port_range            = "*"
-  destination_address_prefixes = local.sub_app_exists ? data.azurerm_subnet.subnet-sap-app[0].address_prefixes : azurerm_subnet.subnet-sap-app[0].address_prefixes
+  destination_address_prefixes = local.sub_web_defined ? (local.sub_web_exists ? data.azurerm_subnet.subnet-sap-web[0].address_prefixes : azurerm_subnet.subnet-sap-web[0].address_prefixes) : (local.sub_app_exists ? data.azurerm_subnet.subnet-sap-app[0].address_prefixes : azurerm_subnet.subnet-sap-app[0].address_prefixes)
   destination_port_range       = local.nsg-ports.web[count.index].port
   resource_group_name          = var.resource-group[0].name
-  network_security_group_name  = local.sub_app_nsg_exists ? data.azurerm_network_security_group.nsg-app[0].name : azurerm_network_security_group.nsg-app[0].name
+  network_security_group_name  = local.sub_web_defined ? (local.sub_web_nsg_exists ? data.azurerm_network_security_group.nsg-web[0].name : azurerm_network_security_group.nsg-web[0].name) : (local.sub_app_nsg_exists ? data.azurerm_network_security_group.nsg-app[0].name : azurerm_network_security_group.nsg-app[0].name)
 }

--- a/deploy/terraform/modules/app_tier/variables_local.tf
+++ b/deploy/terraform/modules/app_tier/variables_local.tf
@@ -34,6 +34,21 @@ locals {
   sub_app_nsg_arm_id = local.sub_app_nsg_exists ? try(local.var_sub_app_nsg.arm_id, "") : ""
   sub_app_nsg_name   = local.sub_app_nsg_exists ? "" : try(local.var_sub_app_nsg.name, "nsg-app")
 
+  # WEB subnet
+  #If subnet_web is not specified deploy into app subnet
+  sub_web_defined = try(var.infrastructure.vnets.sap.subnet_web, null) == null ? false : true
+  sub_web         = try(var.infrastructure.vnets.sap.subnet_web, {})
+  sub_web_exists  = try(local.sub_web.is_existing, false)
+  sub_web_arm_id  = local.sub_web_exists ? try(local.sub_web.arm_id, "") : ""
+  sub_web_name    = local.sub_web_exists ? "" : try(local.sub_web.name, "subnet-web")
+  sub_web_prefix  = local.sub_web_exists ? "" : try(local.sub_web.prefix, "10.1.5.0/24")
+
+  # WEB NSG
+  sub_web_nsg        = try(local.sub_web.nsg, {})
+  sub_web_nsg_exists = try(local.sub_web_nsg.is_existing, false)
+  sub_web_nsg_arm_id = local.sub_web_nsg_exists ? try(local.sub_web_nsg.arm_id, "") : ""
+  sub_web_nsg_name   = local.sub_web_nsg_exists ? "" : try(local.sub_web_nsg.name, "nsg-web")
+
   application_sid          = try(var.application.sid, "HN1")
   enable_deployment        = try(var.application.enable_deployment, false)
   scs_instance_number      = try(var.application.scs_instance_number, "01")
@@ -50,7 +65,7 @@ locals {
 
   app_ostype = try(var.application.os.os_type, "Linux")
 
-  authentication = try(var.application.authentication, 
+  authentication = try(var.application.authentication,
     {
       "type"     = upper(local.app_ostype) == "LINUX" ? "key" : "password"
       "username" = "azureadm"

--- a/deploy/terraform/modules/app_tier/variables_local.tf
+++ b/deploy/terraform/modules/app_tier/variables_local.tf
@@ -49,6 +49,10 @@ locals {
   sub_web_nsg_arm_id = local.sub_web_nsg_exists ? try(local.sub_web_nsg.arm_id, "") : ""
   sub_web_nsg_name   = local.sub_web_nsg_exists ? "" : try(local.sub_web_nsg.name, "nsg-web")
 
+  sub_web_deployed = local.sub_web_defined ? (
+    local.sub_web_exists ? data.azurerm_subnet.subnet-sap-web[0] : azurerm_subnet.subnet-sap-web[0]) : (
+    local.sub_app_exists ? data.azurerm_subnet.subnet-sap-app[0] : azurerm_subnet.subnet-sap-app[0])
+
   application_sid          = try(var.application.sid, "HN1")
   enable_deployment        = try(var.application.enable_deployment, false)
   scs_instance_number      = try(var.application.scs_instance_number, "01")

--- a/deploy/terraform/modules/app_tier/variables_local.tf
+++ b/deploy/terraform/modules/app_tier/variables_local.tf
@@ -49,10 +49,6 @@ locals {
   sub_web_nsg_arm_id = local.sub_web_nsg_exists ? try(local.sub_web_nsg.arm_id, "") : ""
   sub_web_nsg_name   = local.sub_web_nsg_exists ? "" : try(local.sub_web_nsg.name, "nsg-web")
 
-  sub_web_deployed = local.sub_web_defined ? (
-    local.sub_web_exists ? data.azurerm_subnet.subnet-sap-web[0] : azurerm_subnet.subnet-sap-web[0]) : (
-    local.sub_app_exists ? data.azurerm_subnet.subnet-sap-app[0] : azurerm_subnet.subnet-sap-app[0])
-
   application_sid          = try(var.application.sid, "HN1")
   enable_deployment        = try(var.application.enable_deployment, false)
   scs_instance_number      = try(var.application.scs_instance_number, "01")

--- a/deploy/terraform/modules/app_tier/variables_local.tf
+++ b/deploy/terraform/modules/app_tier/variables_local.tf
@@ -42,18 +42,18 @@ locals {
   sub_web_arm_id  = local.sub_web_exists ? try(local.sub_web.arm_id, "") : ""
   sub_web_name    = local.sub_web_exists ? "" : try(local.sub_web.name, "subnet-web")
   sub_web_prefix  = local.sub_web_exists ? "" : try(local.sub_web.prefix, "10.1.5.0/24")
-  sub_web_deployed = local.sub_web_defined ? (
+  sub_web_deployed = try(local.sub_web_defined ? (
     local.sub_web_exists ? data.azurerm_subnet.subnet-sap-web[0] : azurerm_subnet.subnet-sap-web[0]) : (
-  local.sub_app_exists ? data.azurerm_subnet.subnet-sap-app[0] : azurerm_subnet.subnet-sap-app[0])
+  local.sub_app_exists ? data.azurerm_subnet.subnet-sap-app[0] : azurerm_subnet.subnet-sap-app[0]), null)
 
   # WEB NSG
   sub_web_nsg        = try(local.sub_web.nsg, {})
   sub_web_nsg_exists = try(local.sub_web_nsg.is_existing, false)
   sub_web_nsg_arm_id = local.sub_web_nsg_exists ? try(local.sub_web_nsg.arm_id, "") : ""
   sub_web_nsg_name   = local.sub_web_nsg_exists ? "" : try(local.sub_web_nsg.name, "nsg-web")
-  sub_web_nsg_deployed = local.sub_web_defined ? (
+  sub_web_nsg_deployed = try(local.sub_web_defined ? (
     local.sub_web_nsg_exists ? data.azurerm_network_security_group.nsg-web[0] : azurerm_network_security_group.nsg-web[0]) : (
-  local.sub_app_nsg_exists ? data.azurerm_network_security_group.nsg-app[0] : azurerm_network_security_group.nsg-app[0])
+  local.sub_app_nsg_exists ? data.azurerm_network_security_group.nsg-app[0] : azurerm_network_security_group.nsg-app[0]), null)
 
   application_sid          = try(var.application.sid, "HN1")
   enable_deployment        = try(var.application.enable_deployment, false)

--- a/deploy/terraform/modules/app_tier/variables_local.tf
+++ b/deploy/terraform/modules/app_tier/variables_local.tf
@@ -42,12 +42,18 @@ locals {
   sub_web_arm_id  = local.sub_web_exists ? try(local.sub_web.arm_id, "") : ""
   sub_web_name    = local.sub_web_exists ? "" : try(local.sub_web.name, "subnet-web")
   sub_web_prefix  = local.sub_web_exists ? "" : try(local.sub_web.prefix, "10.1.5.0/24")
+  sub_web_deployed = local.sub_web_defined ? (
+    local.sub_web_exists ? data.azurerm_subnet.subnet-sap-web[0] : azurerm_subnet.subnet-sap-web[0]) : (
+  local.sub_app_exists ? data.azurerm_subnet.subnet-sap-app[0] : azurerm_subnet.subnet-sap-app[0])
 
   # WEB NSG
   sub_web_nsg        = try(local.sub_web.nsg, {})
   sub_web_nsg_exists = try(local.sub_web_nsg.is_existing, false)
   sub_web_nsg_arm_id = local.sub_web_nsg_exists ? try(local.sub_web_nsg.arm_id, "") : ""
   sub_web_nsg_name   = local.sub_web_nsg_exists ? "" : try(local.sub_web_nsg.name, "nsg-web")
+  sub_web_nsg_deployed = local.sub_web_defined ? (
+    local.sub_web_nsg_exists ? data.azurerm_network_security_group.nsg-web[0] : azurerm_network_security_group.nsg-web[0]) : (
+  local.sub_app_nsg_exists ? data.azurerm_network_security_group.nsg-app[0] : azurerm_network_security_group.nsg-app[0])
 
   application_sid          = try(var.application.sid, "HN1")
   enable_deployment        = try(var.application.enable_deployment, false)

--- a/deploy/terraform/modules/app_tier/vm-webdisp.tf
+++ b/deploy/terraform/modules/app_tier/vm-webdisp.tf
@@ -8,7 +8,9 @@ resource "azurerm_network_interface" "web" {
 
   ip_configuration {
     name                          = "IPConfig1"
-    subnet_id                     = local.sub_web_deployed.id
+    subnet_id                     = local.sub_web_defined ? (
+      local.sub_web_exists ? data.azurerm_subnet.subnet-sap-web[0].id : azurerm_subnet.subnet-sap-web[0].id) : (
+      local.sub_app_exists ? data.azurerm_subnet.subnet-sap-app[0].id : azurerm_subnet.subnet-sap-app[0].id)
     private_ip_address            = cidrhost(local.sub_web_defined ? local.sub_web_prefix : local.sub_app_prefix, tonumber(count.index) + local.ip_offsets.web_vm)
     private_ip_address_allocation = "static"
   }

--- a/deploy/terraform/modules/app_tier/vm-webdisp.tf
+++ b/deploy/terraform/modules/app_tier/vm-webdisp.tf
@@ -8,8 +8,8 @@ resource "azurerm_network_interface" "web" {
 
   ip_configuration {
     name                          = "IPConfig1"
-    subnet_id                     = local.sub_web_defined ? (local.sub_web_exists ? data.azurerm_subnet.subnet-sap-web[0].id : azurerm_subnet.subnet-sap-web[0].id) : (local.sub_app_exists ? data.azurerm_subnet.subnet-sap-app[0].id : azurerm_subnet.subnet-sap-app[0].id)
-    private_ip_address            = local.sub_web_defined ? cidrhost(local.sub_web_exists ? data.azurerm_subnet.subnet-sap-web[0].address_prefixes[0] : azurerm_subnet.subnet-sap-web[0].address_prefixes[0], tonumber(count.index) + local.ip_offsets.web_vm) : cidrhost(local.sub_app_exists ? data.azurerm_subnet.subnet-sap-app[0].address_prefixes[0] : azurerm_subnet.subnet-sap-app[0].address_prefixes[0], tonumber(count.index) + local.ip_offsets.web_vm)
+    subnet_id                     = sub_web_deployed.id
+    private_ip_address            = cidrhost( local.sub_web_defined ? local.sub_web_prefix : local.sub_app_prefix, tonumber(count.index) + local.ip_offsets.web_vm )
     private_ip_address_allocation = "static"
   }
 }

--- a/deploy/terraform/modules/app_tier/vm-webdisp.tf
+++ b/deploy/terraform/modules/app_tier/vm-webdisp.tf
@@ -8,8 +8,8 @@ resource "azurerm_network_interface" "web" {
 
   ip_configuration {
     name                          = "IPConfig1"
-    subnet_id                     = sub_web_deployed.id
-    private_ip_address            = cidrhost( local.sub_web_defined ? local.sub_web_prefix : local.sub_app_prefix, tonumber(count.index) + local.ip_offsets.web_vm )
+    subnet_id                     = local.sub_web_deployed.id
+    private_ip_address            = cidrhost(local.sub_web_defined ? local.sub_web_prefix : local.sub_app_prefix, tonumber(count.index) + local.ip_offsets.web_vm)
     private_ip_address_allocation = "static"
   }
 }
@@ -21,7 +21,7 @@ resource "azurerm_linux_virtual_machine" "web" {
   computer_name                = "${upper(local.application_sid)}web${format("%02d", count.index)}"
   location                     = var.resource-group[0].location
   resource_group_name          = var.resource-group[0].name
-  availability_set_id          = local.sub_web_defined ? azurerm_availability_set.web[0].id : azurerm_availability_set.app[0].id
+  availability_set_id          = azurerm_availability_set.app[0].id
   proximity_placement_group_id = lookup(var.infrastructure, "ppg", false) != false ? (var.ppg[0].id) : null
   network_interface_ids = [
     azurerm_network_interface.web[count.index].id

--- a/deploy/terraform/modules/app_tier/vm-webdisp.tf
+++ b/deploy/terraform/modules/app_tier/vm-webdisp.tf
@@ -8,8 +8,8 @@ resource "azurerm_network_interface" "web" {
 
   ip_configuration {
     name                          = "IPConfig1"
-    subnet_id                     = local.sub_app_exists ? data.azurerm_subnet.subnet-sap-app[0].id : azurerm_subnet.subnet-sap-app[0].id
-    private_ip_address            = cidrhost(local.sub_app_exists ? data.azurerm_subnet.subnet-sap-app[0].address_prefixes[0] : azurerm_subnet.subnet-sap-app[0].address_prefixes[0], tonumber(count.index) + local.ip_offsets.web_vm)
+    subnet_id                     = local.sub_web_defined ? (local.sub_web_exists ? data.azurerm_subnet.subnet-sap-web[0].id : azurerm_subnet.subnet-sap-web[0].id) : (local.sub_app_exists ? data.azurerm_subnet.subnet-sap-app[0].id : azurerm_subnet.subnet-sap-app[0].id)
+    private_ip_address            = local.sub_web_defined ? cidrhost(local.sub_web_exists ? data.azurerm_subnet.subnet-sap-web[0].address_prefixes[0] : azurerm_subnet.subnet-sap-web[0].address_prefixes[0], tonumber(count.index) + local.ip_offsets.web_vm) : cidrhost(local.sub_app_exists ? data.azurerm_subnet.subnet-sap-app[0].address_prefixes[0] : azurerm_subnet.subnet-sap-app[0].address_prefixes[0], tonumber(count.index) + local.ip_offsets.web_vm)
     private_ip_address_allocation = "static"
   }
 }
@@ -21,7 +21,7 @@ resource "azurerm_linux_virtual_machine" "web" {
   computer_name                = "${upper(local.application_sid)}web${format("%02d", count.index)}"
   location                     = var.resource-group[0].location
   resource_group_name          = var.resource-group[0].name
-  availability_set_id          = azurerm_availability_set.web[0].id
+  availability_set_id          = local.sub_web_defined ? azurerm_availability_set.web[0].id : azurerm_availability_set.app[0].id
   proximity_placement_group_id = lookup(var.infrastructure, "ppg", false) != false ? (var.ppg[0].id) : null
   network_interface_ids = [
     azurerm_network_interface.web[count.index].id

--- a/deploy/terraform/modules/app_tier/vm-webdisp.tf
+++ b/deploy/terraform/modules/app_tier/vm-webdisp.tf
@@ -8,9 +8,7 @@ resource "azurerm_network_interface" "web" {
 
   ip_configuration {
     name                          = "IPConfig1"
-    subnet_id                     = local.sub_web_defined ? (
-      local.sub_web_exists ? data.azurerm_subnet.subnet-sap-web[0].id : azurerm_subnet.subnet-sap-web[0].id) : (
-      local.sub_app_exists ? data.azurerm_subnet.subnet-sap-app[0].id : azurerm_subnet.subnet-sap-app[0].id)
+    subnet_id                     = local.sub_web_deployed.id
     private_ip_address            = cidrhost(local.sub_web_defined ? local.sub_web_prefix : local.sub_app_prefix, tonumber(count.index) + local.ip_offsets.web_vm)
     private_ip_address_allocation = "static"
   }


### PR DESCRIPTION
### Problem
Some customers want to deploy their web dispatchers and central services to a separate subnet.

### Solution
Create a new optional node in the networking section with the subnet information.

"subnet_app": {
"is_existing": "false",
"name": "subnet-app",
"prefix": "10.11.3.0/24",
"nsg": {
"is_existing": "false",
"name": "nsg-app"
}
} ,
"subnet_web": {
"is_existing": "false",
"name": "subnet-web",
"prefix": "10.11.4.0/24",
"nsg": {
"is_existing": "false",
"name": "nsg-web"
}
}
If that section exists the automation will use it and deploy into that subnet, if it does not exist the web dispatchers will be deployed to the app subnet