### PR TITLE
Set created local file permission

### DIFF
--- a/deploy/terraform/modules/output_files/inventory.tf
+++ b/deploy/terraform/modules/output_files/inventory.tf
@@ -70,7 +70,9 @@ resource "local_file" "output-json" {
     "options" = var.options
     }
   )
-  filename = "${terraform.workspace}/ansible_config_files/output.json"
+  filename             = "${terraform.workspace}/ansible_config_files/output.json"
+  file_permission      = "0660"
+  directory_permission = "0770"
 }
 
 # Generates the Ansible Inventory file
@@ -91,7 +93,9 @@ resource "local_file" "ansible-inventory" {
     ips-web               = local.ips-web
     }
   )
-  filename = "${terraform.workspace}/ansible_config_files/hosts"
+  filename             = "${terraform.workspace}/ansible_config_files/hosts"
+  file_permission      = "0660"
+  directory_permission = "0770"
 }
 
 # Generates the Ansible Inventory file
@@ -112,5 +116,7 @@ resource "local_file" "ansible-inventory-yml" {
     ips-web               = local.ips-web
     }
   )
-  filename = "${terraform.workspace}/ansible_config_files/hosts.yml"
+  filename             = "${terraform.workspace}/ansible_config_files/hosts.yml"
+  file_permission      = "0660"
+  directory_permission = "0770"
 }


### PR DESCRIPTION
## Problem
Closes #635 

## Solution
1. Set 770 for dir and 660 for files on local machine.

## Test
Deploy some resource and check file permission:

```
$ tree -p
.
└── [drwxr-x---]  ansible_config_files
    ├── [-rw-r-----]  hosts
    ├── [-rw-r-----]  hosts.yml
    └── [-rw-r-----]  output.json
```