### PR TITLE
Support custom image in deployer

### DIFF
--- a/deploy/terraform-units/modules/sap_deployer/variables_local.tf
+++ b/deploy/terraform-units/modules/sap_deployer/variables_local.tf
@@ -44,21 +44,20 @@ locals {
   deployer_input = var.deployers
 
   // Deployer(s) information with default override
-  deployer_list = length(local.deployer_input) > 0 ? local.deployer_input : [{ "destroy_after_deploy" = true }]
+  deployer_list = length(local.deployer_input) > 0 ? local.deployer_input : [{}]
   deployers = [
     for idx, deployer in local.deployer_list : {
       "name"                 = "deployer",
       "destroy_after_deploy" = true,
       "size"                 = try(deployer.size, "Standard_D2s_v3"),
       "disk_type"            = try(deployer.disk_type, "StandardSSD_LRS")
-      "os" = try(deployer.os,
-        {
-          "publisher" = "Canonical",
-          "offer"     = "UbuntuServer",
-          "sku"       = "18.04-LTS",
-          "version"   = "latest"
-        }
-      ),
+      "os" = {
+        "source_image_id" = try(deployer.os.source_image_id, "")
+        "publisher"       = try(deployer.os.source_image_id, "") == "" ? "Canonical" : ""
+        "offer"           = try(deployer.os.source_image_id, "") == "" ? "UbuntuServer" : ""
+        "sku"             = try(deployer.os.source_image_id, "") == "" ? "18.04-LTS" : ""
+        "version"         = try(deployer.os.source_image_id, "") == "" ? "latest" : ""
+      },
       "authentication" = {
         "type"     = "key",
         "username" = try(deployer.authentication.username, "azureadm")


### PR DESCRIPTION
## Problem
We may want to deploy deployer with existing image.

## Solution
Add deployer.os.source_image_id key if custom image is used.

## Test
1. `cd sap-hana/deploy/terraform-units/workspace/SAP_Deployer/TFE_bootstrap`
1.  create input.json with below:
```
{
  "infrastructure": {
    "region": "westus2",
    "resource_group": {
    }
  },
  "deployers": [ 
    {
      "os": {
        "source_image_id": "/subscriptions/xxx/resourceGroups/nancyc-image/providers/Microsoft.Compute/images/deployer-image-20200720142018"
      }
    }
  ],
  "sshkey": {
    "path_to_public_key": "~/.ssh/id_rsa.pub",
    "path_to_private_key": "~/.ssh/id_rsa"
  },
  "options": {
    "enable_secure_transfer": true
  }
}
```
1. `terraform init`
1. `terraform apply -auto-approve -var-file=input.json`

