### PR TITLE
Add subnet to deployer output and adjust upload script

### DIFF
--- a/deploy/terraform/bootstrap/sap_deployer/deployer.json
+++ b/deploy/terraform/bootstrap/sap_deployer/deployer.json
@@ -1,0 +1,12 @@
+{
+  "infrastructure": {
+    "region": "westus2"
+  },
+  "sshkey": {
+    "path_to_public_key": "~/.ssh/id_rsa.pub",
+    "path_to_private_key": "~/.ssh/id_rsa"
+  },
+  "options": {
+    "enable_secure_transfer": true
+  }
+}

--- a/deploy/terraform/bootstrap/sap_deployer/deployer_scp.tmpl
+++ b/deploy/terraform/bootstrap/sap_deployer/deployer_scp.tmpl
@@ -1,0 +1,7 @@
+%{~ for index, deployer in deployers ~}
+ssh -i ${deployer-ppk}  -o StrictHostKeyChecking=no ${deployer.authentication.username}@${deployer-ips[index]} "mkdir -p ~/.deployer/"
+%{ endfor ~}
+
+%{~ for index, deployer in deployers ~}
+scp -i ${deployer-ppk} -o StrictHostKeyChecking=no ../terraform.tfstate ${deployer.authentication.username}@${deployer-ips[index]}:~/.deployer/deployer.terraform.tfstate
+%{ endfor ~}

--- a/deploy/terraform/bootstrap/sap_deployer/deployer_scp.tmpl
+++ b/deploy/terraform/bootstrap/sap_deployer/deployer_scp.tmpl
@@ -3,5 +3,5 @@ ssh -i ${deployer-ppk}  -o StrictHostKeyChecking=no ${deployer.authentication.us
 %{ endfor ~}
 
 %{~ for index, deployer in deployers ~}
-scp -i ${deployer-ppk} -o StrictHostKeyChecking=no ../terraform.tfstate ${deployer.authentication.username}@${deployer-ips[index]}:~/.deployer/deployer.terraform.tfstate
+scp -i ${deployer-ppk} -o StrictHostKeyChecking=no ../terraform.tfstate ${deployer.authentication.username}@${deployer-ips[index]}:~/.config/deployer.terraform.tfstate
 %{ endfor ~}

--- a/deploy/terraform/bootstrap/sap_deployer/output.tf
+++ b/deploy/terraform/bootstrap/sap_deployer/output.tf
@@ -12,6 +12,14 @@ output "vnet-mgmt" {
   value = module.sap_deployer.vnet-mgmt
 }
 
+output "subnet-mgmt" {
+  value = module.sap_deployer.subnet-mgmt
+}
+
+output "nsg-mgmt" {
+  value = module.sap_deployer.nsg-mgmt
+}
+
 output "deployer-uai" {
   value = module.sap_deployer.deployer-uai
 }

--- a/deploy/terraform/bootstrap/sap_deployer/output.tf
+++ b/deploy/terraform/bootstrap/sap_deployer/output.tf
@@ -23,3 +23,7 @@ output "nsg-mgmt" {
 output "deployer-uai" {
   value = module.sap_deployer.deployer-uai
 }
+
+output "deployer" {
+  value = module.sap_deployer.deployers
+}

--- a/deploy/terraform/bootstrap/sap_deployer/scripts.tf
+++ b/deploy/terraform/bootstrap/sap_deployer/scripts.tf
@@ -7,11 +7,11 @@ Description:
 resource "local_file" "scp" {
   content = templatefile("${path.module}/deployer_scp.tmpl", {
     deployer-ppk = var.sshkey.path_to_private_key,
-    deployers    = local.deployers,
-    deployer-ips = azurerm_public_ip.deployer[*].ip_address
+    deployers    = module.sap_deployer.deployers,
+    deployer-ips = module.sap_deployer.deployer-pip[*].ip_address
   })
   filename             = "${terraform.workspace}/post_deployment.sh"
-  file_permission      = "0770"
+  file_permission      = "0660"
   directory_permission = "0770"
 }
 

--- a/deploy/terraform/run/sap_deployer/output.tf
+++ b/deploy/terraform/run/sap_deployer/output.tf
@@ -12,6 +12,14 @@ output "vnet-mgmt" {
   value = module.sap_deployer.vnet-mgmt
 }
 
+output "subnet-mgmt" {
+  value = module.sap_deployer.subnet-mgmt
+}
+
+output "nsg-mgmt" {
+  value = module.sap_deployer.nsg-mgmt
+}
+
 output "deployer-uai" {
   value = module.sap_deployer.deployer-uai
 }

--- a/deploy/terraform/run/sap_deployer/output.tf
+++ b/deploy/terraform/run/sap_deployer/output.tf
@@ -23,3 +23,7 @@ output "nsg-mgmt" {
 output "deployer-uai" {
   value = module.sap_deployer.deployer-uai
 }
+
+output "deployer" {
+  value = module.sap_deployer.deployers
+}

--- a/deploy/terraform/terraform-units/modules/sap_deployer/deployer_scp.tmpl
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/deployer_scp.tmpl
@@ -1,7 +1,0 @@
-%{~ for index, deployer in deployers ~}
-ssh -i ${deployer-ppk} ${deployer.authentication.username}@${deployer-ips[index]} "mkdir -p ~/.deployer/"
-%{ endfor ~}
-
-%{~ for index, deployer in deployers ~}
-scp -i ${deployer-ppk} -o StrictHostKeyChecking=no ../terraform.tfstate ${deployer.authentication.username}@${deployer-ips[index]}:~/.deployer/deployer_terraform.tfstate
-%{ endfor ~}

--- a/deploy/terraform/terraform-units/modules/sap_deployer/output.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/output.tf
@@ -36,6 +36,6 @@ output "deployer-pip" {
 
 // Details of deployer(s)
 output "deployers" {
-  value = local.deployers
+  value = local.deployers_updated
 }
 

--- a/deploy/terraform/terraform-units/modules/sap_deployer/output.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/output.tf
@@ -14,8 +14,28 @@ output "vnet-mgmt" {
   value = local.vnet_mgmt_exists ? data.azurerm_virtual_network.vnet-mgmt[0] : azurerm_virtual_network.vnet-mgmt[0]
 }
 
+// Details of management subnet that is deployed/imported
+output "subnet-mgmt" {
+  value = local.sub_mgmt_exists ? data.azurerm_subnet.subnet-mgmt[0] : azurerm_subnet.subnet-mgmt[0]
+}
+
+// Details of the management vnet NSG that is deployed/imported
+output "nsg-mgmt" {
+  value = local.sub_mgmt_nsg_exists ? data.azurerm_network_security_group.nsg-mgmt[0] : azurerm_network_security_group.nsg-mgmt[0]
+}
+
 // Details of the user assigned identity for deployer(s)
 output "deployer-uai" {
   value = azurerm_user_assigned_identity.deployer
+}
+
+// Details of deployer pip(s)
+output "deployer-pip" {
+  value = azurerm_public_ip.deployer
+}
+
+// Details of deployer(s)
+output "deployers" {
+  value = local.deployers
 }
 

--- a/deploy/terraform/terraform-units/modules/sap_deployer/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/variables_local.tf
@@ -60,7 +60,10 @@ locals {
       },
       "authentication" = {
         "type"     = "key",
-        "username" = try(deployer.authentication.username, "azureadm")
+        "username" = try(deployer.authentication.username, "azureadm"),
+        "sshkey" = {
+          "path_to_private_key" = "~/.ssh/id_rsa"
+        }
       },
       "components" = [
         "terraform",
@@ -68,6 +71,13 @@ locals {
       ],
       "private_ip_address" = try(deployer.private_ip_address, cidrhost(local.sub_mgmt_deployed.address_prefixes[0], idx + 4))
     }
+  ]
+
+  // Deployer(s) information with updated pip
+  deployers_updated = [
+    for idx, deployer in local.deployers : merge({
+      "public_ip_address" = azurerm_public_ip.deployer[idx].ip_address
+    }, deployer)
   ]
 
 }

--- a/deploy/terraform/terraform-units/modules/sap_deployer/vm-deployer.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/vm-deployer.tf
@@ -145,6 +145,8 @@ resource "null_resource" "prepare-deployer" {
 
   provisioner "remote-exec" {
     inline = local.deployers[count.index].os.source_image_id != "" ? [] : [
+      // Create config folder
+      "mkdir -p $HOME/.config",
       // Install terraform for all users
       "sudo apt-get install unzip",
       "sudo mkdir -p /opt/terraform/terraform_0.12.28",


### PR DESCRIPTION
## Problem
1. management subnet information will be required for sap_landscape deployment
1. upload script should only be run during first deployment

## Solution
1. Add management subnet to output for `bootstrap/sap_deployer` and `run/sap_deployer`
1. Move `script.tf` and related files to `bootstrap/sap_deployer`
1. Change file permission of post_deployment.sh which will be consistent with sap_lib
1. Change file name to `deployer.terraform.tfstate` to be consistent with sap_lib
1. Add missing StrictHostKeyChecking to `deployer_scp.tmpl`

## Test
1. `cd sap-hana/deploy/terraform/bootstrap/sap_deployer`
1. `terraform init`
1. `terraform apply -auto-approve -var-file=deployer.json`
