### PR TITLE
Create JSON with sap_libarary SA information

### DIFF
--- a/deploy/terraform/bootstrap/sap_library/sa_config.tf
+++ b/deploy/terraform/bootstrap/sap_library/sa_config.tf
@@ -1,0 +1,13 @@
+/* 
+  Description:
+  Generate json for storage account config
+*/
+resource "local_file" "sa-config" {
+  content = templatefile("${path.root}/sa_config.tmpl", {
+    saplibrary-resource-group    = module.sap_library.rgName
+    tfstate-storage-account-name = module.sap_library.tfstate-storage-account-name
+    }
+  )
+  filename        = "${path.root}/../.deploy/sa_config.json"
+  file_permission = "0660"
+}

--- a/deploy/terraform/bootstrap/sap_library/sa_config.tf
+++ b/deploy/terraform/bootstrap/sap_library/sa_config.tf
@@ -8,6 +8,6 @@ resource "local_file" "sa-config" {
     tfstate-storage-account-name = module.sap_library.tfstate-storage-account-name
     }
   )
-  filename        = "${path.root}/../.deploy/sa_config.json"
+  filename        = pathexpand("~/.config/sa_config.json")
   file_permission = "0660"
 }

--- a/deploy/terraform/bootstrap/sap_library/sa_config.tmpl
+++ b/deploy/terraform/bootstrap/sap_library/sa_config.tmpl
@@ -1,0 +1,14 @@
+{
+  "deployer": {
+    "resource_group_name": "${saplibrary-resource-group}",
+    "storage_account_name": "${tfstate-storage-account-name}",
+    "container_name": "deployer",
+    "key": "deployer.terraform.tfstate"
+  },
+  "saplibrary": {
+    "resource_group_name": "${saplibrary-resource-group}",
+    "storage_account_name": "${tfstate-storage-account-name}",
+    "container_name": "saplibrary",
+    "key": "saplibrary.terraform.tfstate"
+  }
+}


### PR DESCRIPTION
## Problem
Reading remote tfstate rely on the SA information

## Solution
Put required SA information into JSON format.

## Test
1.  `cd ~/sap-hana/deploy/terraform/bootstrap/sap_library`
1. modify `sap_library.json`
1. `terraform init && terraform apply -auto-approve -var-file=sap_library.json`
1. See json created:
~/sap-hana/deploy/terraform/bootstrap/sap_library$ cat ../.deploy/sa_config.json 
{
  "deployer": {
    "resource_group_name": "<xxx>",
    "storage_account_name": "<xxx>",
    "container_name": "tfstate",
    "key": "deployer.terraform.tfstate"
  },
  "saplibrary": {
    "resource_group_name": "<xxx>",
    "storage_account_name": "<xxx>",
    "container_name": "tfstate",
    "key": "saplibrary.terraform.tfstate"
  }
}