### PR TITLE
Separate files on deployer by SID

### DIFF
--- a/deploy/terraform/run/sap_system/variables_local.tf
+++ b/deploy/terraform/run/sap_system/variables_local.tf
@@ -15,11 +15,17 @@ variable "scenario" {
 
 # Set defaults
 locals {
-  hdb_list = [
+  db_list = [
     for db in var.databases : db
-    if try(db.platform, "NONE") == "HANA"
+    if try(db.platform, "NONE") != "NONE"
   ]
-  hana-sid = try(local.hdb_list[0].instance.sid, "")
+
+  db-sid = length(local.db_list) == 0 ? "" : try(local.db_list[0].instance.sid, local.db_list[0].platform == "HANA" ? "HN1" : "OR1")
+
+  app-sid = try(var.application.enable_deployment, false) ? try(var.application.sid, "") : ""
+
+  // TODO: add sap_lansdscape ENV to the path if stored local, or remote in sap_libarary
+  ansible_path = local.app-sid != "" ? local.app-sid : (local.db-sid != "" ? local.db-sid : ".")
 
   # Options
   enable_secure_transfer = try(var.options.enable_secure_transfer, true)


### PR DESCRIPTION
## Problem
All deployments will upload files (hosts, hosts.yml, output.json,...) onto deployer

## Solution
Separate those files by SID
1. If no db, no app, upload to /home/<user>
1. If no app, upload to folder with db SID
1. Others, upload to folder with app SID

## Test
1. Deploy with no db, no app:
```
~$ ls -ltr
total 24
drwxrwxr-x 10 azureadm azureadm 4096 Jul 28 21:22 sap-hana
-rw-r--r--  1 azureadm azureadm  762 Jul 29 04:52 hosts.yml
-rw-r--r--  1 azureadm azureadm  221 Jul 29 04:52 hosts
-rw-r--r--  1 azureadm azureadm 1773 Jul 29 04:52 output.json
-rw-r--r--  1 azureadm azureadm   38 Jul 29 04:52 export-clustering-sp-details.sh
```
1. Deploy with no app:
```
~/HN1$ pwd
/home/azureadm/HN1
~/HN1$ ls -ltr
total 16
-rw-r--r-- 1 azureadm azureadm 2469 Jul 29 05:04 output.json
-rw-r--r-- 1 azureadm azureadm  860 Jul 29 05:04 hosts.yml
-rw-r--r-- 1 azureadm azureadm  335 Jul 29 05:04 hosts
-rw-r--r-- 1 azureadm azureadm   38 Jul 29 05:04 export-clustering-sp-details.sh
```
1. Deploy with app:
```
~/PRD$ pwd
/home/azureadm/PRD
~/PRD$ ls -ltr
total 16
-rw-r--r-- 1 azureadm azureadm  954 Jul 29 15:33 hosts.yml
-rw-r--r-- 1 azureadm azureadm  445 Jul 29 15:33 hosts
-rw-r--r-- 1 azureadm azureadm 1773 Jul 29 15:33 output.json
-rw-r--r-- 1 azureadm azureadm   38 Jul 29 15:33 export-clustering-sp-details.sh
```