### PR TITLE
Use local var with defaults for app subnet and mgmt vnet

### DIFF
--- a/deploy/terraform/modules/app_tier/infrastructure.tf
+++ b/deploy/terraform/modules/app_tier/infrastructure.tf
@@ -48,14 +48,14 @@ resource "azurerm_lb" "scs" {
     name                          = "${upper(local.application_sid)}_scs-feip"
     subnet_id                     = local.sub_app_exists ? data.azurerm_subnet.subnet-sap-app[0].id : azurerm_subnet.subnet-sap-app[0].id
     private_ip_address_allocation = "Static"
-    private_ip_address            = var.infrastructure.vnets.sap.subnet_app.is_existing ? local.scs_lb_ips[0] : cidrhost(var.infrastructure.vnets.sap.subnet_app.prefix, 0 + local.ip_offsets.scs_lb)
+    private_ip_address            = local.sub_app_exists ? local.scs_lb_ips[0] : cidrhost(local.sub_app_prefix, 0 + local.ip_offsets.scs_lb)
   }
 
   frontend_ip_configuration {
     name                          = "${upper(local.application_sid)}_ers-feip"
     subnet_id                     = local.sub_app_exists ? data.azurerm_subnet.subnet-sap-app[0].id : azurerm_subnet.subnet-sap-app[0].id
     private_ip_address_allocation = "Static"
-    private_ip_address            = var.infrastructure.vnets.sap.subnet_app.is_existing ? local.scs_lb_ips[1] : cidrhost(var.infrastructure.vnets.sap.subnet_app.prefix, 1 + local.ip_offsets.scs_lb)
+    private_ip_address            = local.sub_app_exists ? local.scs_lb_ips[1] : cidrhost(local.sub_app_prefix, 1 + local.ip_offsets.scs_lb)
   }
 }
 

--- a/deploy/terraform/modules/jumpbox/vm-jump-linux.tf
+++ b/deploy/terraform/modules/jumpbox/vm-jump-linux.tf
@@ -31,7 +31,7 @@ resource "azurerm_network_interface" "jump-linux" {
   ip_configuration {
     name                          = "${local.vm-jump-linux[count.index].name}-nic1-ip"
     subnet_id                     = var.subnet-mgmt[0].id
-    private_ip_address            = var.infrastructure.vnets.management.subnet_mgmt.is_existing ? local.vm-jump-linux[count.index].private_ip_address : lookup(local.vm-jump-linux[count.index], "private_ip_address", false) != false ? local.vm-jump-linux[count.index].private_ip_address : cidrhost(var.infrastructure.vnets.management.subnet_mgmt.prefix, (count.index + 4 + length(local.vm-jump-win)))
+    private_ip_address            = local.sub_mgmt_exists ? local.vm-jump-linux[count.index].private_ip_address : lookup(local.vm-jump-linux[count.index], "private_ip_address", false) != false ? local.vm-jump-linux[count.index].private_ip_address : cidrhost(var.infrastructure.vnets.management.subnet_mgmt.prefix, (count.index + 4 + length(local.vm-jump-win)))
     private_ip_address_allocation = "static"
     public_ip_address_id          = azurerm_public_ip.jump-linux[count.index].id
   }

--- a/deploy/terraform/modules/jumpbox/vm-jump-win.tf
+++ b/deploy/terraform/modules/jumpbox/vm-jump-win.tf
@@ -31,7 +31,7 @@ resource "azurerm_network_interface" "jump-win" {
   ip_configuration {
     name                          = "${local.vm-jump-win[count.index].name}-nic1-ip"
     subnet_id                     = var.subnet-mgmt[0].id
-    private_ip_address            = var.infrastructure.vnets.management.subnet_mgmt.is_existing ? local.vm-jump-win[count.index].private_ip_address : lookup(local.vm-jump-win[count.index], "private_ip_address", false) != false ? local.vm-jump-win[count.index].private_ip_address : cidrhost(var.infrastructure.vnets.management.subnet_mgmt.prefix, (count.index + 4))
+    private_ip_address            = local.sub_mgmt_exists ? local.vm-jump-win[count.index].private_ip_address : lookup(local.vm-jump-win[count.index], "private_ip_address", false) != false ? local.vm-jump-win[count.index].private_ip_address : cidrhost(var.infrastructure.vnets.management.subnet_mgmt.prefix, (count.index + 4))
     private_ip_address_allocation = "static"
     public_ip_address_id          = azurerm_public_ip.jump-win[count.index].id
   }


### PR DESCRIPTION
## Problem
terraform plan fails when management vnet or subnet_app not defined.

## Solution
Use local var with defaults

## Test
1. terraform plan with `application.enable_deployment` set to `true`.
1.  terraform plan with windows jumpbox in the input.