### PR TITLE
Import sap bits information from sap_library tfstate

### DIFF
--- a/deploy/terraform/run/sap_system/module.tf
+++ b/deploy/terraform/run/sap_system/module.tf
@@ -7,6 +7,10 @@ module "deployer" {
   source = "../../terraform-units/modules/sap_system/deployer"
 }
 
+module "saplibrary" {
+  source = "../../terraform-units/modules/sap_system/saplibrary"
+}
+
 module "common_infrastructure" {
   source              = "../../terraform-units/modules/sap_system/common_infrastructure"
   is_single_node_hana = "true"
@@ -110,7 +114,9 @@ module "output_files" {
   software                     = var.software
   ssh-timeout                  = var.ssh-timeout
   sshkey                       = var.sshkey
-  storage-sapbits              = module.common_infrastructure.storage-sapbits
+  storage-sapbits              = module.saplibrary.saplibrary
+  file_share_name              = module.saplibrary.file_share_name
+  storagecontainer-sapbits     = module.saplibrary.storagecontainer-sapbits
   nics-iscsi                   = module.common_infrastructure.nics-iscsi
   infrastructure_w_defaults    = module.common_infrastructure.infrastructure_w_defaults
   software_w_defaults          = module.common_infrastructure.software_w_defaults

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/infrastructure.tf
@@ -67,40 +67,6 @@ resource "random_id" "random-id" {
   byte_length = 4
 }
 
-# Creates storage account for storing SAP Bits
-resource "azurerm_storage_account" "storage-sapbits" {
-  count                     = local.sa_sapbits_exists ? 0 : 1
-  name                      = local.sa_name
-  resource_group_name       = local.rg_exists ? data.azurerm_resource_group.resource-group[0].name : azurerm_resource_group.resource-group[0].name
-  location                  = local.rg_exists ? data.azurerm_resource_group.resource-group[0].location : azurerm_resource_group.resource-group[0].location
-  account_replication_type  = "LRS"
-  account_tier              = local.sa_account_tier
-  account_kind              = local.sa_account_kind
-  enable_https_traffic_only = var.options.enable_secure_transfer == "" ? true : var.options.enable_secure_transfer
-}
-
-# Creates the storage container inside the storage account for SAP bits
-resource "azurerm_storage_container" "storagecontainer-sapbits" {
-  count                 = local.sa_sapbits_exists ? 0 : (local.sa_blob_container_name == "null" ? 0 : 1)
-  name                  = local.sa_blob_container_name
-  storage_account_name  = azurerm_storage_account.storage-sapbits[0].name
-  container_access_type = local.sa_container_access_type
-}
-
-# Creates file share inside the storage account for SAP bits
-resource "azurerm_storage_share" "fileshare-sapbits" {
-  count                = local.sa_sapbits_exists ? 0 : (local.sa_file_share_name == "" ? 0 : 1)
-  name                 = local.sa_file_share_name
-  storage_account_name = azurerm_storage_account.storage-sapbits[0].name
-}
-
-# Imports existing storage account to use for SAP bits
-data "azurerm_storage_account" "storage-sapbits" {
-  count               = local.sa_sapbits_exists ? 1 : 0
-  name                = split("/", var.software.storage_account_sapbits.arm_id)[8]
-  resource_group_name = split("/", var.software.storage_account_sapbits.arm_id)[4]
-}
-
 # Creates boot diagnostics storage account
 resource "azurerm_storage_account" "storage-bootdiag" {
   name                      = "sabootdiag${random_id.random-id.hex}"

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/outputs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/outputs.tf
@@ -18,10 +18,6 @@ output "storage-bootdiag" {
   value = azurerm_storage_account.storage-bootdiag
 }
 
-output "storage-sapbits" {
-  value = local.sa_sapbits_exists ? data.azurerm_storage_account.storage-sapbits : azurerm_storage_account.storage-sapbits
-}
-
 output "random-id" {
   value = random_id.random-id
 }

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/variables_local.tf
@@ -222,18 +222,6 @@ locals {
     }
   }
 
-  # Storage account for sapbits
-  sa_sapbits_exists           = try(var.software.storage_account_sapbits.is_existing, false)
-  sa_account_tier             = local.sa_sapbits_exists ? "" : try(var.software.storage_account_sapbits.account_tier, "Premium")
-  sa_account_replication_type = local.sa_sapbits_exists ? "" : try(var.software.storage_account_sapbits.account_replication_type, "LRS")
-  sa_account_kind             = local.sa_sapbits_exists ? "" : try(var.software.storage_account_sapbits.account_kind, "FileStorage")
-  sa_file_share_name          = "bits"
-  sa_blob_container_name      = "null"
-  sa_container_access_type    = "blob"
-  sa_name                     = local.sa_sapbits_exists ? try(var.software.storage_account_sapbits.Storage_account_name, "") : "sapbits${random_id.random-id.hex}"
-  sa_key                      = local.sa_sapbits_exists ? try(var.software.storage_account_sapbits.Storage_access_key, "") : ""
-  sa_arm_id                   = local.sa_sapbits_exists ? try(var.software.storage_account_sapbits.arm_id, "") : ""
-
   # Downloader
   sap_user     = try(var.software.downloader.credentials.sap_user, "sap_smp_user")
   sap_password = try(var.software.downloader.credentials.sap_password, "sap_smp_password")
@@ -287,17 +275,6 @@ locals {
 
   //---- Update software with defaults ----//
   software = merge(var.software, {
-    storage_account_sapbits = {
-      is_existing              = local.sa_sapbits_exists,
-      account_tier             = local.sa_account_tier,
-      account_replication_type = local.sa_account_replication_type,
-      account_kind             = local.sa_account_kind,
-      file_share_name          = local.sa_file_share_name,
-      blob_container_name      = local.sa_blob_container_name,
-      Storage_account_name     = local.sa_name,
-      Storage_access_key       = local.sa_key,
-      arm_id                   = local.sa_arm_id
-    },
     downloader = local.downloader
   })
 }

--- a/deploy/terraform/terraform-units/modules/sap_system/output_files/inventory.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/output_files/inventory.tf
@@ -88,10 +88,10 @@ resource "local_file" "output-json" {
     ),
     "software" = merge(var.software_w_defaults, {
       storage_account_sapbits = {
-        name                = var.storage-sapbits[0].name,
-        storage_access_key  = var.storage-sapbits[0].primary_access_key,
-        file_share_name     = var.software_w_defaults.storage_account_sapbits.file_share_name
-        blob_container_name = var.software_w_defaults.storage_account_sapbits.blob_container_name
+        name                = var.storage-sapbits.name,
+        storage_access_key  = var.storage-sapbits.primary_access_key,
+        file_share_name     = var.file_share_name
+        blob_container_name = try(var.storagecontainer-sapbits.name, null)
       }
     })
     "options" = var.options

--- a/deploy/terraform/terraform-units/modules/sap_system/output_files/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/output_files/variables_local.tf
@@ -38,6 +38,14 @@ variable "storage-sapbits" {
   description = "Details of the storage account for SAP bits"
 }
 
+variable "file_share_name" {
+  description = "Name of the file share for SAP bits"
+}
+
+variable "storagecontainer-sapbits" {
+  description = "Details of the storage container for SAP bits"
+}
+
 variable "nics-iscsi" {
   description = "NICs of ISCSI target servers"
 }

--- a/deploy/terraform/terraform-units/modules/sap_system/saplibrary/imports.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/saplibrary/imports.tf
@@ -1,0 +1,27 @@
+/*
+    Description:
+      Import deployer resources
+*/
+
+data "terraform_remote_state" "saplibrary" {
+  backend = "azurerm"
+  config = {
+    resource_group_name  = local.deployer_config.saplibrary.resource_group_name
+    storage_account_name = local.deployer_config.saplibrary.storage_account_name
+    container_name       = local.deployer_config.saplibrary.container_name
+    key                  = local.deployer_config.saplibrary.key
+  }
+}
+
+// Import SA for sap bits
+data "azurerm_storage_account" "saplibrary" {
+  name                = data.terraform_remote_state.saplibrary.outputs.sapbits_storage_account.name
+  resource_group_name = data.terraform_remote_state.saplibrary.outputs.sapbits_storage_account.resource_group_name
+}
+
+// Import storage container for sap bits if exists
+data "azurerm_storage_container" "storagecontainer-sapbits" {
+  count                = local.blob_container_exists ? 1 : 0
+  name                 = data.terraform_remote_state.saplibrary.outputs.storagecontainer_sapbits.name
+  storage_account_name = data.terraform_remote_state.saplibrary.outputs.storagecontainer_sapbits.storage_account_name
+}

--- a/deploy/terraform/terraform-units/modules/sap_system/saplibrary/output.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/saplibrary/output.tf
@@ -1,0 +1,11 @@
+output "saplibrary" {
+  value = data.azurerm_storage_account.saplibrary
+}
+
+output "file_share_name" {
+  value = local.file_share_name
+}
+
+output "storagecontainer-sapbits" {
+  value = local.blob_container_exists ? data.azurerm_storage_container.storagecontainer-sapbits[0] : null
+}

--- a/deploy/terraform/terraform-units/modules/sap_system/saplibrary/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/saplibrary/variables_local.tf
@@ -1,0 +1,17 @@
+// Imports from saplibrary tfstate
+locals {
+  // Import saplibrary info from config
+  config_path     = pathexpand("~/.config/sa_config.json")
+  deployer_config = jsondecode(file(local.config_path))
+}
+
+locals {
+  file_share_exists     = try(data.terraform_remote_state.saplibrary.outputs.fileshare_sapbits_name, null) == null ? false : true
+  blob_container_exists = try(data.terraform_remote_state.saplibrary.outputs.storagecontainer_sapbits, null) == null ? false : true
+
+  /*
+    TODO: currently data source azurerm_storage_share is not supported 
+    https://github.com/terraform-providers/terraform-provider-azurerm/issues/4931
+  */
+  file_share_name = local.file_share_exists ? data.terraform_remote_state.saplibrary.outputs.fileshare_sapbits_name : null
+}


### PR DESCRIPTION
## Problem
The SA for sapbits currently is provisioned with sap_library

## Solution
Read SA information from remote tfstate

## Test
- Test with Azure file:
1. Deploy SA with Azure file
1. Deploy sap_system with just infrastructure
1. Check storage part from output.json:
```
"storage_account_sapbits": {
      "blob_container_name": null,
      "file_share_name": "bits",
      "name": "sapbits8198c957",
      "storage_access_key": "xxx"
    }
```

- Test with Azure blob:
1. Deploy SA with blob
1. Deploy sap_system with just infrastructure
1. Check storage part from output.json:
```
"storage_account_sapbits": {
      "blob_container_name": "bits-container",
      "file_share_name": null,
      "name": "sapbitsb1bf5933",
      "storage_access_key": "xxx"
    }
```

- Test with both Azure file and blob:
1. Deploy SA with both azure file and blob
1. Deploy sap_system with just infrastructure
1. Check storage part from output.json
```
"storage_account_sapbits": {
      "blob_container_name": "bits-container",
      "file_share_name": "bits",
      "name": "sapbitsb4cea599",
      "storage_access_key": "xxx"
    }
```