### PR TITLE
Make *_tfstate_scrpt.sh idempotent

### DIFF
--- a/deploy/terraform/bootstrap/sap_library/deployer_tfstate_script.tmpl
+++ b/deploy/terraform/bootstrap/sap_library/deployer_tfstate_script.tmpl
@@ -39,6 +39,16 @@ function validate_deployer_tfstate(){
     fi
 }
 
+function validate_deployer_remote_state(){
+
+    az login --identity > /dev/null
+    remote_state_exists=$(az storage blob exists -c ${storagecontainer_deployer_name} --name ${deployer_tfstate_name} --account-name ${tfstate_storage_account_name} | jq -r .exists)
+    if $remote_state_exists; then
+        echo "remote state ${deployer_tfstate_name} already exists"
+        exit 0
+    fi
+}
+
 function deployer_remote_backend_init(){
 
     echo "Start initialize remote backend for deployer"
@@ -47,13 +57,19 @@ function deployer_remote_backend_init(){
 
     cd ..
 
+    rm -r .terraform
+
     terraform init -force-copy \
     -backend-config "resource_group_name=${saplibrary_resource_group_name}" \
     -backend-config "storage_account_name=${tfstate_storage_account_name}" \
     -backend-config "container_name=${storagecontainer_deployer_name}" \
     -backend-config "key=${deployer_tfstate_name}"
 
+    validate_deployer_remote_state
+
     terraform state push "${deployer_tfstate_name}"
 }
+
+
 
 main "$@"

--- a/deploy/terraform/bootstrap/sap_library/saplibrary_tfstate_script.tmpl
+++ b/deploy/terraform/bootstrap/sap_library/saplibrary_tfstate_script.tmpl
@@ -38,6 +38,16 @@ function validate_saplibrary_tfstate(){
     fi
 }
 
+function validate_saplibrary_remote_state(){
+
+    az login --identity > /dev/null
+    remote_state_exists=$(az storage blob exists -c ${storagecontainer_saplibrary_name} --name ${saplibrary_tfstate_name} --account-name ${tfstate_storage_account_name} | jq -r .exists)
+    if $remote_state_exists; then
+        echo "remote state ${saplibrary_tfstate_name} already exists"
+        exit 0
+    fi
+}
+
 function sap_library_remote_backend_init(){
 
     echo "Start initialize remote backend for sap library"
@@ -45,12 +55,16 @@ function sap_library_remote_backend_init(){
     cp ${saplibrary_terraform_tfstate_path} ../
 
     cd ..
+    
+    rm -r .terraform
 
     terraform init -force-copy \
     -backend-config "resource_group_name=${saplibrary_resource_group_name}" \
     -backend-config "storage_account_name=${tfstate_storage_account_name}" \
     -backend-config "container_name=${storagecontainer_saplibrary_name}" \
     -backend-config "key=${saplibrary_tfstate_name}"
+
+    validate_saplibrary_remote_state
 
     terraform state push "${saplibrary_tfstate_name}"
 }


### PR DESCRIPTION
## Problem
The `deployer_tfstate_script.sh` and `saplibrary_tfstate_script.sh` can't be run repeatedly.

## Solution
Add validations/conditions to make it idempotent, includes:
- cleanup `.terraform` (this is especially reuiqred when switch to a different backend config)
- check if tfstate file(s) already exists remotely.

## Test
1. Deploy a sap_libaray.
1. Repeatedly run `deployer_tfstate_script.sh` and `saplibrary_tfstate_script.sh`