### PR TITLE
Add sapsystem default json template

### DIFF
--- a/deploy/terraform/run/sap_system/backend.tf
+++ b/deploy/terraform/run/sap_system/backend.tf
@@ -1,0 +1,8 @@
+/*
+  Description:
+  To use remote backend to deploy deployer(s).
+*/
+
+terraform {
+  backend "azurerm" {}
+}

--- a/deploy/terraform/run/sap_system/module.tf
+++ b/deploy/terraform/run/sap_system/module.tf
@@ -8,7 +8,15 @@ module "deployer" {
 }
 
 module "saplibrary" {
-  source = "../../terraform-units/modules/sap_system/saplibrary"
+  application    = var.application
+  databases      = var.databases
+  infrastructure = var.infrastructure
+  jumpboxes      = var.jumpboxes
+  options        = var.options
+  software       = var.software
+  ssh-timeout    = var.ssh-timeout
+  sshkey         = var.sshkey
+  source         = "../../terraform-units/modules/sap_system/saplibrary"
 }
 
 module "common_infrastructure" {

--- a/deploy/terraform/run/sap_system/module.tf
+++ b/deploy/terraform/run/sap_system/module.tf
@@ -8,6 +8,7 @@ module "deployer" {
 }
 
 module "saplibrary" {
+  source         = "../../terraform-units/modules/sap_system/saplibrary"
   application    = var.application
   databases      = var.databases
   infrastructure = var.infrastructure
@@ -16,7 +17,6 @@ module "saplibrary" {
   software       = var.software
   ssh-timeout    = var.ssh-timeout
   sshkey         = var.sshkey
-  source         = "../../terraform-units/modules/sap_system/saplibrary"
 }
 
 module "common_infrastructure" {

--- a/deploy/terraform/run/sap_system/sapsystem.json
+++ b/deploy/terraform/run/sap_system/sapsystem.json
@@ -1,0 +1,67 @@
+{
+  "infrastructure": {
+    "landscape": "PROD",
+    "region": "eastus",
+    "resource_group": {
+      "is_existing": "false",
+      "arm_id": "",
+      "name": "azure-sap-system-rg"
+    }
+  },
+  "jumpboxes": {
+    "windows": [],
+    "linux": []
+  },
+  "databases": [
+    {
+      "platform": "HANA",
+      "high_availability": false,
+      "db_version": "2.00.050",
+      "credentials": {
+        "db_systemdb_password": "<db_systemdb_password>",
+        "os_sidadm_password": "<os_sidadm_password>",
+        "os_sapadm_password": "<os_sapadm_password>",
+        "xsa_admin_password": "<xsa_admin_password>",
+        "cockpit_admin_password": "<cockpit_admin_password>",
+        "ha_cluster_password": "<ha_cluster_password>"
+      }
+    }
+  ],
+  "application": {
+    "enable_deployment": false,
+    "sid": "PRD",
+    "scs_instance_number": "01",
+    "ers_instance_number": "02",
+    "scs_high_availability": false,
+    "application_server_count": 1,
+    "webdispatcher_count": 1,
+    "authentication" : {
+      "type": "key",
+      "username": "azureadm"
+    }
+  },
+  "software": {
+    "downloader": {
+      "credentials": {
+        "sap_user": "<sap_user>",
+        "sap_password": "<sap_password>"
+      },
+      "scenarios": [
+        {
+          "scenario_type": "DB",
+          "product_name": "HANA",
+          "product_version": "2.0"
+        }
+      ]
+    }
+  },
+  "sshkey": {
+    "path_to_public_key": "~/.ssh/id_rsa.pub",
+    "path_to_private_key": "~/.ssh/id_rsa"
+  },
+  "options": {
+    "enable_secure_transfer": true,
+    "ansible_execution": false,
+    "enable_prometheus": true
+  }
+}

--- a/deploy/terraform/run/sap_system/variables_local.tf
+++ b/deploy/terraform/run/sap_system/variables_local.tf
@@ -16,7 +16,7 @@ variable "scenario" {
 # Set defaults
 locals {
 
-  ansible_path = "${module.saplibrary.landscape_id}-${module.saplibrary.sid}"
+  ansible_path = "${module.saplibrary.landscape_id}_${module.saplibrary.sid}"
 
   # Options
   enable_secure_transfer = try(var.options.enable_secure_transfer, true)

--- a/deploy/terraform/run/sap_system/variables_local.tf
+++ b/deploy/terraform/run/sap_system/variables_local.tf
@@ -15,17 +15,8 @@ variable "scenario" {
 
 # Set defaults
 locals {
-  db_list = [
-    for db in var.databases : db
-    if try(db.platform, "NONE") != "NONE"
-  ]
 
-  db-sid = length(local.db_list) == 0 ? "" : try(local.db_list[0].instance.sid, local.db_list[0].platform == "HANA" ? "HN1" : "OR1")
-
-  app-sid = try(var.application.enable_deployment, false) ? try(var.application.sid, "") : ""
-
-  // TODO: add sap_lansdscape ENV to the path if stored local, or remote in sap_libarary
-  ansible_path = local.app-sid != "" ? local.app-sid : (local.db-sid != "" ? local.db-sid : ".")
+  ansible_path = "${module.saplibrary.landscape_id}-${module.saplibrary.sid}"
 
   # Options
   enable_secure_transfer = try(var.options.enable_secure_transfer, true)

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/variables_local.tf
@@ -92,7 +92,7 @@ locals {
   xsa                    = try(local.hdb.xsa, { routing = "ports" })
   shine                  = try(local.hdb.shine, { email = "shinedemo@microsoft.com" })
 
-  dbnodes = [for idx, dbnode in try(local.hdb.dbnodes, []) : {
+  dbnodes = [for idx, dbnode in try(local.hdb.dbnodes, [{}]) : {
     "name" = try(dbnode.name, format("%s_%s_hdb%02d", local.sap_sid, local.hdb_sid, idx)),
     "role" = try(dbnode.role, "worker")
     }

--- a/deploy/terraform/terraform-units/modules/sap_system/saplibrary/output.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/saplibrary/output.tf
@@ -9,3 +9,11 @@ output "file_share_name" {
 output "storagecontainer-sapbits" {
   value = local.blob_container_exists ? data.azurerm_storage_container.storagecontainer-sapbits[0] : null
 }
+
+output "sid" {
+  value = local.sid
+}
+
+output "landscape_id" {
+  value = local.landscape_id
+}

--- a/deploy/terraform/terraform-units/modules/sap_system/saplibrary/remote_file.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/saplibrary/remote_file.tf
@@ -5,9 +5,9 @@
 
 // Upload sapsystem.json to json container
 resource "azurerm_storage_blob" "sapsystem_json" {
-  name                   = "${local.landscape_id}/${local.sid}/${local.landscape_id}-${local.sid}.json"
+  name                   = "${local.landscape_id}/${local.sid}/${local.landscape_id}_${local.sid}.json"
   storage_account_name   = local.sa_tfstate.name
   storage_container_name = local.storagecontainer_sapsystem.name
   type                   = "Block"
-  source                 = "${path.root}/${local.landscape_id}-${local.sid}.json"
+  source                 = "${path.root}/${local.landscape_id}_${local.sid}.json"
 }

--- a/deploy/terraform/terraform-units/modules/sap_system/saplibrary/remote_file.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/saplibrary/remote_file.tf
@@ -1,0 +1,13 @@
+/*
+  Description:
+  Upload json files to stroage account 
+*/
+
+// Upload sapsystem.json to json container
+resource "azurerm_storage_blob" "sapsystem_json" {
+  name                   = "${local.landscape_id}/${local.sid}/${local.landscape_id}-${local.sid}.json"
+  storage_account_name   = local.sa_tfstate.name
+  storage_container_name = local.storagecontainer_sapsystem.name
+  type                   = "Block"
+  source                 = "${path.root}/${local.landscape_id}-${local.sid}.json"
+}

--- a/deploy/terraform/terraform-units/modules/sap_system/saplibrary/variables_global.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/saplibrary/variables_global.tf
@@ -1,0 +1,8 @@
+variable "application" {}
+variable "databases" {}
+variable "infrastructure" {}
+variable "jumpboxes" {}
+variable "options" {}
+variable "software" {}
+variable "ssh-timeout" {}
+variable "sshkey" {}

--- a/deploy/terraform/terraform-units/modules/sap_system/saplibrary/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/saplibrary/variables_local.tf
@@ -6,8 +6,20 @@ locals {
 }
 
 locals {
-  file_share_exists     = try(data.terraform_remote_state.saplibrary.outputs.fileshare_sapbits_name, null) == null ? false : true
-  blob_container_exists = try(data.terraform_remote_state.saplibrary.outputs.storagecontainer_sapbits, null) == null ? false : true
+  file_share_exists          = try(data.terraform_remote_state.saplibrary.outputs.fileshare_sapbits_name, null) == null ? false : true
+  blob_container_exists      = try(data.terraform_remote_state.saplibrary.outputs.storagecontainer_sapbits, null) == null ? false : true
+  storagecontainer_sapsystem = try(data.terraform_remote_state.saplibrary.outputs.storagecontainer_sapsystem, null)
+  sa_tfstate                 = try(data.terraform_remote_state.saplibrary.outputs.tfstate_storage_account, null)
+
+
+  db_list = [
+    for db in var.databases : db
+    if try(db.platform, "NONE") != "NONE"
+  ]
+  db_sid       = length(local.db_list) == 0 ? "" : try(local.db_list[0].instance.sid, local.db_list[0].platform == "HANA" ? "HN1" : "OR1")
+  app_sid      = try(var.application.enable_deployment, false) ? try(var.application.sid, "") : ""
+  sid          = local.app_sid != "" ? local.app_sid : (local.db_sid != "" ? local.db_sid : "SID")
+  landscape_id = try(var.infrastructure.landscape, "TEST")
 
   /*
     TODO: currently data source azurerm_storage_share is not supported 

--- a/deploy/terraform/terraform-units/modules/sap_system/saplibrary/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/saplibrary/variables_local.tf
@@ -16,8 +16,9 @@ locals {
     for db in var.databases : db
     if try(db.platform, "NONE") != "NONE"
   ]
-  db_sid       = length(local.db_list) == 0 ? "" : try(local.db_list[0].instance.sid, local.db_list[0].platform == "HANA" ? "HN1" : "OR1")
-  app_sid      = try(var.application.enable_deployment, false) ? try(var.application.sid, "") : ""
+  db_sid  = length(local.db_list) == 0 ? "" : try(local.db_list[0].instance.sid, local.db_list[0].platform == "HANA" ? "HN1" : "OR1")
+  app_sid = try(var.application.enable_deployment, false) ? try(var.application.sid, "") : ""
+  // SID decided by application SID if exists, otherwise, use database SID, none provided, default to SID
   sid          = local.app_sid != "" ? local.app_sid : (local.db_sid != "" ? local.db_sid : "SID")
   landscape_id = try(var.infrastructure.landscape, "TEST")
 


### PR DESCRIPTION
## Problem
Currently, we need to upload a json template to deployer.

## Solution
1. To make it easier, provide a default json for sap_system.
1. Upload json during deployment, following `<landscape>/<sid>/<landscape>_<sid>.json` format.
1. Fixed a bug with hdb when no dbnodes is provided.

## Test
On deployer:
```
cp sapsystem.json PROD_HN1.json
cd /home/azureadm/sap-hana/deploy/terraform/run/sap_system
terraform plan -var-file=PROD_HN1.json
```