### PR TITLE
Create a script to help users download input json from sa

### DIFF
--- a/deploy/terraform/bootstrap/sap_library/output.tf
+++ b/deploy/terraform/bootstrap/sap_library/output.tf
@@ -1,5 +1,5 @@
 output "tfstate_storage_account" {
-    value = module.sap_library.sapbits_storage_account
+    value = module.sap_library.tfstate_storage_account
 }
 
 output "sapbits_storage_account" {

--- a/deploy/terraform/run/sap_library/util/download_input.sh
+++ b/deploy/terraform/run/sap_library/util/download_input.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+# exit immediately if a command fails
+set -o errexit
+
+# exit immediately if an unset variable is used
+set -o nounset
+
+readonly target_json="$HOME/.config/sa_config.json"
+
+function main(){
+    
+    check_jq_installed
+
+    check_file_exists ${target_json}
+
+    local storage_account_name=$(read_json .saplibrary.storage_account_name)
+    local container_name=$(read_json .saplibrary.container_name)
+    local remote_file_name="saplibrary.json"
+    local local_file_path="../saplibrary.json"
+
+    json_download ${local_file_path} ${storage_account_name} ${container_name} ${remote_file_name}    
+}
+
+function read_json(){
+
+    local key="$1"
+    local value=$(cat ${target_json} | jq "${key}")
+	
+    echo $value
+}
+
+function check_file_exists(){
+
+    local file_path="$1"
+    
+    if [ ! -f "${file_path}" ]; then
+        printf "%s\n" "ERROR: File ${file_path} does not exist. Please follow guidance to recover it" >&2
+        # TODO: create a guidance about file/env recovery
+        exit 1
+    fi
+}
+
+function check_jq_installed(){
+
+    local cmd="jq"
+    local advice="Try: https://stedolan.github.io/jq/download/"
+
+    # disable exit on error throughout this section as it's designed to fail
+    # when cmd is not installed
+    set +e
+    local is_cmd_installed
+    command -v "${cmd}" > /dev/null
+    is_cmd_installed=$?
+    set -e
+    
+    local error="This script depends on the '${cmd}' command being installed"
+    # append advice if any was provided
+    if [ ${is_cmd_installed} != 0 ]; then
+        error="${error} (${advice})"
+        printf "%s\n" "ERROR: ${error}" >&2
+        exit 1
+    fi
+}
+
+function json_download(){
+
+    echo "Start download file:"
+    local local_file_path=$1
+    local storage_account_name=$2
+    local container_name=$3
+    local remote_file_name=$4
+
+    az login --identity > /dev/null
+
+    local cmd="az storage blob download --container-name ${container_name} --file ${local_file_path} --name ${remote_file_name} --account-name ${storage_account_name}"
+    eval "$cmd"
+}
+
+main "$@"

--- a/deploy/terraform/run/sap_library/util/download_input.sh
+++ b/deploy/terraform/run/sap_library/util/download_input.sh
@@ -8,6 +8,13 @@ set -o nounset
 
 readonly target_json="$HOME/.config/sa_config.json"
 
+SCRIPT=$(readlink -f "$0")
+# Absolute path this script
+SCRIPTPATH=$(dirname "$SCRIPT")
+
+# file will be put in the current working directory
+local_file_path="${SCRIPTPATH}/../saplibrary.json"
+
 function main(){
     
     check_jq_installed
@@ -17,7 +24,6 @@ function main(){
     local storage_account_name=$(read_json .saplibrary.storage_account_name)
     local container_name=$(read_json .saplibrary.container_name)
     local remote_file_name="saplibrary.json"
-    local local_file_path="../saplibrary.json"
 
     json_download ${local_file_path} ${storage_account_name} ${container_name} ${remote_file_name}    
 }


### PR DESCRIPTION
This script is used to help users download saplibrary.json from sa

First it reads config file via jq
Second, use az cli to download the json

### Test
Under /run/sap_library/util/, execute ./download_input.sh
saplibrary.json will be downloaded to the local working directory /run/sap_library/