### PR TITLE
Use resource group name for deployer when provided

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_deployer/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/variables_local.tf
@@ -37,7 +37,7 @@ locals {
   sub_mgmt_nsg_deployed    = try(local.sub_mgmt_nsg_exists ? data.azurerm_network_security_group.nsg-mgmt[0] : azurerm_network_security_group.nsg-mgmt[0], null)
 
   // Resource group and location
-  rg_name = try("${var.infrastructure.resource_group.name}-${local.postfix}", format("sapdeployer-rg-%s", local.postfix))
+  rg_name = try(var.infrastructure.resource_group.name, format("sapdeployer-rg-%s", local.postfix))
   region  = try(var.infrastructure.region, "westus2")
 
   // Deployer(s) information from input


### PR DESCRIPTION
## Problem
It is not necessary to add postfix when resource group name is provided.

## Solution
1. Use provided resource group name.
1. Keep this as internal usage (by default in the deployer.json, this is not provided).

## Test
1. `cd sap-hana/deploy/terraform/bootstrap/sap_deployer`
1. Add "resource_group": { "name": "nancyc-deployer-rg" } into deployer.json
1. `terraform init && terraform apply -auto-approve -var-file=deployer.json `
