### PR TITLE
Remove hyphen from variable names

### DIFF
--- a/deploy/terraform/bootstrap/sap_deployer/output.tf
+++ b/deploy/terraform/bootstrap/sap_deployer/output.tf
@@ -4,24 +4,24 @@ Description:
   Output from sap_deployer module.
 */
 
-output "deployer-id" {
-  value = module.sap_deployer.deployer-id
+output "deployer_id" {
+  value = module.sap_deployer.deployer_id
 }
 
-output "vnet-mgmt" {
-  value = module.sap_deployer.vnet-mgmt
+output "vnet_mgmt" {
+  value = module.sap_deployer.vnet_mgmt
 }
 
-output "subnet-mgmt" {
-  value = module.sap_deployer.subnet-mgmt
+output "subnet_mgmt" {
+  value = module.sap_deployer.subnet_mgmt
 }
 
-output "nsg-mgmt" {
-  value = module.sap_deployer.nsg-mgmt
+output "nsg_mgmt" {
+  value = module.sap_deployer.nsg_mgmt
 }
 
-output "deployer-uai" {
-  value = module.sap_deployer.deployer-uai
+output "deployer_uai" {
+  value = module.sap_deployer.deployer_uai
 }
 
 output "deployer" {

--- a/deploy/terraform/bootstrap/sap_deployer/scripts.tf
+++ b/deploy/terraform/bootstrap/sap_deployer/scripts.tf
@@ -8,7 +8,7 @@ resource "local_file" "scp" {
   content = templatefile("${path.module}/deployer_scp.tmpl", {
     deployer-ppk = var.sshkey.path_to_private_key,
     deployers    = module.sap_deployer.deployers,
-    deployer-ips = module.sap_deployer.deployer-pip[*].ip_address
+    deployer-ips = module.sap_deployer.deployer_pip[*].ip_address
   })
   filename             = "${terraform.workspace}/post_deployment.sh"
   file_permission      = "0660"

--- a/deploy/terraform/run/sap_deployer/output.tf
+++ b/deploy/terraform/run/sap_deployer/output.tf
@@ -4,24 +4,24 @@ Description:
   Output from sap_deployer module.
 */
 
-output "deployer-id" {
-  value = module.sap_deployer.deployer-id
+output "deployer_id" {
+  value = module.sap_deployer.deployer_id
 }
 
-output "vnet-mgmt" {
-  value = module.sap_deployer.vnet-mgmt
+output "vnet_mgmt" {
+  value = module.sap_deployer.vnet_mgmt
 }
 
-output "subnet-mgmt" {
-  value = module.sap_deployer.subnet-mgmt
+output "subnet_mgmt" {
+  value = module.sap_deployer.subnet_mgmt
 }
 
-output "nsg-mgmt" {
-  value = module.sap_deployer.nsg-mgmt
+output "nsg_mgmt" {
+  value = module.sap_deployer.nsg_mgmt
 }
 
-output "deployer-uai" {
-  value = module.sap_deployer.deployer-uai
+output "deployer_uai" {
+  value = module.sap_deployer.deployer_uai
 }
 
 output "deployer" {

--- a/deploy/terraform/terraform-units/modules/sap_deployer/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/infrastructure.tf
@@ -25,7 +25,7 @@ resource "azurerm_management_lock" "deployer" {
 }
 
 // Create/Import management vnet
-resource "azurerm_virtual_network" "vnet-mgmt" {
+resource "azurerm_virtual_network" "vnet_mgmt" {
   count               = local.enable_deployers && ! local.vnet_mgmt_exists ? 1 : 0
   name                = local.vnet_mgmt_name
   location            = azurerm_resource_group.deployer[0].location
@@ -33,22 +33,22 @@ resource "azurerm_virtual_network" "vnet-mgmt" {
   address_space       = [local.vnet_mgmt_addr]
 }
 
-data "azurerm_virtual_network" "vnet-mgmt" {
+data "azurerm_virtual_network" "vnet_mgmt" {
   count               = local.enable_deployers && local.vnet_mgmt_exists ? 1 : 0
   name                = split("/", local.vnet_mgmt_arm_id)[8]
   resource_group_name = split("/", local.vnet_mgmt_arm_id)[4]
 }
 
 // Create/Import management subnet
-resource "azurerm_subnet" "subnet-mgmt" {
+resource "azurerm_subnet" "subnet_mgmt" {
   count                = local.enable_deployers && ! local.sub_mgmt_exists ? 1 : 0
   name                 = local.sub_mgmt_name
-  resource_group_name  = local.vnet_mgmt_exists ? data.azurerm_virtual_network.vnet-mgmt[0].resource_group_name : azurerm_virtual_network.vnet-mgmt[0].resource_group_name
-  virtual_network_name = local.vnet_mgmt_exists ? data.azurerm_virtual_network.vnet-mgmt[0].name : azurerm_virtual_network.vnet-mgmt[0].name
+  resource_group_name  = local.vnet_mgmt_exists ? data.azurerm_virtual_network.vnet_mgmt[0].resource_group_name : azurerm_virtual_network.vnet_mgmt[0].resource_group_name
+  virtual_network_name = local.vnet_mgmt_exists ? data.azurerm_virtual_network.vnet_mgmt[0].name : azurerm_virtual_network.vnet_mgmt[0].name
   address_prefixes     = [local.sub_mgmt_prefix]
 }
 
-data "azurerm_subnet" "subnet-mgmt" {
+data "azurerm_subnet" "subnet_mgmt" {
   count                = local.enable_deployers && local.sub_mgmt_exists ? 1 : 0
   name                 = split("/", local.sub_mgmt_arm_id)[10]
   resource_group_name  = split("/", local.sub_mgmt_arm_id)[4]

--- a/deploy/terraform/terraform-units/modules/sap_deployer/nsg-mgmt.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/nsg-mgmt.tf
@@ -5,28 +5,28 @@ Description:
 */
 
 // Create/Import management nsg
-resource "azurerm_network_security_group" "nsg-mgmt" {
+resource "azurerm_network_security_group" "nsg_mgmt" {
   count               = local.enable_deployers && ! local.sub_mgmt_nsg_exists ? 1 : 0
   name                = local.sub_mgmt_nsg_name
   location            = azurerm_resource_group.deployer[0].location
   resource_group_name = azurerm_resource_group.deployer[0].name
 }
 
-data "azurerm_network_security_group" "nsg-mgmt" {
+data "azurerm_network_security_group" "nsg_mgmt" {
   count               = local.enable_deployers && local.sub_mgmt_nsg_exists ? 1 : 0
   name                = split("/", local.sub_mgmt_nsg_arm_id)[8]
   resource_group_name = split("/", local.sub_mgmt_nsg_arm_id)[4]
 }
 
 // Link management nsg with management vnet
-resource "azurerm_subnet_network_security_group_association" "Associate-nsg-mgmt" {
+resource "azurerm_subnet_network_security_group_association" "associate_nsg_mgmt" {
   count                     = local.enable_deployers ? signum((local.vnet_mgmt_exists ? 0 : 1) + (local.sub_mgmt_nsg_exists ? 0 : 1)) : 0
   subnet_id                 = local.sub_mgmt_deployed.id
   network_security_group_id = local.sub_mgmt_nsg_deployed.id
 }
 
 // Add SSH network security rule
-resource "azurerm_network_security_rule" "nsr-ssh" {
+resource "azurerm_network_security_rule" "nsr_ssh" {
   count                        = local.enable_deployers && ! local.sub_mgmt_nsg_exists ? 1 : 0
   name                         = "ssh"
   resource_group_name          = local.sub_mgmt_nsg_deployed.resource_group_name
@@ -42,7 +42,7 @@ resource "azurerm_network_security_rule" "nsr-ssh" {
 }
 
 // Add RDP network security rule
-resource "azurerm_network_security_rule" "nsr-rdp" {
+resource "azurerm_network_security_rule" "nsr_rdp" {
   count                        = local.enable_deployers && ! local.sub_mgmt_nsg_exists ? 1 : 0
   name                         = "rdp"
   resource_group_name          = local.sub_mgmt_nsg_deployed.resource_group_name
@@ -58,7 +58,7 @@ resource "azurerm_network_security_rule" "nsr-rdp" {
 }
 
 // Add WinRM network security rule
-resource "azurerm_network_security_rule" "nsr-winrm" {
+resource "azurerm_network_security_rule" "nsr_winrm" {
   count                        = local.enable_deployers && ! local.sub_mgmt_nsg_exists ? 1 : 0
   name                         = "winrm"
   resource_group_name          = local.sub_mgmt_nsg_deployed.resource_group_name

--- a/deploy/terraform/terraform-units/modules/sap_deployer/output.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/output.tf
@@ -5,32 +5,32 @@ Description:
 */
 
 // Unique ID for deployer
-output "deployer-id" {
+output "deployer_id" {
   value = random_id.deployer
 }
 
 // Details of management vnet that is deployed/imported
-output "vnet-mgmt" {
-  value = local.vnet_mgmt_exists ? data.azurerm_virtual_network.vnet-mgmt[0] : azurerm_virtual_network.vnet-mgmt[0]
+output "vnet_mgmt" {
+  value = local.vnet_mgmt_exists ? data.azurerm_virtual_network.vnet_mgmt[0] : azurerm_virtual_network.vnet_mgmt[0]
 }
 
 // Details of management subnet that is deployed/imported
-output "subnet-mgmt" {
-  value = local.sub_mgmt_exists ? data.azurerm_subnet.subnet-mgmt[0] : azurerm_subnet.subnet-mgmt[0]
+output "subnet_mgmt" {
+  value = local.sub_mgmt_exists ? data.azurerm_subnet.subnet_mgmt[0] : azurerm_subnet.subnet_mgmt[0]
 }
 
 // Details of the management vnet NSG that is deployed/imported
-output "nsg-mgmt" {
-  value = local.sub_mgmt_nsg_exists ? data.azurerm_network_security_group.nsg-mgmt[0] : azurerm_network_security_group.nsg-mgmt[0]
+output "nsg_mgmt" {
+  value = local.sub_mgmt_nsg_exists ? data.azurerm_network_security_group.nsg_mgmt[0] : azurerm_network_security_group.nsg_mgmt[0]
 }
 
 // Details of the user assigned identity for deployer(s)
-output "deployer-uai" {
+output "deployer_uai" {
   value = azurerm_user_assigned_identity.deployer
 }
 
 // Details of deployer pip(s)
-output "deployer-pip" {
+output "deployer_pip" {
   value = azurerm_public_ip.deployer
 }
 

--- a/deploy/terraform/terraform-units/modules/sap_deployer/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/variables_local.tf
@@ -26,7 +26,7 @@ locals {
   sub_mgmt_arm_id   = local.sub_mgmt_exists ? try(local.sub_mgmt.arm_id, "") : ""
   sub_mgmt_name     = local.sub_mgmt_exists ? "" : try(local.sub_mgmt.name, "subnet-mgmt")
   sub_mgmt_prefix   = local.sub_mgmt_exists ? "" : try(local.sub_mgmt.prefix, "10.0.0.16/28")
-  sub_mgmt_deployed = try(local.sub_mgmt_exists ? data.azurerm_subnet.subnet-mgmt[0] : azurerm_subnet.subnet-mgmt[0], null)
+  sub_mgmt_deployed = try(local.sub_mgmt_exists ? data.azurerm_subnet.subnet_mgmt[0] : azurerm_subnet.subnet_mgmt[0], null)
 
   // Management NSG
   sub_mgmt_nsg             = try(local.sub_mgmt.nsg, {})
@@ -34,7 +34,7 @@ locals {
   sub_mgmt_nsg_arm_id      = local.sub_mgmt_nsg_exists ? try(local.sub_mgmt_nsg.arm_id, "") : ""
   sub_mgmt_nsg_name        = local.sub_mgmt_nsg_exists ? "" : try(local.sub_mgmt_nsg.name, "nsg-mgmt")
   sub_mgmt_nsg_allowed_ips = local.sub_mgmt_nsg_exists ? [] : try(local.sub_mgmt_nsg.allowed_ips, ["0.0.0.0/0"])
-  sub_mgmt_nsg_deployed    = try(local.sub_mgmt_nsg_exists ? data.azurerm_network_security_group.nsg-mgmt[0] : azurerm_network_security_group.nsg-mgmt[0], null)
+  sub_mgmt_nsg_deployed    = try(local.sub_mgmt_nsg_exists ? data.azurerm_network_security_group.nsg_mgmt[0] : azurerm_network_security_group.nsg_mgmt[0], null)
 
   // Resource group and location
   rg_name = try("${var.infrastructure.resource_group.name}-${local.postfix}", format("sapdeployer-rg-%s", local.postfix))


### PR DESCRIPTION
## Problem
We want to avoid using hyphen in variable names

## Solution
Replace hyphen with underscore for variable names.
As for resource names, keep hyphen.

## Test
1. `cd sap-hana/deploy/terraform/bootstrap/sap_deployer`
1. Add "resource_group": { "name": "nancyc-deployer-rg" } into deployer.json
1. `terraform init && terraform apply -auto-approve -var-file=deployer.json `