### PR TITLE
Add scripts to help users download input json from SA

### DIFF
--- a/deploy/terraform/run/sap_deployer/util/download_input.sh
+++ b/deploy/terraform/run/sap_deployer/util/download_input.sh
@@ -24,9 +24,10 @@ function main(){
     local storage_account_name=$(read_json .deployer.storage_account_name)
     local container_name=$(read_json .deployer.container_name)
     local remote_file_name="deployer.json"
+    local remote_file_path="deployer.json"
     local local_file_path="${local_file_dir}${remote_file_name}"
 
-    json_download ${local_file_path} ${storage_account_name} ${container_name} ${remote_file_name}    
+    json_download ${local_file_path} ${storage_account_name} ${container_name} ${remote_file_path}    
 }
 
 function read_json(){
@@ -75,13 +76,23 @@ function json_download(){
     local local_file_path=$1
     local storage_account_name=$2
     local container_name=$3
-    local remote_file_name=$4
-
-    echo "Start downloading file: ${remote_file_name}"
+    local remote_file_path=$4
 
     az login --identity > /dev/null
 
-    local cmd="az storage blob download --container-name ${container_name} --file ${local_file_path} --name ${remote_file_name} --account-name ${storage_account_name}"
+    echo "Check if ${remote_file_path} exists in storage accounts"
+
+    remote_state_exists=$(az storage blob exists -c ${container_name} --name ${remote_file_path} --account-name ${storage_account_name} | jq -r .exists)
+    if [ $remote_state_exists = true ]; then
+        echo "remote file ${remote_file_path} exists"
+    else
+        echo "remote file ${remote_file_path} does not exist"
+        exit 1
+    fi
+
+    echo "Start downloading file: ${remote_file_path}"
+
+    local cmd="az storage blob download --container-name ${container_name} --file ${local_file_path} --name ${remote_file_path} --account-name ${storage_account_name}"
     eval "$cmd"
 }
 

--- a/deploy/terraform/run/sap_deployer/util/download_input.sh
+++ b/deploy/terraform/run/sap_deployer/util/download_input.sh
@@ -24,6 +24,7 @@ function main(){
     local storage_account_name=$(read_json .deployer.storage_account_name)
     local container_name=$(read_json .deployer.container_name)
     local remote_file_name="deployer.json"
+    # The path of remote file can be updated based on actual needs
     local remote_file_path="deployer.json"
     local local_file_path="${local_file_dir}${remote_file_name}"
 
@@ -80,17 +81,17 @@ function json_download(){
 
     az login --identity > /dev/null
 
-    echo "Check if ${remote_file_path} exists in storage accounts"
+    printf "%s\n" "Check if ${remote_file_path} exists in storage accounts"
 
     remote_state_exists=$(az storage blob exists -c ${container_name} --name ${remote_file_path} --account-name ${storage_account_name} | jq -r .exists)
     if [ $remote_state_exists = true ]; then
-        echo "remote file ${remote_file_path} exists"
+        printf "%s\n" "INFO: remote file ${remote_file_path} exists"
     else
-        echo "remote file ${remote_file_path} does not exist"
+        printf "%s\n" "ERROR: remote file ${remote_file_path} does not exist. storage account name = ${storage_account_name}; container name = ${container_name}" >&2
         exit 1
     fi
 
-    echo "Start downloading file: ${remote_file_path}"
+    printf "%s\n" "Start downloading file ${remote_file_path}:"
 
     local cmd="az storage blob download --container-name ${container_name} --file ${local_file_path} --name ${remote_file_path} --account-name ${storage_account_name}"
     eval "$cmd"

--- a/deploy/terraform/run/sap_deployer/util/download_input.sh
+++ b/deploy/terraform/run/sap_deployer/util/download_input.sh
@@ -21,9 +21,9 @@ function main(){
 
     check_file_exists ${target_json}
 
-    local storage_account_name=$(read_json .saplibrary.storage_account_name)
-    local container_name=$(read_json .saplibrary.container_name)
-    local remote_file_name="saplibrary.json"
+    local storage_account_name=$(read_json .deployer.storage_account_name)
+    local container_name=$(read_json .deployer.container_name)
+    local remote_file_name="deployer.json"
     local local_file_path="${local_file_dir}${remote_file_name}"
 
     json_download ${local_file_path} ${storage_account_name} ${container_name} ${remote_file_name}    

--- a/deploy/terraform/run/sap_library/util/download_input.sh
+++ b/deploy/terraform/run/sap_library/util/download_input.sh
@@ -24,6 +24,7 @@ function main(){
     local storage_account_name=$(read_json .saplibrary.storage_account_name)
     local container_name=$(read_json .saplibrary.container_name)
     local remote_file_name="saplibrary.json"
+    # The path of remote file can be updated based on actual needs
     local remote_file_path="saplibrary.json"
     local local_file_path="${local_file_dir}${remote_file_name}"
 
@@ -80,17 +81,17 @@ function json_download(){
 
     az login --identity > /dev/null
 
-    echo "Check if ${remote_file_path} exists in storage accounts"
+    printf "%s\n" "Check if ${remote_file_path} exists in storage accounts"
 
     remote_state_exists=$(az storage blob exists -c ${container_name} --name ${remote_file_path} --account-name ${storage_account_name} | jq -r .exists)
     if [ $remote_state_exists = true ]; then
-        echo "remote file ${remote_file_path} exists"
+        printf "%s\n" "INFO: remote file ${remote_file_path} exists" 
     else
-        echo "remote file ${remote_file_path} does not exist"
+        printf "%s\n" "ERROR: remote file ${remote_file_path} does not exist. storage account name = ${storage_account_name}; container name = ${container_name}" >&2
         exit 1
     fi
 
-    echo "Start downloading file: ${remote_file_path}"
+    printf "%s\n" "Start downloading file ${remote_file_path}:"
 
     local cmd="az storage blob download --container-name ${container_name} --file ${local_file_path} --name ${remote_file_path} --account-name ${storage_account_name}"
     eval "$cmd"

--- a/deploy/terraform/run/sap_system/util/download_input.sh
+++ b/deploy/terraform/run/sap_system/util/download_input.sh
@@ -29,6 +29,7 @@ function main(){
     local storage_account_name=$(read_json .saplibrary.storage_account_name)
     local container_name="sapsystem"
     local remote_file_name="${workspace}_${sid}.json"
+    # The path of remote file can be updated based on actual needs
     local remote_file_path="${workspace}/${sid}/${remote_file_name}"
     local local_file_path="${local_file_dir}${remote_file_name}"
 
@@ -93,17 +94,17 @@ function json_download(){
 
     az login --identity > /dev/null
     
-    echo "Check if ${remote_file_path} exists in storage accounts"
+    printf "%s\n" "Check if ${remote_file_path} exists in storage accounts"
 
     remote_state_exists=$(az storage blob exists -c ${container_name} --name ${remote_file_path} --account-name ${storage_account_name} | jq -r .exists)
     if [ $remote_state_exists = true ]; then
-        echo "remote file ${remote_file_path} exists"
+        printf "%s\n" "INFO: remote file ${remote_file_path} exists"
     else
-        echo "remote file ${remote_file_path} does not exist"
+        printf "%s\n" "ERROR: remote file ${remote_file_path} does not exist. storage account name = ${storage_account_name}; container name = ${container_name}" >&2
         exit 1
     fi
 
-    echo "Start downloading file:"
+    printf "%s\n" "Start downloading file ${remote_file_path}:"
 
     local cmd="az storage blob download --container-name ${container_name} --file ${local_file_path} --name ${remote_file_path} --account-name ${storage_account_name}"
     eval "$cmd"


### PR DESCRIPTION
## Problem
<Please describe what problem this PR is trying to resolve>
Users need script to download input json from SA

## Solution
<Please elaborate the solution for the problem>
Shell scripts read storage account info from sa_config.json and use az cli to download file to the local

## Tests
<Please provide steps to test the PR>

- To test download_input.sh of sapsystem: go to /run/sap_system/ execute util/download_input.sh QA Z01; then check if the QA-Z01.json shows at the working directory

- To test download_input.sh of saplibrary: go to /run/sap_library/ execute util/download_input.sh; then check if the saplibrary.json shows at the working directory

- To test download_input.sh of sapdeployer: go to /run/sap_deployer/ execute util/download_input.sh; then check if the deployer.json shows at the working directory

## Notes
<Additional comments for the PR>