### PR TITLE
fixes for deployer

### DIFF
--- a/deploy/terraform/bootstrap/sap_deployer/deployer_scp.tmpl
+++ b/deploy/terraform/bootstrap/sap_deployer/deployer_scp.tmpl
@@ -1,11 +1,18 @@
-%{~ for index, deployer in deployers ~}
-ssh -i ${deployer-ppk}  -o StrictHostKeyChecking=no ${deployer.authentication.username}@${deployer-ips[index]} "mkdir -p ~/.deployer/"
-%{ endfor ~}
+local_file_dir=$(dirname "$BASH_SOURCE")
+
 
 %{~ for index, deployer in deployers ~}
-scp -i ${deployer-ppk} -o StrictHostKeyChecking=no ../deployer.terraform.tfstate ${deployer.authentication.username}@${deployer-ips[index]}:~/.config/deployer.terraform.tfstate
+ssh -i ${deployer-ppk}  -o StrictHostKeyChecking=no ${deployer.authentication.username}@${deployer-ips[index]} "mkdir -p ~/.config/"
 %{ endfor ~}
 
+printf "%s\n" "Start uploading deployer tfstate"
+
 %{~ for index, deployer in deployers ~}
-scp -i ${deployer-ppk} -o StrictHostKeyChecking=no ../deployer.json ${deployer.authentication.username}@${deployer-ips[index]}:~/.config/deployer.json
+scp -i ${deployer-ppk} -o StrictHostKeyChecking=no $${local_file_dir}/../deployer.terraform.tfstate ${deployer.authentication.username}@${deployer-ips[index]}:~/.config/deployer.terraform.tfstate
+%{ endfor ~}
+
+printf "%s\n" "Start uploading deployer json"
+
+%{~ for index, deployer in deployers ~}
+scp -i ${deployer-ppk} -o StrictHostKeyChecking=no $${local_file_dir}/../deployer.json ${deployer.authentication.username}@${deployer-ips[index]}:~/.config/deployer.json
 %{ endfor ~}

--- a/deploy/terraform/bootstrap/sap_deployer/scripts.tf
+++ b/deploy/terraform/bootstrap/sap_deployer/scripts.tf
@@ -11,7 +11,7 @@ resource "local_file" "scp" {
     deployer-ips = module.sap_deployer.deployer_pip[*].ip_address
   })
   filename             = "${terraform.workspace}/post_deployment.sh"
-  file_permission      = "0660"
+  file_permission      = "0770"
   directory_permission = "0770"
 }
 

--- a/deploy/terraform/terraform-units/modules/sap_system/deployer/imports.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/deployer/imports.tf
@@ -15,25 +15,25 @@ data "terraform_remote_state" "deployer" {
 
 // Import deployer management vnet
 data "azurerm_virtual_network" "vnet-mgmt" {
-  name                = data.terraform_remote_state.deployer.outputs.vnet-mgmt.name
-  resource_group_name = data.terraform_remote_state.deployer.outputs.vnet-mgmt.resource_group_name
+  name                = data.terraform_remote_state.deployer.outputs.vnet_mgmt.name
+  resource_group_name = data.terraform_remote_state.deployer.outputs.vnet_mgmt.resource_group_name
 }
 
 // Import deployer management subnet
 data "azurerm_subnet" "subnet-mgmt" {
-  name                 = data.terraform_remote_state.deployer.outputs.subnet-mgmt.name
-  resource_group_name  = data.terraform_remote_state.deployer.outputs.subnet-mgmt.resource_group_name
-  virtual_network_name = data.terraform_remote_state.deployer.outputs.subnet-mgmt.virtual_network_name
+  name                 = data.terraform_remote_state.deployer.outputs.subnet_mgmt.name
+  resource_group_name  = data.terraform_remote_state.deployer.outputs.subnet_mgmt.resource_group_name
+  virtual_network_name = data.terraform_remote_state.deployer.outputs.subnet_mgmt.virtual_network_name
 }
 
 // Import deployer management nsg
 data "azurerm_network_security_group" "nsg-mgmt" {
-  name                = data.terraform_remote_state.deployer.outputs.nsg-mgmt.name
-  resource_group_name = data.terraform_remote_state.deployer.outputs.nsg-mgmt.resource_group_name
+  name                = data.terraform_remote_state.deployer.outputs.nsg_mgmt.name
+  resource_group_name = data.terraform_remote_state.deployer.outputs.nsg_mgmt.resource_group_name
 }
 
 // Import UAI
 data "azurerm_user_assigned_identity" "deployer" {
-  name                = data.terraform_remote_state.deployer.outputs.deployer-uai.name
-  resource_group_name = data.terraform_remote_state.deployer.outputs.deployer-uai.resource_group_name
+  name                = data.terraform_remote_state.deployer.outputs.deployer_uai.name
+  resource_group_name = data.terraform_remote_state.deployer.outputs.deployer_uai.resource_group_name
 }


### PR DESCRIPTION
## Problem
To fix problems found during integration test.

## Solution
1. Fixed remote folder from `.deployer` to `.config`.
1. Fixed import resource name in `sap_system` with underscore, instead of hyphen.
1. Make `post_deployment.sh` runnable from anywhere.
1. Change file permission of `post_deployment.sh`  to 770.

## Tests
1. `cd  sap-hana/deploy/terraform/bootstrap/sap_deployer && terraform apply -auto-approve -var-file=deployer.json`
1. Try to upload files:
```
sap_deployer nancyc$ default/post_deployment.sh 
Start uploading deployer tfstate
deployer.terraform.tfstate                                                                            100%   52KB 515.1KB/s   00:00    
Start uploading deployer json
deployer.json                                                                                         100%  218     9.0KB/s   00:00 
```

## Notes
N/A