### PR TITLE
force a new deployment of json if the content of input json changed

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_library/remote_file.tf
+++ b/deploy/terraform/terraform-units/modules/sap_library/remote_file.tf
@@ -9,7 +9,10 @@ resource "azurerm_storage_blob" "deployer_json" {
   storage_account_name   = local.sa_tfstate.name
   storage_container_name = local.storagecontainer_deployer.name
   type                   = "Block"
-  source                 = pathexpand("~/.config/${local.storagecontainer_deployer.name}.json")
+  // TODO: azure is working on enable content_md5. It will force a new deployment if the value for content_md5 is changed, 
+  // When this feature is launched, we can choose to use "source" combined with content_md5
+  // https://github.com/terraform-providers/terraform-provider-azurerm/pull/7786
+  source_content         = file(pathexpand("~/.config/${local.storagecontainer_deployer.name}.json"))
 }
 
 // Upload saplibrary.json to saplibrary container
@@ -18,5 +21,8 @@ resource "azurerm_storage_blob" "saplibrary_json" {
   storage_account_name   = local.sa_tfstate.name
   storage_container_name = local.storagecontainer_saplibrary.name
   type                   = "Block"
-  source                 = "${path.root}/${local.storagecontainer_saplibrary.name}.json"
+  // TODO: azure is working on enable content_md5. It will force a new deployment if the value for content_md5 is changed, 
+  // When this feature is launched, we can choose to use "source" combined with content_md5
+  // https://github.com/terraform-providers/terraform-provider-azurerm/pull/7786
+  source_content         = file("${path.root}/${local.storagecontainer_saplibrary.name}.json")
 }

--- a/deploy/terraform/terraform-units/modules/sap_system/saplibrary/remote_file.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/saplibrary/remote_file.tf
@@ -9,5 +9,8 @@ resource "azurerm_storage_blob" "sapsystem_json" {
   storage_account_name   = local.sa_tfstate.name
   storage_container_name = local.storagecontainer_sapsystem.name
   type                   = "Block"
-  source                 = "${path.root}/${local.landscape_id}_${local.sid}.json"
+  // TODO: azure is working on enable content_md5. It will force a new deployment if the value for content_md5 is changed, 
+  // When this feature is launched, we can choose to use "source" combined with content_md5
+  // https://github.com/terraform-providers/terraform-provider-azurerm/pull/7786
+  source_content         = file("${path.root}/${local.landscape_id}_${local.sid}.json")
 }


### PR DESCRIPTION
## Problem
<Please describe what problem this PR is trying to resolve>
Currently, using "source" at azurerm_storage_blob will not lead to the redeployment of the input json even if the json is changed

## Solution
<Please elaborate the solution for the problem>
Change "source" to "source_content", then after the content of json is changed, it will be redeployed.

## Tests
<Please provide steps to test the PR>

Edit .config/deployer.json
Then under /run/sap_library, execute util/terraform.sh
![image](https://user-images.githubusercontent.com/62584551/89937087-7c631880-dbc9-11ea-9a25-92e5217fbc02.png)


Edit /run/sap_library/saplibrary.json
Then under /run/sap_library, execute util/terraform.sh
![image](https://user-images.githubusercontent.com/62584551/89936414-728ce580-dbc8-11ea-99d3-451fef690684.png)

## Notes
<Additional comments for the PR>