### PR TITLE
Set default location to eastus for deployer

### DIFF
--- a/deploy/terraform/bootstrap/sap_deployer/deployer.json
+++ b/deploy/terraform/bootstrap/sap_deployer/deployer.json
@@ -1,6 +1,6 @@
 {
   "infrastructure": {
-    "region": "westus2"
+    "region": "eastus"
   },
   "sshkey": {
     "path_to_public_key": "~/.ssh/id_rsa.pub",

--- a/deploy/terraform/terraform-units/modules/sap_deployer/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/variables_local.tf
@@ -38,7 +38,7 @@ locals {
 
   // Resource group and location
   rg_name = try(var.infrastructure.resource_group.name, format("sapdeployer-rg-%s", local.postfix))
-  region  = try(var.infrastructure.region, "westus2")
+  region  = try(var.infrastructure.region, "eastus")
 
   // Deployer(s) information from input
   deployer_input = var.deployers


### PR DESCRIPTION
## Problem
`sap_library` and `sap_system` use `eastus` as default region.

## Solution
Change `deployer.json` to use `eastus` as default.

## Tests
N/A

## Notes
N/A