### PR TITLE
Change default sap_system settings

### DIFF
--- a/deploy/terraform/run/sap_system/sapsystem.json
+++ b/deploy/terraform/run/sap_system/sapsystem.json
@@ -6,6 +6,23 @@
       "is_existing": "false",
       "arm_id": "",
       "name": "azure-sap-system-rg"
+    },
+    "vnets": {
+      "sap": {
+        "address_space": "10.1.0.0/16",
+        "subnet_admin": {
+          "prefix": "10.1.1.0/24"
+        },
+        "subnet_db": {
+          "prefix": "10.1.2.0/24"
+        },
+        "subnet_iscsi": {
+          "prefix": "10.1.3.0/24"
+        },
+        "subnet_app": {
+          "prefix": "10.1.4.0/24"
+        }
+      }
     }
   },
   "jumpboxes": {

--- a/deploy/terraform/run/sap_system/sapsystem.json
+++ b/deploy/terraform/run/sap_system/sapsystem.json
@@ -1,6 +1,6 @@
 {
   "infrastructure": {
-    "landscape": "PROD",
+    "landscape": "DEMO",
     "region": "eastus",
     "resource_group": {
       "is_existing": "false",
@@ -17,6 +17,7 @@
       "platform": "HANA",
       "high_availability": false,
       "db_version": "2.00.050",
+      "size": "Demo",
       "credentials": {
         "db_systemdb_password": "<db_systemdb_password>",
         "os_sidadm_password": "<os_sidadm_password>",

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/variables_local.tf
@@ -24,6 +24,8 @@ variable "ppg" {
 
 # Set defaults
 locals {
+  # Name of the landscape
+  landscape_id = try(var.infrastructure.landscape, "DEMO")
 
   # Admin subnet
   var_sub_admin    = try(var.infrastructure.vnets.sap.subnet_admin, {})


### PR DESCRIPTION
## Problem
1. Size is not in the default sapsystem.json
1. landscape PROD by default seems scary :)
1. prefixes are often required to be changed if there are several sap systems to be deployed.

## Solution
1. Add size to sapsystem.json
1. Change default landscape to DEMO
1. Add default prefixes section to sapsystem.json

## Tests
1. locally do terraform plan with different demo size, and observe number of resources changes.

## Notes
N/A