### PR TITLE
add deployer pip to allowed ips

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_deployer/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/variables_local.tf
@@ -33,7 +33,8 @@ locals {
   sub_mgmt_nsg_exists      = try(local.sub_mgmt_nsg.is_existing, false)
   sub_mgmt_nsg_arm_id      = local.sub_mgmt_nsg_exists ? try(local.sub_mgmt_nsg.arm_id, "") : ""
   sub_mgmt_nsg_name        = local.sub_mgmt_nsg_exists ? "" : try(local.sub_mgmt_nsg.name, "nsg-mgmt")
-  sub_mgmt_nsg_allowed_ips = local.sub_mgmt_nsg_exists ? [] : try(local.sub_mgmt_nsg.allowed_ips, ["0.0.0.0/0"])
+  deployer_pip_list        = azurerm_public_ip.deployer[*].ip_address
+  sub_mgmt_nsg_allowed_ips = local.sub_mgmt_nsg_exists ? [] : try(concat(local.sub_mgmt_nsg.allowed_ips, local.deployer_pip_list), ["0.0.0.0/0"])
   sub_mgmt_nsg_deployed    = try(local.sub_mgmt_nsg_exists ? data.azurerm_network_security_group.nsg_mgmt[0] : azurerm_network_security_group.nsg_mgmt[0], null)
 
   // Resource group and location


### PR DESCRIPTION
## Problem
Deployer pip(s) is not in the allowed_ip for SSH rule in mgmt nsg.
This cause timeout issue with remote_exec to copy over ansible files.

## Solution
Add deployer pip(s) to allowed_ip list.

## Tests
1. `cd sap-hana/deploy/terraform/bootstrap/sap_deployer`
2. add allowed_ip in deployer.json:
```
{
  "infrastructure": {
    "region": "westus2",
    "vnets": {
      "management": {
        "subnet_mgmt": {
          "nsg": {
            "allowed_ips": ["67.160.0.0/16"]
          }
        }
      }
    }
  },
  "sshkey": {
    "path_to_public_key": "~/.ssh/id_rsa.pub",
    "path_to_private_key": "~/.ssh/id_rsa"
  },
  "options": {
    "enable_secure_transfer": true
  }
}
```
3. `terraform init && terraform apply -auto-approve -var-file=deployer.json`
4. See ip added:
![image](https://user-images.githubusercontent.com/38501271/90073478-21572180-dcae-11ea-9dc4-8bab46600fee.png)
 

## Notes
N/A