### PR TITLE
Use local SSH keypair for sapsystem by default

### DIFF
--- a/deploy/terraform/run/sap_system/sapsystem.json
+++ b/deploy/terraform/run/sap_system/sapsystem.json
@@ -90,8 +90,8 @@
     }
   },
   "sshkey": {
-    "path_to_public_key": "~/.ssh/id_rsa.pub",
-    "path_to_private_key": "~/.ssh/id_rsa"
+    "path_to_public_key": "sshkey.pub",
+    "path_to_private_key": "sshkey"
   },
   "options": {
     "enable_secure_transfer": true,


### PR DESCRIPTION
## Problem
1. It is required to not use SSH keypair under ~/.ssh by default.

## Solution
1. Change to use SSH keypair under workspace by default.

## Tests
<Please provide steps to test the PR>

## Notes
<Additional comments for the PR>