### PR TITLE
Always create resources despite of fail of validation step

### DIFF
--- a/.pipeline/templates/saplib/create-saplib-steps.yml
+++ b/.pipeline/templates/saplib/create-saplib-steps.yml
@@ -32,8 +32,8 @@ steps:
       terraform apply -auto-approve -var-file=${input} ${repo_dir}/deploy/terraform/bootstrap/sap_library/ 2>$HOME/.log/$(Build.BuildId)_apply_error.log 2>&1>$HOME/.log/$(Build.BuildId)_apply.log
       if [ -s $HOME/.log/$(Build.BuildId)_apply_error.log ]; then cat $HOME/.log/$(Build.BuildId)_apply_error.log; exit 1; fi;
       '
-
     displayName: "Deploy saplibrary: Branch ${{parameters.branch_name}}"
+    condition: or(succeededOrFailed(), always())
     env:
       ARM_CLIENT_ID: $(hana-pipeline-spn-id)
       ARM_CLIENT_SECRET: $(hana-pipeline-spn-pw)

--- a/.pipeline/templates/sapsystem/create-sapsystem-steps.yml
+++ b/.pipeline/templates/sapsystem/create-sapsystem-steps.yml
@@ -89,6 +89,7 @@ steps:
       if [ -s ~/.log/$(Build.BuildId)_apply_error.log ]; then cat ~/.log/$(Build.BuildId)_apply_error.log; exit 1; fi;
       '
     displayName: "Deploy new sap system: Branch ${{parameters.branch_name}}"
+    condition: or(succeededOrFailed(), always())
     env:
       ARM_CLIENT_ID: $(hana-pipeline-spn-id)
       ARM_CLIENT_SECRET: $(hana-pipeline-spn-pw)


### PR DESCRIPTION
## Problem
tf-sapsystem-test and tf-saplib-test will not create resource on source branch if validate job fails.
validate job sometime is expected to fail due to naming changes.

## Solution
Add condition to always run create resource job.

## Tests
<Please provide steps to test the PR>

## Notes
<Additional comments for the PR>