### PR TITLE
Enhance post_deployment script

### DIFF
--- a/deploy/terraform/bootstrap/sap_deployer/deployer_scp.tmpl
+++ b/deploy/terraform/bootstrap/sap_deployer/deployer_scp.tmpl
@@ -1,23 +1,31 @@
-local_file_dir=$(dirname "$BASH_SOURCE")
+local_file_dir=$(cd "$(dirname "$BASH_SOURCE")" && pwd)
+workspace=$(basename $${local_file_dir})
+remote_dir="~/azure_sap_automated_deployment/workspaces/local/$${workspace}"
+
+printf "%s\n" "Create remote workspace if not exists"
+
+%{~ for index, deployer in deployers ~}
+ssh -i $${local_file_dir}/${deployer-ppk}  -o StrictHostKeyChecking=no ${deployer.authentication.username}@${deployer-ips[index]} "[ -d $${remote_dir} ] && mkdir -p $${remote_dir}"
+%{ endfor ~}
 
 printf "%s\n" "Start uploading deployer tfstate"
 
 %{~ for index, deployer in deployers ~}
-scp -i ${deployer-ppk} -o StrictHostKeyChecking=no $${local_file_dir}/terraform.tfstate ${deployer.authentication.username}@${deployer-ips[index]}:~/azure_sap_automated_deployment/workspaces/local/${deployer-ws}/
+scp -i $${local_file_dir}/${deployer-ppk} -o StrictHostKeyChecking=no $${local_file_dir}/terraform.tfstate ${deployer.authentication.username}@${deployer-ips[index]}:$${remote_dir}
 %{ endfor ~}
 
 printf "%s\n" "Start uploading deployer json"
 
 %{~ for index, deployer in deployers ~}
-scp -i ${deployer-ppk} -o StrictHostKeyChecking=no $${local_file_dir}/${deployer-ws}.json ${deployer.authentication.username}@${deployer-ips[index]}:~/azure_sap_automated_deployment/workspaces/local/${deployer-ws}/
+scp -i $${local_file_dir}/${deployer-ppk} -o StrictHostKeyChecking=no $${local_file_dir}/$${workspace}.json ${deployer.authentication.username}@${deployer-ips[index]}:$${remote_dir}
 %{ endfor ~}
 
 printf "%s\n" "Start uploading deployer SSH keypair"
 
 %{~ for index, deployer in deployers ~}
-scp -i ${deployer-ppk} -o StrictHostKeyChecking=no $${local_file_dir}/${deployer-ppk} ${deployer.authentication.username}@${deployer-ips[index]}:~/azure_sap_automated_deployment/workspaces/local/${deployer-ws}/
+scp -i $${local_file_dir}/${deployer-ppk} -o StrictHostKeyChecking=no $${local_file_dir}/${deployer-ppk} ${deployer.authentication.username}@${deployer-ips[index]}:$${remote_dir}
 %{ endfor ~}
 
 %{~ for index, deployer in deployers ~}
-scp -i ${deployer-ppk} -o StrictHostKeyChecking=no $${local_file_dir}/${deployer-pk} ${deployer.authentication.username}@${deployer-ips[index]}:~/azure_sap_automated_deployment/workspaces/local/${deployer-ws}/
+scp -i $${local_file_dir}/${deployer-ppk} -o StrictHostKeyChecking=no $${local_file_dir}/${deployer-pk} ${deployer.authentication.username}@${deployer-ips[index]}:$${remote_dir}
 %{ endfor ~}

--- a/deploy/terraform/bootstrap/sap_deployer/deployer_scp.tmpl
+++ b/deploy/terraform/bootstrap/sap_deployer/deployer_scp.tmpl
@@ -1,31 +1,32 @@
 local_file_dir=$(cd "$(dirname "$BASH_SOURCE")" && pwd)
 workspace=$(basename $${local_file_dir})
 remote_dir="~/azure_sap_automated_deployment/workspaces/local/$${workspace}"
+ssh_timeout_s=10
 
 printf "%s\n" "Create remote workspace if not exists"
 
 %{~ for index, deployer in deployers ~}
-ssh -i $${local_file_dir}/${deployer-ppk}  -o StrictHostKeyChecking=no ${deployer.authentication.username}@${deployer-ips[index]} "[ -d $${remote_dir} ] && mkdir -p $${remote_dir}"
+ssh -i $${local_file_dir}/${deployer-ppk}  -o StrictHostKeyChecking=no -o ConnectTimeout=$${ssh_timeout_s} ${deployer.authentication.username}@${deployer-ips[index]} "[ -d $${remote_dir} ] && mkdir -p $${remote_dir}"
 %{ endfor ~}
 
 printf "%s\n" "Start uploading deployer tfstate"
 
 %{~ for index, deployer in deployers ~}
-scp -i $${local_file_dir}/${deployer-ppk} -o StrictHostKeyChecking=no $${local_file_dir}/terraform.tfstate ${deployer.authentication.username}@${deployer-ips[index]}:$${remote_dir}
+scp -i $${local_file_dir}/${deployer-ppk} -o StrictHostKeyChecking=no -o ConnectTimeout=$${ssh_timeout_s} $${local_file_dir}/terraform.tfstate ${deployer.authentication.username}@${deployer-ips[index]}:$${remote_dir}
 %{ endfor ~}
 
 printf "%s\n" "Start uploading deployer json"
 
 %{~ for index, deployer in deployers ~}
-scp -i $${local_file_dir}/${deployer-ppk} -o StrictHostKeyChecking=no $${local_file_dir}/$${workspace}.json ${deployer.authentication.username}@${deployer-ips[index]}:$${remote_dir}
+scp -i $${local_file_dir}/${deployer-ppk} -o StrictHostKeyChecking=no -o ConnectTimeout=$${ssh_timeout_s} $${local_file_dir}/$${workspace}.json ${deployer.authentication.username}@${deployer-ips[index]}:$${remote_dir}
 %{ endfor ~}
 
 printf "%s\n" "Start uploading deployer SSH keypair"
 
 %{~ for index, deployer in deployers ~}
-scp -i $${local_file_dir}/${deployer-ppk} -o StrictHostKeyChecking=no $${local_file_dir}/${deployer-ppk} ${deployer.authentication.username}@${deployer-ips[index]}:$${remote_dir}
+scp -i $${local_file_dir}/${deployer-ppk} -o StrictHostKeyChecking=no -o ConnectTimeout=$${ssh_timeout_s} $${local_file_dir}/${deployer-ppk} ${deployer.authentication.username}@${deployer-ips[index]}:$${remote_dir}
 %{ endfor ~}
 
 %{~ for index, deployer in deployers ~}
-scp -i $${local_file_dir}/${deployer-ppk} -o StrictHostKeyChecking=no $${local_file_dir}/${deployer-pk} ${deployer.authentication.username}@${deployer-ips[index]}:$${remote_dir}
+scp -i $${local_file_dir}/${deployer-ppk} -o StrictHostKeyChecking=no -o ConnectTimeout=$${ssh_timeout_s} $${local_file_dir}/${deployer-pk} ${deployer.authentication.username}@${deployer-ips[index]}:$${remote_dir}
 %{ endfor ~}

--- a/deploy/terraform/bootstrap/sap_deployer/scripts.tf
+++ b/deploy/terraform/bootstrap/sap_deployer/scripts.tf
@@ -9,8 +9,7 @@ resource "local_file" "scp" {
     deployer-ppk = var.sshkey.path_to_private_key,
     deployer-pk  = var.sshkey.path_to_public_key,
     deployers    = module.sap_deployer.deployers,
-    deployer-ips = module.sap_deployer.deployer_pip[*].ip_address,
-    deployer-ws  = module.sap_deployer.deployer_rg_name
+    deployer-ips = module.sap_deployer.deployer_pip[*].ip_address
   })
   filename             = "${path.cwd}/post_deployment.sh"
   file_permission      = "0770"


### PR DESCRIPTION
## Problem
There are room of improvements for post_deployement.sh.

## Solution
1. Use abs path of `local_file_dir`.
1. Introduce `workspace` which is the same as local relative path name, json file name, as well as remote relative path name.
1. Use `remote_dir` to reduce maintenance effort.

## Tests
Execute from workspace:
```
sap_deployer nancyc$ ./post_deployment.sh 
Create remote workspace if not exists
Start uploading deployer tfstate
terraform.tfstate                                                                                     100%   65KB 205.6KB/s   00:00    
Start uploading deployer json
sap_deployer.json                                                                                     100%  390     4.9KB/s   00:00    
Start uploading deployer SSH keypair
sshkey                                                                                                100% 3422    39.8KB/s   00:00    
sshkey.pub                                                                                            100%  774     9.6KB/s   00:00
``` 
Execute from one level up:
```
bootstrap nancyc$ sap_deployer/post_deployment.sh 
Create remote workspace if not exists
Start uploading deployer tfstate
terraform.tfstate                                                                                     100%   65KB 194.3KB/s   00:00    
Start uploading deployer json
sap_deployer.json                                                                                     100%  390     4.8KB/s   00:00    
Start uploading deployer SSH keypair
sshkey                                                                                                100% 3422    42.3KB/s   00:00    
sshkey.pub                                                                                            100%  774     9.5KB/s   00:00 
```

## Notes
Closes #717.