### PR TITLE
Add softlink to current terraform version

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_deployer/vm-deployer.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/vm-deployer.tf
@@ -58,7 +58,7 @@ resource "azurerm_role_assignment" "sub_user_admin" {
 resource "azurerm_linux_virtual_machine" "deployer" {
   count                           = length(local.deployers)
   name                            = format("%s%02d-vm", local.deployers[count.index].name, count.index)
-  computer_name                   = format("%s%02dvm", replace(replace(local.deployers[count.index].name,"-",""),"_",""), count.index)
+  computer_name                   = format("%s%02dvm", replace(replace(local.deployers[count.index].name, "-", ""), "_", ""), count.index)
   location                        = azurerm_resource_group.deployer[0].location
   resource_group_name             = azurerm_resource_group.deployer[0].name
   network_interface_ids           = [azurerm_network_interface.deployer[count.index].id]
@@ -161,7 +161,7 @@ resource "null_resource" "prepare-deployer" {
       "sudo mkdir -p /opt/terraform/bin/",
       "sudo wget -P /opt/terraform/terraform_0.12.29 https://releases.hashicorp.com/terraform/0.12.29/terraform_0.12.29_linux_amd64.zip",
       "sudo unzip /opt/terraform/terraform_0.12.29/terraform_0.12.29_linux_amd64.zip -d /opt/terraform/terraform_0.12.29/",
-      "sudo mv /opt/terraform/terraform_0.12.29/terraform /opt/terraform/bin/terraform",
+      "sudo ln -s /opt/terraform/terraform_0.12.29/terraform /opt/terraform/bin/terraform",
       "sudo sh -c \"echo export PATH=$PATH:/opt/terraform/bin > /etc/profile.d/deploy_server.sh\"",
       // Set env for MSI
       "sudo sh -c \"echo export ARM_USE_MSI=true >> /etc/profile.d/deploy_server.sh\"",


### PR DESCRIPTION
## Problem
terraform should not be a copy from the downloaded version.

## Solution
Create softlink instead.

## Tests
```
azureadm@deployer00:/opt/terraform$ tree .
.
├── bin
│   └── terraform -> /opt/terraform/terraform_0.12.29/terraform
└── terraform_0.12.29
    ├── terraform
    └── terraform_0.12.29_linux_amd64.zip

```
## Notes
The irrelevant change is from the editor auto spacing...