### PR TITLE
By default two SAs will be provisioned.

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_library/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_library/variables_local.tf
@@ -64,14 +64,14 @@ locals {
   sa_sapbits_arm_id                   = local.sa_sapbits_exists ? try(var.storage_account_sapbits.arm_id, "") : ""
 
   // File share for sapbits
-  sa_sapbits_file_share_enable = try(var.storage_account_sapbits.file_share.enable_deployment, false)
+  sa_sapbits_file_share_enable = try(var.storage_account_sapbits.file_share.enable_deployment, true)
   sa_sapbits_file_share_exists = try(var.storage_account_sapbits.file_share.is_existing, false)
-  sa_sapbits_file_share_name   = try(var.storage_account_sapbits.file_share.name, "")
+  sa_sapbits_file_share_name   = try(var.storage_account_sapbits.file_share.name, "sapbits")
 
   // Blob container for sapbits
-  sa_sapbits_blob_container_enable = try(var.storage_account_sapbits.sapbits_blob_container.enable_deployment, false)
+  sa_sapbits_blob_container_enable = try(var.storage_account_sapbits.sapbits_blob_container.enable_deployment, true)
   sa_sapbits_blob_container_exists = try(var.storage_account_sapbits.sapbits_blob_container.is_existing, false)
-  sa_sapbits_blob_container_name   = try(var.storage_account_sapbits.sapbits_blob_container.name, "")
+  sa_sapbits_blob_container_name   = try(var.storage_account_sapbits.sapbits_blob_container.name, "sapbits")
   sa_sapbits_container_access_type = "private"
 
   // Storage account for saplandscape, sapsystem, deployer, saplibrary


### PR DESCRIPTION
## Problem
<Please describe what problem this PR is trying to resolve>
If customers don't specify SA for saplib(sapbits), it won't be provisioned

## Solution
<Please elaborate the solution for the problem>
Provision two SAs(1 for saplib, 1 for tfstate) by default 
Provision two containers in saplib by default (1 fileshare, 1 blob container)

## Tests
<Please provide steps to test the PR>
Apply complete! Resources: 7 added, 0 changed, 0 destroyed.

## Notes
<Additional comments for the PR>