### PR TITLE
Fix web alb and vm offset when sub_web defined

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/infrastructure.tf
@@ -151,7 +151,7 @@ resource "azurerm_lb" "web" {
     name                          = "sap${lower(local.application_sid)}web"
     subnet_id                     = local.sub_web_deployed.id
     private_ip_address_allocation = "Static"
-    private_ip_address            = cidrhost(local.sub_web_defined ? local.sub_web_prefix : local.sub_app_prefix, local.ip_offsets.web_lb)
+    private_ip_address            = local.sub_web_defined ? cidrhost(local.sub_web_prefix, local.ip_offsets.web_lb) : cidrhost(local.sub_app_prefix, local.ip_offsets.web_lb)
   }
 }
 

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/variables_local.tf
@@ -102,10 +102,10 @@ locals {
   # Note: First 4 IP addresses in a subnet are reserved by Azure
   ip_offsets = {
     scs_lb = 4 + 1
-    web_lb = 4 + 3
+    web_lb = local.sub_web_defined ? (4 + 1) : (4 + 3)
     scs_vm = 4 + 6
     app_vm = 4 + 10
-    web_vm = 4 + 20
+    web_vm = local.sub_web_defined ? (4 + 2) : (4 + 20)
   }
 
   # Default VM config should be merged with any the user passes in

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/variables_local.tf
@@ -102,10 +102,10 @@ locals {
   # Note: First 4 IP addresses in a subnet are reserved by Azure
   ip_offsets = {
     scs_lb = 4 + 1
-    web_lb = local.sub_web_defined ? (4 + 1) : (4 + 3)
+    web_lb = local.sub_web_defined ? (4 + 1) : -2
     scs_vm = 4 + 6
     app_vm = 4 + 10
-    web_vm = local.sub_web_defined ? (4 + 2) : (4 + 20)
+    web_vm = local.sub_web_defined ? (4 + 2) : -3
   }
 
   # Default VM config should be merged with any the user passes in

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-webdisp.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-webdisp.tf
@@ -9,7 +9,7 @@ resource "azurerm_network_interface" "web" {
   ip_configuration {
     name                          = "IPConfig1"
     subnet_id                     = local.sub_web_deployed.id
-    private_ip_address            = cidrhost(local.sub_web_defined ? local.sub_web_prefix : local.sub_app_prefix, tonumber(count.index) + local.ip_offsets.web_vm)
+    private_ip_address            = local.sub_web_defined ? cidrhost(local.sub_web_prefix, (tonumber(count.index) + local.ip_offsets.web_vm)) : cidrhost(local.sub_app_prefix, (tonumber(count.index) * -1 + local.ip_offsets.web_vm))
     private_ip_address_allocation = "static"
   }
 }


### PR DESCRIPTION
## Problem
1. When `sub_web` is defined, web vms should start from beginning.
1. It is required to have webdisp vm to have IP from the end of the `sub_app` when `sub_web` not provided. This way reduce the change of conflicts with app IPs.

## Solution
1. Add condition to web alb and vm offset.
1. Change webdisp alb and vm to assign IP from the back of the subnet.

## Tests
Deploy with below subnet definition, successful.
```
"subnet_admin": {
 "prefix" : "10.1.1.64/27"
 },
 "subnet_db": {
 "prefix" : "10.1.1.0/28"
 },
 "subnet_app": {
 "prefix" : "10.1.1.32/27"
 },
 "subnet_web": {
 "prefix" : "10.1.1.16/28"
 }
```

![image](https://user-images.githubusercontent.com/38501271/91909145-8b396a00-ec61-11ea-9ed0-987282b3acec.png)


## Notes
1. Will have separate PR to fix in master.

2. Also the last ip can't be used - that is why web alb starts from the second last.

```
Error: Error Creating/Updating Load Balancer "PRD_web-alb" (Resource Group "azure-test-rg"): network.LoadBalancersClient#CreateOrUpdate: Failure sending request: StatusCode=400 -- Original Error: Code="PrivateIPAddressInReservedRange" Message="Private static IP address 10.1.1.63 falls within reserved IP range of subnet prefix 10.1.1.32/27." Details=[]

  on ../../../sap-hana/deploy/terraform/terraform-units/modules/sap_system/app_tier/infrastructure.tf line 144, in resource "azurerm_lb" "web":
 144: resource "azurerm_lb" "web" {
```
3. `tf-sapsystem-test` fails as expected, since there is IP change.