### PR TITLE
Improve pipeline by adding set -e

### DIFF
--- a/.pipeline/templates/ansible/ansible-playbook-steps.yml
+++ b/.pipeline/templates/ansible/ansible-playbook-steps.yml
@@ -1,5 +1,7 @@
 steps:
   - script: |
+      set -e
+      
       echo "=== Run ansible playbook from deployer ==="
       ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no -o ConnectTimeout=$(ssh_timeout_s) "$(username)"@"$(publicIP)" '
       source /etc/profile.d/deploy_server.sh

--- a/.pipeline/templates/saplib/create-saplib-steps.yml
+++ b/.pipeline/templates/saplib/create-saplib-steps.yml
@@ -1,5 +1,6 @@
 steps:
   - script: |
+      set -e
 
       echo "=== Deploy SAP library from deployer ==="
       ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no -o ConnectTimeout=$(ssh_timeout_s) "$(username)"@"$(publicIP)" '

--- a/.pipeline/templates/saplib/post-saplib-steps.yml
+++ b/.pipeline/templates/saplib/post-saplib-steps.yml
@@ -1,5 +1,7 @@
 steps:
   - script: |
+      set -e
+      
       ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no -o ConnectTimeout=$(ssh_timeout_s) "$(username)"@"$(publicIP)" '
       source /etc/profile.d/deploy_server.sh
       

--- a/.pipeline/templates/saplib/validate-saplib-steps.yml
+++ b/.pipeline/templates/saplib/validate-saplib-steps.yml
@@ -1,5 +1,7 @@
 steps:
   - script: |
+      set -e
+      
       ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no -o ConnectTimeout=$(ssh_timeout_s) "$(username)"@"$(publicIP)" '
       source /etc/profile.d/deploy_server.sh
 

--- a/.pipeline/templates/sapsystem/create-sapsystem-steps.yml
+++ b/.pipeline/templates/sapsystem/create-sapsystem-steps.yml
@@ -1,5 +1,7 @@
 steps:
   - script: |
+      set -e
+
       echo "=== Logon deployer ==="
       ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no -o ConnectTimeout=$(ssh_timeout_s) "$(username)"@"$(publicIP)" '
       source /etc/profile.d/deploy_server.sh
@@ -113,10 +115,6 @@ steps:
       terraform apply -auto-approve -var-file=${input} ${repo_dir}/deploy/terraform/run/sap_system/ 2>~/.log/$(Build.BuildId)_apply_error.log 2>&1>~/.log/$(Build.BuildId)_apply.log
       if [ -s ~/.log/$(Build.BuildId)_apply_error.log ]; then cat ~/.log/$(Build.BuildId)_apply_error.log; exit 1; fi;
       '
-
-      if [ $? -ne 0 ]; then
-        exit 1
-      fi
     displayName: "Deploy new sap system: Branch ${{parameters.branch_name}}"
     condition: or(succeededOrFailed(), always())
     env:

--- a/.pipeline/templates/sapsystem/validate-sapsystem-steps.yml
+++ b/.pipeline/templates/sapsystem/validate-sapsystem-steps.yml
@@ -1,5 +1,7 @@
 steps:
   - script: |
+      set -e
+      
       ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no -o ConnectTimeout=$(ssh_timeout_s) "$(username)"@"$(publicIP)" '
       source /etc/profile.d/deploy_server.sh
 


### PR DESCRIPTION
## Problem
Sometimes the pipeline task shows successful although failed within the remote shell script.

## Solution
Add set -e, so it will return error code from the remote shell script.

## Tests
<Please provide steps to test the PR>

## Notes
<Additional comments for the PR>