### PR TITLE
Remove default naming for deployer vnet

### DIFF
--- a/.pipeline/templates/deployer/create-deployer-steps.yml
+++ b/.pipeline/templates/deployer/create-deployer-steps.yml
@@ -12,6 +12,7 @@ steps:
       cp $HOME/.ssh/id_rsa.pub sshkey.pub
 
       cp ${repo_path}/deploy/terraform/bootstrap/sap_deployer/deployer.json deployer.json
+      [[ -f ${input} ]] ||
       cat deployer.json | jq --arg allowed_ip "$(agent_ip)" --arg rg_name "${deployer_rg}" '.infrastructure += {
         landscape: $(Build.BuildId),
         resource_group: {

--- a/.pipeline/templates/deployer/validate-deployer-steps.yml
+++ b/.pipeline/templates/deployer/validate-deployer-steps.yml
@@ -8,6 +8,9 @@ steps:
       git checkout $(sourceBranchName)
 
       cd ${ws_dir}
+      cp ${repo_path}/deploy/terraform/bootstrap/sap_deployer/deployer.json deployer.json
+      merge_json=$(jq -s '.[0] * .[1]' deployer.json ${input})
+      echo ${merge_json} > ${input}
       terraform plan -var-file=${input} ${repo_path}/deploy/terraform/bootstrap/sap_deployer/ > plan_output.log
       cat plan_output.log
       

--- a/.pipeline/templates/deployer/validate-deployer-steps.yml
+++ b/.pipeline/templates/deployer/validate-deployer-steps.yml
@@ -10,7 +10,7 @@ steps:
       cd ${ws_dir}
       cp ${repo_path}/deploy/terraform/bootstrap/sap_deployer/deployer.json deployer.json
       merge_json=$(jq -s '.[0] * .[1]' deployer.json ${input})
-      echo ${merge_json} > ${input}
+      echo ${merge_json} | jq '.' > ${input}
       terraform plan -var-file=${input} ${repo_path}/deploy/terraform/bootstrap/sap_deployer/ > plan_output.log
       cat plan_output.log
       

--- a/deploy/terraform/bootstrap/sap_deployer/deployer.json
+++ b/deploy/terraform/bootstrap/sap_deployer/deployer.json
@@ -4,6 +4,7 @@
     "landscape": "global",
     "vnets": {
       "management": {
+        "name" : "MGMT",
         "address_space": "10.0.0.0/26",
         "subnet_mgmt": {
           "prefix": "10.0.0.16/28"

--- a/deploy/terraform/terraform-units/modules/sap_deployer/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/variables_local.tf
@@ -56,11 +56,10 @@ locals {
   region             = try(var.infrastructure.region, "")
   landscape          = try(var.infrastructure.landscape, "")
   location_short     = try(var.region_mapping[local.region], "unkn")
-  vnet_mgmt_tempname = try(local.vnet_mgmt.name, "deployer")
-  prefix             = try(var.infrastructure.resource_group.name, upper(format("%s-%s-%s", local.landscape, local.location_short, local.vnet_mgmt_tempname)))
+  vnet_mgmt_tempname = local.vnet_mgmt.name
+  prefix             = try(var.infrastructure.resource_group.name, upper(format("%s-%s-%s", local.landscape, local.location_short, substr(local.vnet_mgmt_tempname,0,7))))
   sa_prefix          = lower(format("%s%s%sdiag", substr(local.landscape,0,5), local.location_short, substr(local.vnet_mgmt_tempname,0,7)))
   rg_name            = try(var.infrastructure.resource_group.name,format("%s-INFRASTRUCTURE", local.prefix))
-
 
   // Management vnet
   vnet_mgmt        = try(var.infrastructure.vnets.management, {})

--- a/deploy/terraform/terraform-units/modules/sap_deployer/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/variables_local.tf
@@ -63,16 +63,16 @@ locals {
 
   // Management vnet
   vnet_mgmt        = try(var.infrastructure.vnets.management, {})
-  vnet_mgmt_exists = try(local.vnet_mgmt.is_existing, false)
-  vnet_mgmt_arm_id = local.vnet_mgmt_exists ? try(local.vnet_mgmt.arm_id, "") : ""
-  vnet_mgmt_name   = local.vnet_mgmt_exists ? "" : try(local.vnet_mgmt.name, format("%s-vnet", local.prefix))
+  vnet_mgmt_arm_id = try(local.vnet_mgmt.arm_id, "") 
+  vnet_mgmt_exists = length(local.vnet_mgmt_arm_id) > 0 ? true : false
+  vnet_mgmt_name   = local.vnet_mgmt_exists ?  split("/", local.vnet_mgmt_arm_id)[8] : format("%s-vnet", local.prefix)
   vnet_mgmt_addr   = local.vnet_mgmt_exists ? "" : try(local.vnet_mgmt.address_space, "10.0.0.0/24")
 
   // Management subnet
   sub_mgmt          = try(local.vnet_mgmt.subnet_mgmt, {})
-  sub_mgmt_exists   = try(local.sub_mgmt.is_existing, false)
-  sub_mgmt_arm_id   = local.sub_mgmt_exists ? try(local.sub_mgmt.arm_id, "") : ""
-  sub_mgmt_name     = local.sub_mgmt_exists ? "" : try(local.sub_mgmt.name, format("%s_deployment-subnet", local.prefix))
+  sub_mgmt_arm_id   = try(local.sub_mgmt.arm_id, "") 
+  sub_mgmt_exists   = length(local.sub_mgmt_arm_id) > 0 ? true : false
+  sub_mgmt_name     = local.sub_mgmt_exists ? split("/", local.sub_mgmt_arm_id)[10] : try(local.sub_mgmt.name, format("%s_deployment-subnet", local.prefix))
   sub_mgmt_prefix   = local.sub_mgmt_exists ? "" : try(local.sub_mgmt.prefix, "10.0.0.16/28")
   sub_mgmt_deployed = try(local.sub_mgmt_exists ? data.azurerm_subnet.subnet_mgmt[0] : azurerm_subnet.subnet_mgmt[0], null)
 


### PR DESCRIPTION
## Problem
Deployer VNet had default naming

## Solution
Removing the default naming for deployer VNet

## Tests
<Please provide steps to test the PR>

## Notes
Closes https://github.com/Azure/sap-hana/issues/750 