### PR TITLE
First iteration: Add key vaults to sap_deployer

### DIFF
--- a/deploy/terraform/bootstrap/sap_deployer/deployer_scp.tmpl
+++ b/deploy/terraform/bootstrap/sap_deployer/deployer_scp.tmpl
@@ -3,30 +3,28 @@ workspace=$(basename $${local_file_dir})
 remote_dir="~/Azure_SAP_Automated_Deployment/WORKSPACES/LOCAL/$${workspace}"
 ssh_timeout_s=10
 
+temp_file=$(mktemp)
+vault_name=${user_vault_name}
+ppk_name=${ppk_name}
+ppk=$(az keyvault secret show --vault-name $${vault_name} --name $${ppk_name} | jq -r .value)
+echo "$${ppk}" > $${temp_file}
+
 printf "%s\n" "Create remote workspace if not exists"
 
 %{~ for index, deployer in deployers ~}
-ssh -i $${local_file_dir}/${deployer-ppk}  -o StrictHostKeyChecking=no -o ConnectTimeout=$${ssh_timeout_s} ${deployer.authentication.username}@${deployer-ips[index]} "[ -d $${remote_dir} ] && mkdir -p $${remote_dir}"
+ssh -i $${temp_file}  -o StrictHostKeyChecking=no -o ConnectTimeout=$${ssh_timeout_s} ${deployer.authentication.username}@${deployer-ips[index]} "[ -d $${remote_dir} ] && mkdir -p $${remote_dir}"
 %{ endfor ~}
 
 printf "%s\n" "Start uploading deployer tfstate"
 
 %{~ for index, deployer in deployers ~}
-scp -i $${local_file_dir}/${deployer-ppk} -o StrictHostKeyChecking=no -o ConnectTimeout=$${ssh_timeout_s} $${local_file_dir}/terraform.tfstate ${deployer.authentication.username}@${deployer-ips[index]}:$${remote_dir}
+scp -i $${temp_file} -o StrictHostKeyChecking=no -o ConnectTimeout=$${ssh_timeout_s} $${local_file_dir}/terraform.tfstate ${deployer.authentication.username}@${deployer-ips[index]}:$${remote_dir}
 %{ endfor ~}
 
 printf "%s\n" "Start uploading deployer json"
 
 %{~ for index, deployer in deployers ~}
-scp -i $${local_file_dir}/${deployer-ppk} -o StrictHostKeyChecking=no -o ConnectTimeout=$${ssh_timeout_s} $${local_file_dir}/$${workspace}.json ${deployer.authentication.username}@${deployer-ips[index]}:$${remote_dir}
+scp -i $${temp_file} -o StrictHostKeyChecking=no -o ConnectTimeout=$${ssh_timeout_s} $${local_file_dir}/$${workspace}.json ${deployer.authentication.username}@${deployer-ips[index]}:$${remote_dir}
 %{ endfor ~}
 
-printf "%s\n" "Start uploading deployer SSH keypair"
-
-%{~ for index, deployer in deployers ~}
-scp -i $${local_file_dir}/${deployer-ppk} -o StrictHostKeyChecking=no -o ConnectTimeout=$${ssh_timeout_s} $${local_file_dir}/${deployer-ppk} ${deployer.authentication.username}@${deployer-ips[index]}:$${remote_dir}
-%{ endfor ~}
-
-%{~ for index, deployer in deployers ~}
-scp -i $${local_file_dir}/${deployer-ppk} -o StrictHostKeyChecking=no -o ConnectTimeout=$${ssh_timeout_s} $${local_file_dir}/${deployer-pk} ${deployer.authentication.username}@${deployer-ips[index]}:$${remote_dir}
-%{ endfor ~}
+rm $${temp_file}

--- a/deploy/terraform/bootstrap/sap_deployer/providers.tf
+++ b/deploy/terraform/bootstrap/sap_deployer/providers.tf
@@ -25,5 +25,6 @@ terraform {
     local    = { version = "~> 1.4" }
     random   = { version = "~> 2.2" }
     null     = { version = "~> 2.1" }
+    tls      = { version = "~> 2.2" }
   }
 }

--- a/deploy/terraform/bootstrap/sap_deployer/scripts.tf
+++ b/deploy/terraform/bootstrap/sap_deployer/scripts.tf
@@ -2,17 +2,17 @@
 Description:
 
   Generate post-deployment scripts.
+
 */
 
 resource "local_file" "scp" {
   content = templatefile("${path.module}/deployer_scp.tmpl", {
-    deployer-ppk = var.sshkey.path_to_private_key,
-    deployer-pk  = var.sshkey.path_to_public_key,
-    deployers    = module.sap_deployer.deployers,
-    deployer-ips = module.sap_deployer.deployer_pip[*].ip_address
+    user_vault_name = module.sap_deployer.user_vault_name,
+    ppk_name        = module.sap_deployer.ppk_name,
+    deployers       = module.sap_deployer.deployers,
+    deployer-ips    = module.sap_deployer.deployer_pip[*].ip_address
   })
   filename             = "${path.cwd}/post_deployment.sh"
   file_permission      = "0770"
   directory_permission = "0770"
 }
-

--- a/deploy/terraform/run/sap_deployer/providers.tf
+++ b/deploy/terraform/run/sap_deployer/providers.tf
@@ -14,7 +14,7 @@ Description:
 */
 
 provider "azurerm" {
-  version = "~> 2.10"
+  version = "~> 2.25.0"
   features {}
 }
 
@@ -25,5 +25,6 @@ terraform {
     local    = { version = "~> 1.4" }
     random   = { version = "~> 2.2" }
     null     = { version = "~> 2.1" }
+    tls      = { version = "~> 2.2" }
   }
 }

--- a/deploy/terraform/terraform-units/modules/sap_deployer/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/infrastructure.tf
@@ -134,7 +134,11 @@ resource "azurerm_key_vault_access_policy" "kv_user_portal" {
 
 // Using TF tls to generate SSH key pair and store in user KV
 resource "tls_private_key" "deployer" {
-  count     = local.enable_deployers && local.enable_key ? 1 : 0
+  count = (
+    local.enable_deployers
+    && local.enable_key
+    && (try(file(var.sshkey.path_to_public_key), "") == "" ? true : false)
+  ) ? 1 : 0
   algorithm = "RSA"
   rsa_bits  = 2048
 }

--- a/deploy/terraform/terraform-units/modules/sap_deployer/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/infrastructure.tf
@@ -20,7 +20,7 @@ resource "azurerm_resource_group" "deployer" {
 
 // Create/Import management vnet
 resource "azurerm_virtual_network" "vnet_mgmt" {
-  count               = local.enable_deployers && ! local.vnet_mgmt_exists ? 1 : 0
+  count               = (local.enable_deployers && ! local.vnet_mgmt_exists) ? 1 : 0
   name                = local.vnet_mgmt_name
   location            = azurerm_resource_group.deployer[0].location
   resource_group_name = azurerm_resource_group.deployer[0].name
@@ -28,14 +28,14 @@ resource "azurerm_virtual_network" "vnet_mgmt" {
 }
 
 data "azurerm_virtual_network" "vnet_mgmt" {
-  count               = local.enable_deployers && local.vnet_mgmt_exists ? 1 : 0
+  count               = (local.enable_deployers && local.vnet_mgmt_exists) ? 1 : 0
   name                = split("/", local.vnet_mgmt_arm_id)[8]
   resource_group_name = split("/", local.vnet_mgmt_arm_id)[4]
 }
 
 // Create/Import management subnet
 resource "azurerm_subnet" "subnet_mgmt" {
-  count                = local.enable_deployers && ! local.sub_mgmt_exists ? 1 : 0
+  count                = (local.enable_deployers && ! local.sub_mgmt_exists) ? 1 : 0
   name                 = local.sub_mgmt_name
   resource_group_name  = local.vnet_mgmt_exists ? data.azurerm_virtual_network.vnet_mgmt[0].resource_group_name : azurerm_virtual_network.vnet_mgmt[0].resource_group_name
   virtual_network_name = local.vnet_mgmt_exists ? data.azurerm_virtual_network.vnet_mgmt[0].name : azurerm_virtual_network.vnet_mgmt[0].name
@@ -43,7 +43,7 @@ resource "azurerm_subnet" "subnet_mgmt" {
 }
 
 data "azurerm_subnet" "subnet_mgmt" {
-  count                = local.enable_deployers && local.sub_mgmt_exists ? 1 : 0
+  count                = (local.enable_deployers && local.sub_mgmt_exists) ? 1 : 0
   name                 = split("/", local.sub_mgmt_arm_id)[10]
   resource_group_name  = split("/", local.sub_mgmt_arm_id)[4]
   virtual_network_name = split("/", local.sub_mgmt_arm_id)[8]
@@ -150,7 +150,7 @@ resource "tls_private_key" "deployer" {
 
 resource "azurerm_key_vault_secret" "ppk" {
   depends_on   = [azurerm_key_vault_access_policy.kv_user_portal[0]]
-  count        = local.enable_deployers && local.enable_key ? 1 : 0
+  count        = (local.enable_deployers && local.enable_key) ? 1 : 0
   name         = format("%s-sshkey", local.prefix)
   value        = local.private_key
   key_vault_id = azurerm_key_vault.kv_user[0].id
@@ -158,7 +158,7 @@ resource "azurerm_key_vault_secret" "ppk" {
 
 resource "azurerm_key_vault_secret" "pk" {
   depends_on   = [azurerm_key_vault_access_policy.kv_user_portal[0]]
-  count        = local.enable_deployers && local.enable_key ? 1 : 0
+  count        = (local.enable_deployers && local.enable_key) ? 1 : 0
   name         = format("%s-sshkey-pub", local.prefix)
   value        = local.public_key
   key_vault_id = azurerm_key_vault.kv_user[0].id

--- a/deploy/terraform/terraform-units/modules/sap_deployer/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/infrastructure.tf
@@ -52,10 +52,110 @@ data "azurerm_subnet" "subnet_mgmt" {
 // Creates boot diagnostics storage account for Deployer
 resource "azurerm_storage_account" "deployer" {
   count                     = local.enable_deployers ? 1 : 0
-  name                      = lower(format("%s%s",local.sa_prefix,substr(local.postfix,0,4)))
+  name                      = lower(format("%s%s", local.sa_prefix, substr(local.postfix, 0, 4)))
   resource_group_name       = azurerm_resource_group.deployer[0].name
   location                  = azurerm_resource_group.deployer[0].location
   account_replication_type  = "LRS"
   account_tier              = "Standard"
   enable_https_traffic_only = local.enable_secure_transfer
+}
+
+// Create private KV with access policy
+data "azurerm_client_config" "deployer" {}
+
+resource "azurerm_key_vault" "kv_prvt" {
+  count                      = local.enable_deployers ? 1 : 0
+  name                       = format("%sprvt%s", local.kv_prefix, upper(substr(local.postfix, 0, 3)))
+  location                   = azurerm_resource_group.deployer[0].location
+  resource_group_name        = azurerm_resource_group.deployer[0].name
+  tenant_id                  = data.azurerm_client_config.deployer.tenant_id
+  soft_delete_enabled        = true
+  soft_delete_retention_days = 7
+  purge_protection_enabled   = true
+
+  sku_name = "standard"
+}
+
+resource "azurerm_key_vault_access_policy" "kv_prvt_msi" {
+  count        = local.enable_deployers ? 1 : 0
+  key_vault_id = azurerm_key_vault.kv_prvt[0].id
+
+  tenant_id = data.azurerm_client_config.deployer.tenant_id
+  object_id = azurerm_user_assigned_identity.deployer.principal_id
+
+  secret_permissions = [
+    "get",
+  ]
+}
+
+// Create user KV with access policy
+resource "azurerm_key_vault" "kv_user" {
+  count                      = local.enable_deployers ? 1 : 0
+  name                       = format("%suser%s", local.kv_prefix, upper(substr(local.postfix, 0, 3)))
+  location                   = azurerm_resource_group.deployer[0].location
+  resource_group_name        = azurerm_resource_group.deployer[0].name
+  tenant_id                  = data.azurerm_client_config.deployer.tenant_id
+  soft_delete_enabled        = true
+  soft_delete_retention_days = 7
+  purge_protection_enabled   = true
+
+  sku_name = "standard"
+}
+
+resource "azurerm_key_vault_access_policy" "kv_user_msi" {
+  count        = local.enable_deployers ? 1 : 0
+  key_vault_id = azurerm_key_vault.kv_user[0].id
+
+  tenant_id = data.azurerm_client_config.deployer.tenant_id
+  object_id = azurerm_user_assigned_identity.deployer.principal_id
+
+  secret_permissions = [
+    "delete",
+    "get",
+    "list",
+    "set",
+  ]
+}
+
+resource "azurerm_key_vault_access_policy" "kv_user_portal" {
+  count        = local.enable_deployers ? 1 : 0
+  key_vault_id = azurerm_key_vault.kv_user[0].id
+
+  tenant_id = data.azurerm_client_config.deployer.tenant_id
+  object_id = data.azurerm_client_config.deployer.object_id
+
+  secret_permissions = [
+    "delete",
+    "get",
+    "list",
+    "set",
+  ]
+}
+
+// Using TF tls to generate SSH key pair and store in user KV
+resource "tls_private_key" "deployer" {
+  count     = local.enable_deployers && local.enable_key ? 1 : 0
+  algorithm = "RSA"
+  rsa_bits  = 2048
+}
+
+/*
+ To force dependency between kv access policy and secrets. Expected behavior:
+ https://github.com/terraform-providers/terraform-provider-azurerm/issues/4971
+*/
+
+resource "azurerm_key_vault_secret" "ppk" {
+  depends_on   = [azurerm_key_vault_access_policy.kv_user_portal[0]]
+  count        = local.enable_deployers && local.enable_key ? 1 : 0
+  name         = format("%s-sshkey", local.prefix)
+  value        = local.private_key
+  key_vault_id = azurerm_key_vault.kv_user[0].id
+}
+
+resource "azurerm_key_vault_secret" "pk" {
+  depends_on   = [azurerm_key_vault_access_policy.kv_user_portal[0]]
+  count        = local.enable_deployers && local.enable_key ? 1 : 0
+  name         = format("%s-sshkey-pub", local.prefix)
+  value        = local.public_key
+  key_vault_id = azurerm_key_vault.kv_user[0].id
 }

--- a/deploy/terraform/terraform-units/modules/sap_deployer/output.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/output.tf
@@ -44,3 +44,10 @@ output "deployers" {
   value = local.deployers_updated
 }
 
+output "user_vault_name" {
+  value = azurerm_key_vault.kv_user[0].name
+}
+
+output "ppk_name" {
+  value = local.enable_deployers && local.enable_key ? azurerm_key_vault_secret.ppk[0].name : ""
+}

--- a/deploy/terraform/terraform-units/modules/sap_deployer/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/variables_local.tf
@@ -96,8 +96,8 @@ locals {
   ]), "true")
 
   // By default use generated public key. Provide sshkey.path_to_public_key and path_to_private_key overides it
-  public_key  = local.enable_deployers && local.enable_key ? try(file(var.sshkey.path_to_public_key), tls_private_key.deployer[0].public_key_openssh) : null
-  private_key = local.enable_deployers && local.enable_key ? try(file(var.sshkey.path_to_private_key), tls_private_key.deployer[0].private_key_pem) : null
+  public_key  = (local.enable_deployers && local.enable_key) ? try(file(var.sshkey.path_to_public_key), tls_private_key.deployer[0].public_key_openssh) : null
+  private_key = (local.enable_deployers && local.enable_key) ? try(file(var.sshkey.path_to_private_key), tls_private_key.deployer[0].private_key_pem) : null
 
   // Deployer(s) information with default override
   enable_deployers = length(local.deployer_input) > 0 ? true : false

--- a/deploy/terraform/terraform-units/modules/sap_deployer/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/variables_local.tf
@@ -60,7 +60,7 @@ locals {
   vnet_mgmt_tempname = local.vnet_mgmt.name
   prefix             = try(var.infrastructure.resource_group.name, upper(format("%s-%s-%s", local.environment, local.location_short, substr(local.vnet_mgmt_tempname, 0, 7))))
   sa_prefix          = lower(format("%s%s%sdiag", substr(local.environment, 0, 5), local.location_short, substr(local.vnet_mgmt_tempname, 0, 7)))
-  kv_prefix          = upper(format("%s%s%s", substr(local.landscape, 0, 5), local.location_short, substr(local.vnet_mgmt_tempname, 0, 7)))
+  kv_prefix          = upper(format("%s%s%s", substr(local.environment, 0, 5), local.location_short, substr(local.vnet_mgmt_tempname, 0, 7)))
   rg_name            = try(var.infrastructure.resource_group.name, format("%s-INFRASTRUCTURE", local.prefix))
 
   // Management vnet

--- a/deploy/terraform/terraform-units/modules/sap_deployer/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/variables_local.tf
@@ -53,12 +53,14 @@ locals {
 
   // Resource group and location
 
-  region             = try(var.infrastructure.region, "")
-  environment        = try(var.infrastructure.environment, "")
-  location_short     = try(var.region_mapping[local.region], "unkn")
+  region         = try(var.infrastructure.region, "")
+  environment    = try(var.infrastructure.environment, "")
+  location_short = try(var.region_mapping[local.region], "unkn")
+
   vnet_mgmt_tempname = local.vnet_mgmt.name
   prefix             = try(var.infrastructure.resource_group.name, upper(format("%s-%s-%s", local.environment, local.location_short, substr(local.vnet_mgmt_tempname, 0, 7))))
   sa_prefix          = lower(format("%s%s%sdiag", substr(local.environment, 0, 5), local.location_short, substr(local.vnet_mgmt_tempname, 0, 7)))
+  kv_prefix          = upper(format("%s%s%s", substr(local.landscape, 0, 5), local.location_short, substr(local.vnet_mgmt_tempname, 0, 7)))
   rg_name            = try(var.infrastructure.resource_group.name, format("%s-INFRASTRUCTURE", local.prefix))
 
   // Management vnet
@@ -88,6 +90,15 @@ locals {
   // Deployer(s) information from input
   deployer_input = var.deployers
 
+  enable_key = contains(compact([
+    for deployer in local.deployer_input :
+    try(deployer.authentication.type, "key") == "key" ? true : false
+  ]), "true")
+
+  // By default use generated public key. Provide sshkey.path_to_public_key and path_to_private_key overides it
+  public_key  = local.enable_deployers && local.enable_key ? try(file(var.sshkey.path_to_public_key), tls_private_key.deployer[0].public_key_openssh) : null
+  private_key = local.enable_deployers && local.enable_key ? try(file(var.sshkey.path_to_private_key), tls_private_key.deployer[0].private_key_pem) : null
+
   // Deployer(s) information with default override
   enable_deployers = length(local.deployer_input) > 0 ? true : false
   deployers = [
@@ -107,7 +118,8 @@ locals {
         "type"     = "key",
         "username" = try(deployer.authentication.username, "azureadm"),
         "sshkey" = {
-          "path_to_private_key" = "~/.ssh/id_rsa"
+          "public_key"  = local.public_key
+          "private_key" = local.private_key
         }
       },
       "components" = [


### PR DESCRIPTION
## Problem
It is required to store secrets in KVs. 
Resolves #772.

## Solution
Add two KVs, one private, one for user to retrieve secrets.

## Tests
Deploy locally and see two KVs:
![image](https://user-images.githubusercontent.com/38501271/92509351-f97cb000-f1be-11ea-8952-119fba42d7fd.png)
See SSH saved:
![image](https://user-images.githubusercontent.com/38501271/92510803-43669580-f1c1-11ea-8077-db33962f93f0.png)
Upload files works fine:
```
$ ./post_deployment.sh 
Create remote workspace if not exists
ssh: connect to host 52.255.154.232 port 22: Operation timed out
Start uploading deployer tfstate
Warning: Permanently added '52.255.154.232' (ECDSA) to the list of known hosts.
terraform.tfstate                                                                          100%   73KB 207.5KB/s   00:00    
Start uploading deployer json
sap_deployer.json                                                                          100%  313     3.5KB/s   00:00
```

## Notes
PR #767 Add password support with KV for deployer.