### PR TITLE
First iteration: Support password with deployer

### DIFF
--- a/deploy/terraform/bootstrap/sap_deployer/deployer_scp.tmpl
+++ b/deploy/terraform/bootstrap/sap_deployer/deployer_scp.tmpl
@@ -5,26 +5,55 @@ ssh_timeout_s=10
 
 temp_file=$(mktemp)
 vault_name=${user_vault_name}
+
 ppk_name=${ppk_name}
-ppk=$(az keyvault secret show --vault-name $${vault_name} --name $${ppk_name} | jq -r .value)
-echo "$${ppk}" > $${temp_file}
+if [ ! -z $${ppk_name} ]
+then
+  printf "%s\n" "Collecting secrets from KV"
+  ppk=$(az keyvault secret show --vault-name $${vault_name} --name $${ppk_name} | jq -r .value)
+  echo "$${ppk}" > $${temp_file}
+fi
 
 printf "%s\n" "Create remote workspace if not exists"
 
-%{~ for index, deployer in deployers ~}
+%{~ for index, deployer in deployers }
+%{~ if deployer.authentication.type == "key"  }
 ssh -i $${temp_file}  -o StrictHostKeyChecking=no -o ConnectTimeout=$${ssh_timeout_s} ${deployer.authentication.username}@${deployer-ips[index]} "[ -d $${remote_dir} ] && mkdir -p $${remote_dir}"
-%{ endfor ~}
+%{~ endif }
+%{~ endfor }
+
+%{~ for index, deployer in deployers }
+%{~ if deployer.authentication.type == "password"  }
+ssh -o StrictHostKeyChecking=no -o ConnectTimeout=$${ssh_timeout_s} ${deployer.authentication.username}@${deployer-ips[index]} "[ -d $${remote_dir} ] && mkdir -p $${remote_dir}"
+%{~ endif }
+%{~ endfor }
 
 printf "%s\n" "Start uploading deployer tfstate"
 
-%{~ for index, deployer in deployers ~}
+%{~ for index, deployer in deployers }
+%{~ if deployer.authentication.type == "key"  }
 scp -i $${temp_file} -o StrictHostKeyChecking=no -o ConnectTimeout=$${ssh_timeout_s} $${local_file_dir}/terraform.tfstate ${deployer.authentication.username}@${deployer-ips[index]}:$${remote_dir}
-%{ endfor ~}
+%{~ endif }
+%{~ endfor }
+
+%{~ for index, deployer in deployers }
+%{~ if deployer.authentication.type == "password"  }
+scp -o StrictHostKeyChecking=no -o ConnectTimeout=$${ssh_timeout_s} $${local_file_dir}/terraform.tfstate ${deployer.authentication.username}@${deployer-ips[index]}:$${remote_dir}
+%{~ endif }
+%{~ endfor }
 
 printf "%s\n" "Start uploading deployer json"
 
-%{~ for index, deployer in deployers ~}
+%{~ for index, deployer in deployers }
+%{~ if deployer.authentication.type == "key"  }
 scp -i $${temp_file} -o StrictHostKeyChecking=no -o ConnectTimeout=$${ssh_timeout_s} $${local_file_dir}/$${workspace}.json ${deployer.authentication.username}@${deployer-ips[index]}:$${remote_dir}
-%{ endfor ~}
+%{~ endif }
+%{~ endfor }
+
+%{~ for index, deployer in deployers }
+%{~ if deployer.authentication.type == "password"  }
+scp -o StrictHostKeyChecking=no -o ConnectTimeout=$${ssh_timeout_s} $${local_file_dir}/$${workspace}.json ${deployer.authentication.username}@${deployer-ips[index]}:$${remote_dir}
+%{~ endif }
+%{~ endfor }
 
 rm $${temp_file}

--- a/deploy/terraform/bootstrap/sap_deployer/scripts.tf
+++ b/deploy/terraform/bootstrap/sap_deployer/scripts.tf
@@ -9,6 +9,7 @@ resource "local_file" "scp" {
   content = templatefile("${path.module}/deployer_scp.tmpl", {
     user_vault_name = module.sap_deployer.user_vault_name,
     ppk_name        = module.sap_deployer.ppk_name,
+    pwd_name        = module.sap_deployer.pwd_name,
     deployers       = module.sap_deployer.deployers,
     deployer-ips    = module.sap_deployer.deployer_pip[*].ip_address
   })

--- a/deploy/terraform/terraform-units/modules/sap_deployer/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/infrastructure.tf
@@ -163,3 +163,23 @@ resource "azurerm_key_vault_secret" "pk" {
   value        = local.public_key
   key_vault_id = azurerm_key_vault.kv_user[0].id
 }
+
+// Generate random password if password is set as authentication type, and save in KV
+resource "random_password" "deployer" {
+  count = (
+    local.enable_deployers
+    && local.enable_password
+    && local.input_pwd == null ? true : false
+  ) ? 1 : 0
+  length           = 16
+  special          = true
+  override_special = "_%@"
+}
+
+resource "azurerm_key_vault_secret" "pwd" {
+  depends_on   = [azurerm_key_vault_access_policy.kv_user_portal[0]]
+  count        = (local.enable_deployers && local.enable_password) ? 1 : 0
+  name         = format("%s-password", local.prefix)
+  value        = local.password
+  key_vault_id = azurerm_key_vault.kv_user[0].id
+}

--- a/deploy/terraform/terraform-units/modules/sap_deployer/output.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/output.tf
@@ -52,6 +52,10 @@ output "ppk_name" {
   value = local.enable_deployers && local.enable_key ? azurerm_key_vault_secret.ppk[0].name : ""
 }
 
+output "pwd_name" {
+  value = local.enable_deployers && local.enable_password ? azurerm_key_vault_secret.pwd[0].name : ""
+}
+
 output "deployer_user" {
   value = data.azurerm_client_config.deployer.object_id
 }

--- a/deploy/terraform/terraform-units/modules/sap_deployer/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/variables_local.tf
@@ -89,6 +89,15 @@ locals {
   // Deployer(s) information from input
   deployer_input = var.deployers
 
+  enable_key = contains(compact([
+    for deployer in local.deployer_input :
+    try(deployer.authentication.type, "key") == "key" ? true : false
+  ]), "true")
+
+  // By default use generated public key. Provide sshkey.path_to_public_key and path_to_private_key overides it
+  public_key  = local.enable_deployers && local.enable_key ? try(file(var.sshkey.path_to_public_key), tls_private_key.deployer[0].public_key_openssh) : null
+  private_key = local.enable_deployers && local.enable_key ? try(file(var.sshkey.path_to_private_key), tls_private_key.deployer[0].private_key_pem) : null
+
   // Deployer(s) information with default override
   enable_deployers = length(local.deployer_input) > 0 ? true : false
 

--- a/deploy/terraform/terraform-units/modules/sap_deployer/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/variables_local.tf
@@ -53,10 +53,9 @@ locals {
 
   // Resource group and location
 
-  region         = try(var.infrastructure.region, "")
-  environment    = try(var.infrastructure.environment, "")
-  location_short = try(var.region_mapping[local.region], "unkn")
-
+  region             = try(var.infrastructure.region, "")
+  environment        = try(var.infrastructure.environment, "")
+  location_short     = try(var.region_mapping[local.region], "unkn")
   vnet_mgmt_tempname = local.vnet_mgmt.name
   prefix             = try(var.infrastructure.resource_group.name, upper(format("%s-%s-%s", local.environment, local.location_short, substr(local.vnet_mgmt_tempname, 0, 7))))
   sa_prefix          = lower(format("%s%s%sdiag", substr(local.environment, 0, 5), local.location_short, substr(local.vnet_mgmt_tempname, 0, 7)))

--- a/deploy/terraform/terraform-units/modules/sap_deployer/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/variables_local.tf
@@ -95,8 +95,8 @@ locals {
   ]), "true")
 
   // By default use generated public key. Provide sshkey.path_to_public_key and path_to_private_key overides it
-  public_key  = local.enable_deployers && local.enable_key ? try(file(var.sshkey.path_to_public_key), tls_private_key.deployer[0].public_key_openssh) : null
-  private_key = local.enable_deployers && local.enable_key ? try(file(var.sshkey.path_to_private_key), tls_private_key.deployer[0].private_key_pem) : null
+  public_key  = (local.enable_deployers && local.enable_key) ? try(file(var.sshkey.path_to_public_key), tls_private_key.deployer[0].public_key_openssh) : null
+  private_key = (local.enable_deployers && local.enable_key) ? try(file(var.sshkey.path_to_private_key), tls_private_key.deployer[0].private_key_pem) : null
 
   // Deployer(s) information with default override
   enable_deployers = length(local.deployer_input) > 0 ? true : false

--- a/deploy/terraform/terraform-units/modules/sap_deployer/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/variables_local.tf
@@ -89,15 +89,6 @@ locals {
   // Deployer(s) information from input
   deployer_input = var.deployers
 
-  enable_key = contains(compact([
-    for deployer in local.deployer_input :
-    try(deployer.authentication.type, "key") == "key" ? true : false
-  ]), "true")
-
-  // By default use generated public key. Provide sshkey.path_to_public_key and path_to_private_key overides it
-  public_key  = (local.enable_deployers && local.enable_key) ? try(file(var.sshkey.path_to_public_key), tls_private_key.deployer[0].public_key_openssh) : null
-  private_key = (local.enable_deployers && local.enable_key) ? try(file(var.sshkey.path_to_private_key), tls_private_key.deployer[0].private_key_pem) : null
-
   // Deployer(s) information with default override
   enable_deployers = length(local.deployer_input) > 0 ? true : false
 
@@ -114,6 +105,15 @@ locals {
   ])
   input_pwd = length(local.input_pwd_list) > 0 ? local.input_pwd_list[0] : null
   password  = (local.enable_deployers && local.enable_password) ? try(local.input_pwd_list[0], random_password.deployer[0].result) : null
+
+  enable_key = contains(compact([
+    for deployer in local.deployer_input :
+    try(deployer.authentication.type, "key") == "key" ? true : false
+  ]), "true")
+
+  // By default use generated public key. Provide sshkey.path_to_public_key and path_to_private_key overides it
+  public_key  = (local.enable_deployers && local.enable_key) ? try(file(var.sshkey.path_to_public_key), tls_private_key.deployer[0].public_key_openssh) : null
+  private_key = (local.enable_deployers && local.enable_key) ? try(file(var.sshkey.path_to_private_key), tls_private_key.deployer[0].private_key_pem) : null
 
   deployers = [
     for idx, deployer in local.deployer_input : {

--- a/deploy/terraform/terraform-units/modules/sap_deployer/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/variables_local.tf
@@ -89,17 +89,23 @@ locals {
   // Deployer(s) information from input
   deployer_input = var.deployers
 
-  enable_key = contains(compact([
-    for deployer in local.deployer_input :
-    try(deployer.authentication.type, "key") == "key" ? true : false
-  ]), "true")
-
-  // By default use generated public key. Provide sshkey.path_to_public_key and path_to_private_key overides it
-  public_key  = (local.enable_deployers && local.enable_key) ? try(file(var.sshkey.path_to_public_key), tls_private_key.deployer[0].public_key_openssh) : null
-  private_key = (local.enable_deployers && local.enable_key) ? try(file(var.sshkey.path_to_private_key), tls_private_key.deployer[0].private_key_pem) : null
-
   // Deployer(s) information with default override
   enable_deployers = length(local.deployer_input) > 0 ? true : false
+
+  // Deployer(s) authentication method with default
+  enable_password = contains(compact([
+    for deployer in local.deployer_input :
+    try(deployer.authentication.type, "key") == "password" ? true : false
+  ]), "true")
+
+  // By default use generated password. Provide password under authentication overides it
+  input_pwd_list = compact([
+    for deployer in local.deployer_input :
+    try(deployer.authentication.password, "")
+  ])
+  input_pwd = length(local.input_pwd_list) > 0 ? local.input_pwd_list[0] : null
+  password  = (local.enable_deployers && local.enable_password) ? try(local.input_pwd_list[0], random_password.deployer[0].result) : null
+
   deployers = [
     for idx, deployer in local.deployer_input : {
       "name"                 = "deployer",
@@ -114,12 +120,13 @@ locals {
         "version"         = try(deployer.os.source_image_id, "") == "" ? "latest" : ""
       },
       "authentication" = {
-        "type"     = "key",
-        "username" = try(deployer.authentication.username, "azureadm"),
+        "type"     = try(deployer.authentication.type, "key")
+        "username" = try(deployer.authentication.username, "azureadm")
         "sshkey" = {
           "public_key"  = local.public_key
           "private_key" = local.private_key
         }
+        "password" = local.password
       },
       "components" = [
         "terraform",

--- a/deploy/terraform/terraform-units/modules/sap_deployer/vm-deployer.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/vm-deployer.tf
@@ -90,9 +90,12 @@ resource "azurerm_linux_virtual_machine" "deployer" {
     identity_ids = [azurerm_user_assigned_identity.deployer.id]
   }
 
-  admin_ssh_key {
-    username   = local.deployers[count.index].authentication.username
-    public_key = local.deployers[count.index].authentication.sshkey.public_key
+  dynamic "admin_ssh_key" {
+    for_each = range(local.deployers[count.index].authentication.sshkey.public_key == null ? 0 : 1)
+    content {
+      username   = local.deployers[count.index].authentication.username
+      public_key = local.deployers[count.index].authentication.sshkey.public_key
+    }
   }
 
   boot_diagnostics {


### PR DESCRIPTION
## Problem
Support generate and save password for deployer.
Resolves #772.

## Solution
By default, if `authentication.type` is set to `key`. If it is set to `password`, we will:
- by default generate and use random password.
- if `password` is provided in the authentication section, we use the provided password.

## Tests
Deploy with below section added in deployer.json - still uses SSH key pair.
```
  "deployers": [
    {
      "authentication": {
        "type": "key"
      }
    }
  ]
```

Deploy with below section - it creates random password and use that for the VM (also in post_deployment.sh)
```
  "deployers": [
    {
      "authentication": {
        "type": "password"
      }
    }
  ]
```

Deploy with below section - it uses the password provided for the VM (also in post_deployment.sh)
```
  "deployers": [
    {
      "authentication": {
        "type": "password",
       "password"： "2020Hey!"
      }
    }
  ]
```
## Notes
Limitation:

1. For security, the password will not be saved in post_deployment.sh, user have to retrieve the password from portal, then enter when execute the script.
2. Just like we always use one set  of SSH keypair for all deployer(s), we only support to take one password for all deployer(s) as well.