### PR TITLE
Only configure fencing when sbd not configured

### DIFF
--- a/deploy/ansible/roles/hana-os-clustering/tasks/cluster-Suse.yml
+++ b/deploy/ansible/roles/hana-os-clustering/tasks/cluster-Suse.yml
@@ -144,8 +144,10 @@
         crm configure op_defaults \$id="op-options"
         timeout="600"
 
-    - name: Ensure the STONITH Azure fence agent is created
-      when: hdb_size != "LargeInstance"
+    - name: Ensure the STONITH Azure fence agent is created when SBD not used
+      when: 
+        - hdb_size != "LargeInstance"
+        - groups['iscsi'] | length == 0
       shell: >
         crm configure primitive rsc_st_azure stonith:fence_azure_arm params
         subscriptionId="{{ sap_hana_fencing_agent_subscription_id }}"

--- a/templates/terraform-deployment-steps-daily.yaml
+++ b/templates/terraform-deployment-steps-daily.yaml
@@ -10,6 +10,13 @@ parameters:
     osImage: ''
 steps:
   - script: |
+      echo "=== Install fixed version of Terraform ==="
+      wget -q https://releases.hashicorp.com/terraform/0.12.29/terraform_0.12.29_linux_amd64.zip
+      unzip terraform_0.12.29_linux_amd64.zip -d terraform_0.12.29/
+      sudo mv terraform_0.12.29/terraform /usr/local/bin/terraform
+      terraform --version
+    displayName: "Install terraform 0.12.29"
+  - script: |
       echo '##vso[task.setvariable variable=agent_ip]$(curl -s https://ipinfo.io/json | jq -r .ip)'
     displayName: "Set agent ip"
   - script: |

--- a/templates/terraform-deployment-steps.yaml
+++ b/templates/terraform-deployment-steps.yaml
@@ -10,6 +10,13 @@ parameters:
     osImage: ''
 steps:
   - script: |
+      echo "=== Install fixed version of Terraform ==="
+      wget -q https://releases.hashicorp.com/terraform/0.12.29/terraform_0.12.29_linux_amd64.zip
+      unzip terraform_0.12.29_linux_amd64.zip -d terraform_0.12.29/
+      sudo mv terraform_0.12.29/terraform /usr/local/bin/terraform
+      terraform --version
+    displayName: "Install terraform 0.12.29"
+  - script: |
       echo '##vso[task.setvariable variable=agent_ip]$(curl -s https://ipinfo.io/json | jq -r .ip)'
     displayName: "Set agent ip"
   - script: |


### PR DESCRIPTION
## Problem
Closes #739 

## Solution
[Doc](https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/high-availability-guide-suse-pacemaker) has been updated since 2020.09.09 to not have azure fencing agent configured when SBD is used.
Adapt the same in ansible code.

## Tests
Deploy HANA HA with 1 iSCSI device, and configure cluster, see below:
```
Online: [ prddprd00l014c prddprd00l114c ]

Full list of resources:

stonith-sbd     (stonith:external/sbd): Started prddprd00l014c
 Clone Set: cln_azure-events [rsc_azure-events]
     Started: [ prddprd00l014c prddprd00l114c ]
 Clone Set: cln_SAPHanaTopology_PRD_HDB01 [rsc_SAPHanaTopology_PRD_HDB01]
     Started: [ prddprd00l014c prddprd00l114c ]
 Master/Slave Set: msl_SAPHana_PRD_HDB01 [rsc_SAPHana_PRD_HDB01]
     Masters: [ prddprd00l014c ]
     Slaves: [ prddprd00l114c ]
 Resource Group: g_ip_PRD_HDB01
     rsc_ip_PRD_HDB01   (ocf::heartbeat:IPaddr2):       Started prddprd00l014c
     rsc_nc_PRD_HDB01   (ocf::heartbeat:anything):      Started prddprd00l014c
.
```

## Notes
1. Azure scheduled event is not dependent on the STONITH method and it would be useful for clusters with SBD. Hence always configure with that.
1. Have to add fixes in this PR to fix the version of terraform, otherwise, pipeline will fail.