### PR TITLE
Add char to environment and limit to 5 char

### DIFF
--- a/.pipeline/ansible-test.yml
+++ b/.pipeline/ansible-test.yml
@@ -24,31 +24,31 @@ stages:
       - template: templates/util/prepare-agent.yml
       - template: templates/util/collect-deployer-info.yml
         parameters:
-          deployer_rg_name: "UNIT-EAUS-DEPLOYER-INFRASTRUCTURE"
+          deployer_rg_name: "UNIT-EAUS-MGMT-INFRASTRUCTURE"
       - template: templates/util/add-agent-to-deployer-nsg.yml
         parameters:
-          deployer_rg_name: "UNIT-EAUS-DEPLOYER-INFRASTRUCTURE"
+          deployer_rg_name: "UNIT-EAUS-MGMT-INFRASTRUCTURE"
       - template: templates/ansible/ansible-playbook-steps.yml
         parameters:
           branch_name: $(sourceBranchName)
-          sapsystem_rg_name: "SLES-EAUS-SAP0-PRD"
+          sapsystem_rg_name: "SLES-EAUS-SAP-PRD"
       - template: templates/util/remove-agent-from-deployer-nsg.yml
         parameters:
-          deployer_rg_name: "UNIT-EAUS-DEPLOYER-INFRASTRUCTURE"
+          deployer_rg_name: "UNIT-EAUS-MGMT-INFRASTRUCTURE"
   - job: runAnsibleRHEL
     timeoutInMinutes: 120
     steps:
       - template: templates/util/prepare-agent.yml
       - template: templates/util/collect-deployer-info.yml
         parameters:
-          deployer_rg_name: "UNIT-EAUS-DEPLOYER-INFRASTRUCTURE"
+          deployer_rg_name: "UNIT-EAUS-MGMT-INFRASTRUCTURE"
       - template: templates/util/add-agent-to-deployer-nsg.yml
         parameters:
-          deployer_rg_name: "UNIT-EAUS-DEPLOYER-INFRASTRUCTURE"
+          deployer_rg_name: "UNIT-EAUS-MGMT-INFRASTRUCTURE"
       - template: templates/ansible/ansible-playbook-steps.yml
         parameters:
           branch_name: $(sourceBranchName)
-          sapsystem_rg_name: "RHEL-EAUS-SAP0-PRD"
+          sapsystem_rg_name: "RHEL-EAUS-SAP-PRD"
       - template: templates/util/remove-agent-from-deployer-nsg.yml
         parameters:
-          deployer_rg_name: "UNIT-EAUS-DEPLOYER-INFRASTRUCTURE"
+          deployer_rg_name: "UNIT-EAUS-MGMT-INFRASTRUCTURE"

--- a/.pipeline/templates/deployer/create-deployer-steps.yml
+++ b/.pipeline/templates/deployer/create-deployer-steps.yml
@@ -1,10 +1,22 @@
 steps:
   - script: |
       repo_path=$(pwd)
-      deployer_rg=${{parameters.deployer_rg_name}}
+
+      # Modify environment value so it starts with u and with length of 5
+      deployer_env=${{parameters.deployer_env}}
+      buildId=$(Build.BuildId)
+      isRelease=${deployer_env%%$buildId*}
+      if [ -z "${isRelease}" ]
+      then 
+        deployer_prefix="U$(echo $(Build.BuildId) | rev | cut -c1-4 | rev)"
+      else
+        deployer_prefix=${deployer_env}
+      fi
+
+      deployer_rg="${deployer_prefix}-EAUS-MGMT-INFRASTRUCTURE"
       ws_dir=$(Agent.BuildDirectory)/Azure_SAP_Automated_Deployment/WORKSPACES/LOCAL/${deployer_rg}
       input=${ws_dir}/${deployer_rg}.json
-      environment=$(Build.BuildId)
+      
       git checkout ${{parameters.branch_name}}
 
       mkdir -p ${ws_dir}; cd $_
@@ -14,12 +26,9 @@ steps:
       cp ${repo_path}/deploy/terraform/bootstrap/sap_deployer/deployer.json deployer.json
 
       [[ -f ${input} ]] ||
-      cat deployer.json | jq --arg rg_name "${deployer_rg}" '.infrastructure += {
-        environment: $(Build.BuildId),
-        resource_group: {
-          name: $rg_name
-        }
-      }' | jq --arg allowed_ip "$(agent_ip)" '.infrastructure.vnets.management.subnet_mgmt += {
+      cat deployer.json \
+      | jq --arg environment "${deployer_prefix}" .infrastructure.environment\ =\ \$environment \
+      | jq --arg allowed_ip "$(agent_ip)" '.infrastructure.vnets.management.subnet_mgmt += {
         nsg: {
           allowed_ips: ["67.160.0.0/16", $allowed_ip]
         }

--- a/.pipeline/templates/deployer/delete-deployer-steps.yml
+++ b/.pipeline/templates/deployer/delete-deployer-steps.yml
@@ -5,7 +5,18 @@ steps:
       git checkout ${{parameters.branch_name}}
       repo_path=$(pwd)
 
-      deployer_rg=${{parameters.deployer_rg_name}}
+      # Modify environment value so it starts with u and with length of 5
+      deployer_env=${{parameters.deployer_env}}
+      buildId=$(Build.BuildId)
+      isRelease=${deployer_env%%$buildId*}
+      if [ -z "${isRelease}" ]
+      then 
+        deployer_prefix="U$(echo $(Build.BuildId) | rev | cut -c1-4 | rev)"
+      else
+        deployer_prefix=${deployer_env}
+      fi
+
+      deployer_rg="${deployer_prefix}-EAUS-MGMT-INFRASTRUCTURE"
       ws_dir=$(Agent.BuildDirectory)/Azure_SAP_Automated_Deployment/WORKSPACES/LOCAL/${deployer_rg}
 
       echo "=== Start to delete deployer with terraform destroy ==="
@@ -13,8 +24,8 @@ steps:
       terraform destroy -auto-approve -var-file=${deployer_rg}.json ${repo_path}/deploy/terraform/bootstrap/sap_deployer/
       
       echo "=== Mark and try to delete rg  ==="
-      az group update --resource-group ${{parameters.deployer_rg_name}} --set tags.Delete=True --output none
-      az group delete -n ${{parameters.deployer_rg_name}} --no-wait -y
+      az group update --resource-group ${deployer_rg} --set tags.Delete=True --output none
+      az group delete -n ${deployer_rg} --no-wait -y
 
       exit 0
     displayName: "Delete new deployer"

--- a/.pipeline/templates/deployer/post-deployer-steps.yml
+++ b/.pipeline/templates/deployer/post-deployer-steps.yml
@@ -1,6 +1,18 @@
 steps:
   - script: |
-      deployer_rg=${{parameters.deployer_rg_name}}
+      # Modify environment value so it starts with u and with length of 5
+      deployer_env=${{parameters.deployer_env}}
+      buildId=$(Build.BuildId)
+      isRelease=${deployer_env%%$buildId*}
+      if [ -z "${isRelease}" ]
+      then 
+        deployer_prefix="U$(echo $(Build.BuildId) | rev | cut -c1-4 | rev)"
+      else
+        deployer_prefix=${deployer_env}
+      fi
+
+      deployer_rg="${deployer_prefix}-EAUS-MGMT-INFRASTRUCTURE"
+      
       ws_dir=$(Agent.BuildDirectory)/Azure_SAP_Automated_Deployment/WORKSPACES/LOCAL/${deployer_rg}
 
       cd ${ws_dir}

--- a/.pipeline/templates/deployer/validate-deployer-steps.yml
+++ b/.pipeline/templates/deployer/validate-deployer-steps.yml
@@ -1,7 +1,20 @@
 steps:
   - script: |
       repo_path=$(pwd)
-      deployer_rg=${{parameters.deployer_rg_name}}
+
+      # Modify environment value so it starts with u and with length of 5
+      deployer_env=${{parameters.deployer_env}}
+      buildId=$(Build.BuildId)
+      isRelease=${deployer_env%%$buildId*}
+      if [ -z "${isRelease}" ]
+      then 
+        deployer_prefix="U$(echo $(Build.BuildId) | rev | cut -c1-4 | rev)"
+      else
+        deployer_prefix=${deployer_env}
+      fi
+
+      deployer_rg="${deployer_prefix}-EAUS-MGMT-INFRASTRUCTURE"
+
       ws_dir=$(Agent.BuildDirectory)/Azure_SAP_Automated_Deployment/WORKSPACES/LOCAL/${deployer_rg}
       input=${ws_dir}/${deployer_rg}.json
 

--- a/.pipeline/templates/saplib/create-saplib-steps.yml
+++ b/.pipeline/templates/saplib/create-saplib-steps.yml
@@ -6,15 +6,30 @@ steps:
       ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no -o ConnectTimeout=$(ssh_timeout_s) "$(username)"@"$(publicIP)" '
       source /etc/profile.d/deploy_server.sh
 
-      saplib_rg=${{parameters.saplib_rg_name}}
+      # Modify environment value so it starts with u and with length of 5
+      saplib_env=${{parameters.saplib_env}}
+      buildId=$(Build.BuildId)
+      isRelease=${saplib_env%%$buildId*}
+      if [ -z "${isRelease}" ]
+      then 
+        saplib_prefix="U$(echo $(Build.BuildId) | rev | cut -c1-4 | rev)"
+      else
+        saplib_prefix=${saplib_env}
+      fi
+
+      saplib_rg="${saplib_prefix}-EAUS-SAP_LIBRARY"
+
       repo_dir=$HOME/${saplib_rg}/sap-hana
       ws_dir=$HOME/Azure_SAP_Automated_Deployment/WORKSPACES/SAP_LIBRARY/${saplib_rg}
       input=${ws_dir}/${saplib_rg}.json
 
       echo "=== Checkout required branch ${{parameters.branch_name}} ==="
-      mkdir $HOME/${saplib_rg}; cd $_
-      git clone https://github.com/Azure/sap-hana.git
-      cd sap-hana && git pull && git checkout ${{parameters.branch_name}}
+      if [ ! -d "${repo_dir}" ]
+      then
+        mkdir $HOME/${saplib_rg}; cd $_
+        git clone https://github.com/Azure/sap-hana.git
+      fi
+      cd ${repo_dir} && git pull && git checkout ${{parameters.branch_name}}
       
       echo "=== Create workspace ${ws_dir} ==="
       mkdir -p ${ws_dir}; cd $_
@@ -22,8 +37,10 @@ steps:
       echo "=== Prepare input for saplibrary ==="
       cp ${repo_dir}/deploy/terraform/bootstrap/sap_library/saplibrary.json ${ws_dir}/saplibrary.json
       cat ${ws_dir}/saplibrary.json \
-      | jq --arg rg_name "${saplib_rg}" .infrastructure.resource_group.name\ =\ \$rg_name \
+      | jq --arg environment "${saplib_prefix}" .infrastructure.environment\ =\ \$environment \
       > ${input}
+
+      cat ${input}
       
       echo "=== Create SAP library from deployer with terraform ==="
       echo "=== This may take quite a while, please be patient ==="

--- a/.pipeline/templates/saplib/delete-saplib-steps.yml
+++ b/.pipeline/templates/saplib/delete-saplib-steps.yml
@@ -1,12 +1,35 @@
 steps:
   - script: |
-      saplib_rg=${{parameters.saplib_rg_name}}
+      # Modify environment value so it starts with u and with length of 5
+      saplib_env=${{parameters.saplib_env}}
+      buildId=$(Build.BuildId)
+      isRelease=${saplib_env%%$buildId*}
+      if [ -z "${isRelease}" ]
+      then 
+        saplib_prefix="U$(echo $(Build.BuildId) | rev | cut -c1-4 | rev)"
+      else
+        saplib_prefix=${saplib_env}
+      fi
+
+      saplib_rg="${saplib_prefix}-EAUS-SAP_LIBRARY"
 
       echo "=== Delete SAP library from deployer ==="
       ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no -o ConnectTimeout=$(ssh_timeout_s) "$(username)"@"$(publicIP)" '
       source /etc/profile.d/deploy_server.sh
 
-      saplib_rg=${{parameters.saplib_rg_name}}
+      # Modify environment value so it starts with u and with length of 5
+      saplib_env=${{parameters.saplib_env}}
+      buildId=$(Build.BuildId)
+      isRelease=${saplib_env%%$buildId*}
+      if [ -z "${isRelease}" ]
+      then 
+        saplib_prefix="U$(echo $(Build.BuildId) | rev | cut -c1-4 | rev)"
+      else
+        saplib_prefix=${saplib_env}
+      fi
+
+      saplib_rg="${saplib_prefix}-EAUS-SAP_LIBRARY"
+
       repo_dir=$HOME/${saplib_rg}/sap-hana
       ws_dir=$HOME/Azure_SAP_Automated_Deployment/WORKSPACES/SAP_LIBRARY/${saplib_rg}
       input=${ws_dir}/${saplib_rg}.json

--- a/.pipeline/templates/saplib/post-saplib-steps.yml
+++ b/.pipeline/templates/saplib/post-saplib-steps.yml
@@ -5,8 +5,31 @@ steps:
       ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no -o ConnectTimeout=$(ssh_timeout_s) "$(username)"@"$(publicIP)" '
       source /etc/profile.d/deploy_server.sh
       
-      deployer_rg=${{parameters.deployer_rg_name}}
-      saplib_rg=${{parameters.saplib_rg_name}}
+      # Modify environment value so it starts with u and with length of 5
+      deployer_env=${{parameters.deployer_env}}
+      buildId=$(Build.BuildId)
+      deployer_isRelease=${deployer_env%%$buildId*}
+      if [ -z "${deployer_isRelease}" ]
+      then 
+        deployer_prefix="U$(echo $(Build.BuildId) | rev | cut -c1-4 | rev)"
+      else
+        deployer_prefix=${deployer_env}
+      fi
+
+      deployer_rg="${deployer_prefix}-EAUS-MGMT-INFRASTRUCTURE"
+
+      # Modify environment value so it starts with u and with length of 5
+      saplib_env=${{parameters.saplib_env}}
+      saplib_isRelease=${saplib_env%%$buildId*}
+      if [ -z "${saplib_isRelease}" ]
+      then 
+        saplib_prefix="U$(echo $(Build.BuildId) | rev | cut -c1-4 | rev)"
+      else
+        saplib_prefix=${saplib_env}
+      fi
+
+      saplib_rg="${saplib_prefix}-EAUS-SAP_LIBRARY"
+      
       repo_dir=$HOME/${saplib_rg}/sap-hana
 
       deployer_ws_dir=$HOME/Azure_SAP_Automated_Deployment/WORKSPACES/LOCAL/${deployer_rg}

--- a/.pipeline/templates/saplib/validate-saplib-steps.yml
+++ b/.pipeline/templates/saplib/validate-saplib-steps.yml
@@ -5,7 +5,19 @@ steps:
       ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no -o ConnectTimeout=$(ssh_timeout_s) "$(username)"@"$(publicIP)" '
       source /etc/profile.d/deploy_server.sh
 
-      saplib_rg=${{parameters.saplib_rg_name}}
+      # Modify environment value so it starts with u and with length of 5
+      saplib_env=${{parameters.saplib_env}}
+      buildId=$(Build.BuildId)
+      isRelease=${saplib_env%%$buildId*}
+      if [ -z "${isRelease}" ]
+      then 
+        saplib_prefix="U$(echo $(Build.BuildId) | rev | cut -c1-4 | rev)"
+      else
+        saplib_prefix=${saplib_env}
+      fi
+
+      saplib_rg="${saplib_prefix}-EAUS-SAP_LIBRARY"
+
       repo_dir=$HOME/${saplib_rg}/sap-hana
       ws_dir=$HOME/Azure_SAP_Automated_Deployment/WORKSPACES/SAP_LIBRARY/${saplib_rg}
       input=${ws_dir}/${saplib_rg}.json

--- a/.pipeline/templates/sapsystem/create-sapsystem-steps.yml
+++ b/.pipeline/templates/sapsystem/create-sapsystem-steps.yml
@@ -6,9 +6,61 @@ steps:
       ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no -o ConnectTimeout=$(ssh_timeout_s) "$(username)"@"$(publicIP)" '
       source /etc/profile.d/deploy_server.sh
 
-      sapsystem_rg=${{parameters.sapsystem_rg_name}}
-      deployer_rg=${{parameters.deployer_rg_name}}
-      saplib_rg_name=${{parameters.saplib_rg_name}}
+      # Modify environment value so it starts with u and with length of 5
+      deployer_env=${{parameters.deployer_env}}
+      buildId=$(Build.BuildId)
+      deployer_isRelease=${deployer_env%%$buildId*}
+      if [ -z "${deployer_isRelease}" ]
+      then 
+        deployer_prefix="U$(echo $(Build.BuildId) | rev | cut -c1-4 | rev)"
+      else
+        deployer_prefix=${deployer_env}
+      fi
+
+      deployer_rg="${deployer_prefix}-EAUS-MGMT-INFRASTRUCTURE"
+
+      # Modify environment value so it starts with u and with length of 5
+      saplib_env=${{parameters.saplib_env}}
+      saplib_isRelease=${saplib_env%%$buildId*}
+      if [ -z "${saplib_isRelease}" ]
+      then 
+        saplib_prefix="U$(echo $(Build.BuildId) | rev | cut -c1-4 | rev)"
+      else
+        saplib_prefix=${saplib_env}
+      fi
+
+      saplib_rg="${saplib_prefix}-EAUS-SAP_LIBRARY"
+
+      # Modify environment value so it starts with u and with length of 5
+      sapsystem_env=${{parameters.sapsystem_env}}
+      sapsystem_isRelease=${sapsystem_env%%$buildId*}
+
+      [[ ${osImage_publisher} == "SUSE" ]] && isSles=true || isSles=false
+      
+      # subnet is decided by buildId if it is unit test.
+      # Otherwise, use 10.10.0.0 for sles and 10.10.1.0 for rhel
+      if [ -z "${sapsystem_isRelease}" ]
+      then 
+        idx1=${buildId: -1}
+        idx2=$((${buildId: -2:1} + 1))
+        sapsystem_prefix="U$(echo $(Build.BuildId) | rev | cut -c1-4 | rev)"
+        ha="false"
+      else
+        idx1=10
+        sapsystem_prefix=${sapsystem_env}
+        ha="true"
+        if ${isSles}
+        then idx2=11
+        else idx2=12
+        fi
+      fi
+      sap_vnet_address_space="10.${idx2}.${idx1}.0/25"
+      subnet_admin_prefix="10.${idx2}.${idx1}.0/27"
+      subnet_db_prefix="10.${idx2}.${idx1}.32/27"
+      subnet_iscsi_prefix="10.${idx2}.${idx1}.64/27"
+      subnet_app_prefix="10.${idx2}.${idx1}.96/27"
+
+      sapsystem_rg="${sapsystem_prefix}-EAUS-SAP-PRD"
 
       # If no osImage provided, deploy SLES12SP5
       [ -z "${{parameters.osImage_offer}}" ] && osImage_offer="sles-sap-12-sp5" || osImage_offer=${{parameters.osImage_offer}}
@@ -39,43 +91,15 @@ steps:
         export SAP_HANA_FENCING_AGENT_CLIENT_SECRET=$(hana-pipeline-spn-pw)
       EOF
 
-      tfstate_sa_name=$(az storage account list --resource-group ${saplib_rg_name} | jq -r "'".[] |  select(.name | contains(\\\"tfstate\\\")).name"'")
+      tfstate_sa_name=$(az storage account list --resource-group ${saplib_rg} | jq -r "'".[] |  select(.name | contains(\\\"tfstate\\\")).name"'")
       sap_system_key="${sapsystem_rg}.terraform.tfstate"
-      deployer_tfstate_key=$(az storage blob list --account-name ${tfstate_sa_name} --container-name tfstate --only-show-errors | jq -r "'".[] | select(.name | contains(\\\"DEPLOYER\\\")).name"'")
+      deployer_tfstate_key=$(az storage blob list --account-name ${tfstate_sa_name} --container-name tfstate --only-show-errors | jq -r "'".[] | select(.name | contains(\\\"INFRASTRUCTURE\\\")).name"'")
       saplib_tfstate_key=$(az storage blob list --account-name ${tfstate_sa_name} --container-name tfstate --only-show-errors | jq -r "'".[] | select(.name | contains(\\\"LIBRARY\\\")).name"'")
-
-      buildId=$(Build.BuildId)
-      isRelease=${sapsystem_rg%%$buildId*}
-      [[ ${osImage_publisher} == "SUSE" ]] && isSles=true || isSles=false
-      
-      # subnet is decided by buildId if it is unit test.
-      # Otherwise, use 10.10.0.0 for sles and 10.10.1.0 for rhel
-      if [ -z "${isRelease}" ]
-      then 
-        idx1=${buildId: -1}
-        idx2=${buildId: -2:1}
-        environment="$(Build.BuildId)"
-        ha="false"
-      else
-        idx1=10
-        environment="unit"
-        ha="true"
-        if ${isSles}
-        then idx2=0
-        else idx2=1
-        fi
-      fi
-      sap_vnet_address_space="10.${idx2}.${idx1}.0/25"
-      subnet_admin_prefix="10.${idx2}.${idx1}.0/27"
-      subnet_db_prefix="10.${idx2}.${idx1}.32/27"
-      subnet_iscsi_prefix="10.${idx2}.${idx1}.64/27"
-      subnet_app_prefix="10.${idx2}.${idx1}.96/27"
 
       cp ${repo_dir}/deploy/terraform/run/sap_system/sapsystem.json ${ws_dir}/sapsystem.json
       cat ${ws_dir}/sapsystem.json \
-      | jq --arg environment "${environment}" .infrastructure.environment\ =\ \$environment \
-      | jq --arg rg_name "${sapsystem_rg}" .infrastructure.resource_group.name\ =\ \$rg_name \
-      | jq --arg saplib_rg_name "${saplib_rg_name}" .infrastructure.vnets.management.saplib_resource_group_name\ =\ \$saplib_rg_name \
+      | jq --arg environment "${sapsystem_prefix}" .infrastructure.environment\ =\ \$environment \
+      | jq --arg saplib_rg "${saplib_rg}" .infrastructure.vnets.management.saplib_resource_group_name\ =\ \$saplib_rg \
       | jq --arg tfstate_sa_name "${tfstate_sa_name}" .infrastructure.vnets.management.tfstate_storage_account_name\ =\ \$tfstate_sa_name \
       | jq --arg deployer_tfstate_key "${deployer_tfstate_key}" .infrastructure.vnets.management.deployer_tfstate_key\ =\ \$deployer_tfstate_key \
       | jq --arg sap_vnet_address_space "${sap_vnet_address_space}" .infrastructure.vnets.sap.address_space\ =\ \$sap_vnet_address_space \
@@ -93,7 +117,7 @@ steps:
       | jq --arg xsa_admin_password "$(hana-pipeline-db-pwd)" .databases[].credentials.xsa_admin_password\ =\ \$xsa_admin_password \
       | jq --arg cockpit_admin_password "$(hana-pipeline-db-pwd)" .databases[].credentials.cockpit_admin_password\ =\ \$cockpit_admin_password \
       | jq --arg ha_cluster_password "$(hana-pipeline-os-pwd)" .databases[].credentials.ha_cluster_password\ =\ \$ha_cluster_password \
-      | jq --arg saplib_rg_name "${saplib_rg_name}" .software.storage_account_sapbits.saplib_resource_group_name\ =\ \$saplib_rg_name \
+      | jq --arg saplib_rg "${saplib_rg}" .software.storage_account_sapbits.saplib_resource_group_name\ =\ \$saplib_rg \
       | jq --arg tfstate_sa_name "${tfstate_sa_name}" .software.storage_account_sapbits.tfstate_storage_account_name\ =\ \$tfstate_sa_name \
       | jq --arg saplib_tfstate_key "${saplib_tfstate_key}" .software.storage_account_sapbits.saplib_tfstate_key\ =\ \$saplib_tfstate_key \
       | jq --arg sap_user "$(hana-smp-nancyc-username)" .software.downloader.credentials.sap_user\ =\ \$sap_user \
@@ -106,7 +130,7 @@ steps:
       echo "=== This may take quite a while, please be patient ==="
       terraform -version
       terraform init -upgrade=true -force-copy \
-        --backend-config "resource_group_name=${saplib_rg_name}" \
+        --backend-config "resource_group_name=${saplib_rg}" \
         --backend-config "storage_account_name=${tfstate_sa_name}" \
         --backend-config "container_name=tfstate" \
         --backend-config "key=${sap_system_key}" \

--- a/.pipeline/templates/sapsystem/delete-sapsystem-steps.yml
+++ b/.pipeline/templates/sapsystem/delete-sapsystem-steps.yml
@@ -1,14 +1,51 @@
 steps:
   - script: |
-      deployer_rg=${{parameters.deployer_rg_name}}
-      sapsystem_rg=${{parameters.sapsystem_rg_name}}
+      # Modify environment value so it starts with u and with length of 5
+      deployer_env=${{parameters.deployer_env}}
+      buildId=$(Build.BuildId)
+      isRelease=${deployer_env%%$buildId*}
+      if [ -z "${isRelease}" ]
+      then 
+        deployer_prefix="U$(echo $(Build.BuildId) | rev | cut -c1-4 | rev)"
+      else
+        deployer_prefix=${deployer_env}
+      fi
+
+      deployer_rg="${deployer_prefix}-EAUS-MGMT-INFRASTRUCTURE"
+
+      # Modify environment value so it starts with u and with length of 5
+      sapsystem_env=${{parameters.sapsystem_env}}
+      buildId=$(Build.BuildId)
+      isRelease=${sapsystem_env%%$buildId*}
+
+      if [ -z "${isRelease}" ]
+      then 
+        sapsystem_prefix="U$(echo $(Build.BuildId) | rev | cut -c1-4 | rev)"
+      else
+        sapsystem_prefix=${sapsystem_env}
+      fi
+
+      sapsystem_rg="${sapsystem_prefix}-EAUS-SAP-PRD"
 
       echo "=== Delete SAP system from deployer ==="
       ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no -o ConnectTimeout=$(ssh_timeout_s) "$(username)"@"$(publicIP)" '
       source /etc/profile.d/deploy_server.sh
 
-      sapsystem_rg=${{parameters.sapsystem_rg_name}}
-      repo_dir=$HOME/$saplib_rg/sap-hana
+      # Modify environment value so it starts with u and with length of 5
+      sapsystem_env=${{parameters.sapsystem_env}}
+      buildId=$(Build.BuildId)
+      isRelease=${sapsystem_env%%$buildId*}
+
+      if [ -z "${isRelease}" ]
+      then 
+        sapsystem_prefix="U$(echo $(Build.BuildId) | rev | cut -c1-4 | rev)"
+      else
+        sapsystem_prefix=${sapsystem_env}
+      fi
+
+      sapsystem_rg="${sapsystem_prefix}-EAUS-SAP-PRD"
+
+      repo_dir=$HOME/$sapsystem_rg/sap-hana
       ws_dir=$HOME/Azure_SAP_Automated_Deployment/WORKSPACES/SAP_SYSTEM/${sapsystem_rg}
       input=${ws_dir}/${sapsystem_rg}.json
 
@@ -29,8 +66,9 @@ steps:
       '
 
       echo "=== Remove vnet peering with vnet-mgmt in case deployment/destroy fails ==="
-      peering_name=$(az network vnet peering list --resource-group ${deployer_rg} --vnet-name vnet-mgmt | jq -r .[].name | grep $(Build.BuildId))
-      [ ! -z "$peering_name" ] && az network vnet peering delete --resource-group ${deployer_rg} --name $peering_name --vnet-name vnet-mgmt
+      vnet_name="${deployer_prefix}-EAUS-MGMT-vnet"
+      peering_name=$(az network vnet peering list --resource-group ${deployer_rg} --vnet-name ${vnet_name} | jq -r .[].name | grep $(Build.BuildId))
+      [ ! -z "$peering_name" ] && az network vnet peering delete --resource-group ${deployer_rg} --name ${peering_name} --vnet-name ${vnet_name}
 
       echo "=== Mark and try to delete rg  ==="
       az login --service-principal --user $(hana-pipeline-spn-id) --password $(hana-pipeline-spn-pw) --tenant $(landscape-tenant) --output none

--- a/.pipeline/templates/sapsystem/validate-sapsystem-steps.yml
+++ b/.pipeline/templates/sapsystem/validate-sapsystem-steps.yml
@@ -5,7 +5,20 @@ steps:
       ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no -o ConnectTimeout=$(ssh_timeout_s) "$(username)"@"$(publicIP)" '
       source /etc/profile.d/deploy_server.sh
 
-      sapsystem_rg=${{parameters.sapsystem_rg_name}}
+      # Modify environment value so it starts with u and with length of 5
+      sapsystem_env=${{parameters.sapsystem_env}}
+      buildId=$(Build.BuildId)
+      isRelease=${sapsystem_env%%$buildId*}
+
+      if [ -z "${isRelease}" ]
+      then 
+        sapsystem_prefix="U$(echo $(Build.BuildId) | rev | cut -c1-4 | rev)"
+      else
+        sapsystem_prefix=${sapsystem_env}
+      fi
+
+      sapsystem_rg="${sapsystem_prefix}-EAUS-SAP-PRD"
+      
       repo_dir=$HOME/${sapsystem_rg}/sap-hana
       ws_dir=$HOME/Azure_SAP_Automated_Deployment/WORKSPACES/SAP_SYSTEM/${sapsystem_rg}
       input=${ws_dir}/${sapsystem_rg}.json

--- a/.pipeline/templates/util/add-agent-to-deployer-nsg.yml
+++ b/.pipeline/templates/util/add-agent-to-deployer-nsg.yml
@@ -6,7 +6,19 @@ steps:
   - script: |
       az login --service-principal --user $(hana-pipeline-spn-id) --password $(hana-pipeline-spn-pw) --tenant $(landscape-tenant) --output none
 
-      rg_name=${{parameters.deployer_rg_name}}
+      # Modify environment value so it starts with u and with length of 5
+      deployer_env=${{parameters.deployer_env}}
+      buildId=$(Build.BuildId)
+      isRelease=${deployer_env%%$buildId*}
+      if [ -z "${isRelease}" ]
+      then 
+        deployer_prefix="U$(echo $(Build.BuildId) | rev | cut -c1-4 | rev)"
+      else
+        deployer_prefix=${deployer_env}
+      fi
+
+      rg_name="${deployer_prefix}-EAUS-MGMT-INFRASTRUCTURE"
+
       vnet_name=$(az network vnet list --resource-group ${rg_name} | jq -r .[].name)
       subnet_name=$(az network vnet list --resource-group ${rg_name} | jq -r .[].subnets[].name)
       nsg_name=$(az network nsg list --resource-group ${rg_name} | jq -r --arg vnet_name "${vnet_name}" '.[] | select(.name | contains($vnet_name) | not) | .name')

--- a/.pipeline/templates/util/collect-deployer-info.yml
+++ b/.pipeline/templates/util/collect-deployer-info.yml
@@ -3,7 +3,20 @@ steps:
       az login --service-principal --user $(hana-pipeline-spn-id) --password $(hana-pipeline-spn-pw) --tenant $(landscape-tenant) --output none
       
       echo "=== Fetch deployer info ==="
-      rg_name=${{parameters.deployer_rg_name}}
+      
+      # Modify environment value so it starts with u and with length of 5
+      deployer_env=${{parameters.deployer_env}}
+      buildId=$(Build.BuildId)
+      isRelease=${deployer_env%%$buildId*}
+      if [ -z "${isRelease}" ]
+      then 
+        deployer_prefix="U$(echo $(Build.BuildId) | rev | cut -c1-4 | rev)"
+      else
+        deployer_prefix=${deployer_env}
+      fi
+
+      rg_name="${deployer_prefix}-EAUS-MGMT-INFRASTRUCTURE"
+
       echo "##vso[task.setvariable variable=username]$(az vm list --resource-group ${rg_name} | jq -r .[].osProfile.adminUsername)"
       vm_name=$(az vm list --resource-group ${rg_name} | jq -r .[].name)
       pip=$(az vm list-ip-addresses -g ${rg_name} -n ${vm_name} | jq -r .[].virtualMachine.network.publicIpAddresses | jq -r .[].ipAddress)

--- a/.pipeline/templates/util/remove-agent-from-deployer-nsg.yml
+++ b/.pipeline/templates/util/remove-agent-from-deployer-nsg.yml
@@ -6,7 +6,19 @@ steps:
   - script: |
       az login --service-principal --user $(hana-pipeline-spn-id) --password $(hana-pipeline-spn-pw) --tenant $(landscape-tenant) --output none
 
-      rg_name=${{parameters.deployer_rg_name}}
+      # Modify environment value so it starts with u and with length of 5
+      deployer_env=${{parameters.deployer_env}}
+      buildId=$(Build.BuildId)
+      isRelease=${deployer_env%%$buildId*}
+      if [ -z "${isRelease}" ]
+      then 
+        deployer_prefix="U$(echo $(Build.BuildId) | rev | cut -c1-4 | rev)"
+      else
+        deployer_prefix=${deployer_env}
+      fi
+
+      rg_name="${deployer_prefix}-EAUS-MGMT-INFRASTRUCTURE"
+
       vnet_name=$(az network vnet list --resource-group ${rg_name} | jq -r .[].name)
       subnet_name=$(az network vnet list --resource-group ${rg_name} | jq -r .[].subnets[].name)
       nsg_name=$(az network nsg list --resource-group ${rg_name} | jq -r --arg vnet_name "${vnet_name}" '.[] | select(.name | contains($vnet_name) | not) | .name')

--- a/.pipeline/tf-deployer-test.yml
+++ b/.pipeline/tf-deployer-test.yml
@@ -23,15 +23,15 @@ stages:
       - template: templates/deployer/create-deployer-steps.yml
         parameters:
           branch_name: $(targetBranchName)
-          deployer_rg_name: "$(Build.BuildId)-EAUS-DEPLOYER-INFRASTRUCTURE"
+          deployer_env: "$(Build.BuildId)"
       - template: templates/deployer/validate-deployer-steps.yml
         parameters:
-          deployer_rg_name: "$(Build.BuildId)-EAUS-DEPLOYER-INFRASTRUCTURE"
+          deployer_env: "$(Build.BuildId)"
       - template: templates/deployer/create-deployer-steps.yml
         parameters:
           branch_name: $(sourceBranchName)
-          deployer_rg_name: "$(Build.BuildId)-EAUS-DEPLOYER-INFRASTRUCTURE"
+          deployer_env: "$(Build.BuildId)"
       - template: templates/deployer/delete-deployer-steps.yml
         parameters:
           branch_name: $(sourceBranchName)
-          deployer_rg_name: "$(Build.BuildId)-EAUS-DEPLOYER-INFRASTRUCTURE"
+          deployer_env: "$(Build.BuildId)"

--- a/.pipeline/tf-integration-test.yml
+++ b/.pipeline/tf-integration-test.yml
@@ -24,71 +24,71 @@ stages:
       - template: templates/deployer/create-deployer-steps.yml
         parameters:
           branch_name: $(sourceBranchName)
-          deployer_rg_name: "$(Build.BuildId)-EAUS-DEPLOYER-INFRASTRUCTURE"
+          deployer_env: "$(Build.BuildId)"
       - template: templates/deployer/post-deployer-steps.yml
         parameters:
-          deployer_rg_name: "$(Build.BuildId)-EAUS-DEPLOYER-INFRASTRUCTURE"
+          deployer_env: "$(Build.BuildId)"
   - job: createSAPLib
     dependsOn: createDeployer
     steps:
       - template: templates/util/prepare-agent.yml
       - template: templates/util/collect-deployer-info.yml
         parameters:
-          deployer_rg_name: "$(Build.BuildId)-EAUS-DEPLOYER-INFRASTRUCTURE"
+          deployer_env: "$(Build.BuildId)"
       - template: templates/util/add-agent-to-deployer-nsg.yml
         parameters:
-          deployer_rg_name: "$(Build.BuildId)-EAUS-DEPLOYER-INFRASTRUCTURE"
+          deployer_env: "$(Build.BuildId)"
       - template: templates/saplib/create-saplib-steps.yml
         parameters:
           branch_name: $(sourceBranchName)
-          saplib_rg_name: "$(Build.BuildId)-EAUS-SAP_LIBRARY"
+          saplib_env: "$(Build.BuildId)"
       - template: templates/saplib/post-saplib-steps.yml
         parameters:
           branch_name: $(sourceBranchName)
-          deployer_rg_name: "$(Build.BuildId)-EAUS-DEPLOYER-INFRASTRUCTURE"
-          saplib_rg_name: "$(Build.BuildId)-EAUS-SAP_LIBRARY"
+          deployer_env: "$(Build.BuildId)"
+          saplib_env: "$(Build.BuildId)"
       - template: templates/util/remove-agent-from-deployer-nsg.yml
         parameters:
-          deployer_rg_name: "$(Build.BuildId)-EAUS-DEPLOYER-INFRASTRUCTURE"
+          deployer_env: "$(Build.BuildId)"
   - job: createSAPSystem
     dependsOn: createSAPLib
     steps:
       - template: templates/util/prepare-agent.yml
       - template: templates/util/collect-deployer-info.yml
         parameters:
-          deployer_rg_name: "$(Build.BuildId)-EAUS-DEPLOYER-INFRASTRUCTURE"
+          deployer_env: "$(Build.BuildId)"
       - template: templates/util/add-agent-to-deployer-nsg.yml
         parameters:
-          deployer_rg_name: "$(Build.BuildId)-EAUS-DEPLOYER-INFRASTRUCTURE"
+          deployer_env: "$(Build.BuildId)"
       - template: templates/sapsystem/create-sapsystem-steps.yml
         parameters:
           branch_name: $(sourceBranchName)
-          deployer_rg_name: "$(Build.BuildId)-EAUS-DEPLOYER-INFRASTRUCTURE"
-          saplib_rg_name: "$(Build.BuildId)-EAUS-SAP_LIBRARY"
-          sapsystem_rg_name: "$(Build.BuildId)-EAUS-SAP0-PRD"
+          deployer_env: "$(Build.BuildId)"
+          saplib_env: "$(Build.BuildId)"
+          sapsystem_env: "$(Build.BuildId)"
       - template: templates/util/remove-agent-from-deployer-nsg.yml
         parameters:
-          deployer_rg_name: "$(Build.BuildId)-EAUS-DEPLOYER-INFRASTRUCTURE"
+          deployer_env: "$(Build.BuildId)"
   - job: deleteAll
     dependsOn: createSAPSystem
     condition: or(succeededOrFailed(), always())
     steps:
       - script: |
+          environment="U$(echo $(Build.BuildId) | rev | cut -c1-4 | rev)"
+
           az login --service-principal --user $(hana-pipeline-spn-id) --password $(hana-pipeline-spn-pw) --tenant $(landscape-tenant) --output none
-          sapsystem_rg="$(Build.BuildId)-EAUS-SAP0-PRD"
+          sapsystem_rg="${environment}-EAUS-SAP-PRD"
           echo "=== Mark and try to delete rg ${sapsystem_rg} ==="
           az group update --resource-group ${sapsystem_rg} --set tags.Delete=True
           az group delete -n ${sapsystem_rg} --no-wait -y
 
-          saplib_rg="$(Build.BuildId)-EAUS-SAP_LIBRARY"
+          saplib_rg="${environment}-EAUS-SAP_LIBRARY"
           echo "=== Mark and try to delete rg ${saplib_rg} ==="
-          az lock delete --name resource-group-level --resource-group ${saplib_rg}
           az group update --resource-group ${saplib_rg} --set tags.Delete=True
           az group delete -n ${saplib_rg} --no-wait -y
 
-          deployer_rg="$(Build.BuildId)-EAUS-DEPLOYER-INFRASTRUCTURE"
-          echo "=== Mark and try to delete rg ${saplib_rg} ==="
-          az lock delete --name resource-group-level --resource-group ${deployer_rg}
+          deployer_rg="${environment}-EAUS-MGMT-INFRASTRUCTURE"
+          echo "=== Mark and try to delete rg ${deployer_rg} ==="
           az group update --resource-group ${deployer_rg} --set tags.Delete=True
           az group delete -n ${deployer_rg} --no-wait -y
         displayName: "Clean up"

--- a/.pipeline/tf-release.yml
+++ b/.pipeline/tf-release.yml
@@ -22,12 +22,12 @@ stages:
     steps:
       - script: |
           az login --service-principal --user $(hana-pipeline-spn-id) --password $(hana-pipeline-spn-pw) --tenant $(landscape-tenant) --output none
-          sapsystem_rg="SLES-EAUS-SAP0-PRD"
+          sapsystem_rg="SLES-EAUS-SAP-PRD"
           echo "=== Mark and try to delete rg $sapsystem_rg ==="
           az group update --resource-group $sapsystem_rg --set tags.Delete=True
           az group delete -n $sapsystem_rg -y
 
-          sapsystem_rg="RHEL-EAUS-SAP0-PRD"
+          sapsystem_rg="RHEL-EAUS-SAP-PRD"
           echo "=== Mark and try to delete rg $sapsystem_rg ==="
           az group update --resource-group $sapsystem_rg --set tags.Delete=True
           az group delete -n $sapsystem_rg -y
@@ -37,7 +37,7 @@ stages:
           az group update --resource-group $saplib_rg --set tags.Delete=True
           az group delete -n $saplib_rg -y
 
-          deployer_rg="UNIT-EAUS-DEPLOYER-INFRASTRUCTURE"
+          deployer_rg="UNIT-EAUS-MGMT-INFRASTRUCTURE"
           echo "=== Mark and try to delete rg $deployer_rg ==="
           az group update --resource-group $deployer_rg --set tags.Delete=True
           az group delete -n $deployer_rg -y
@@ -55,75 +55,75 @@ stages:
       - template: templates/deployer/create-deployer-steps.yml
         parameters:
           branch_name: $(sourceBranchName)
-          deployer_rg_name: "UNIT-EAUS-DEPLOYER-INFRASTRUCTURE"
+          deployer_env: "UNIT"
       - template: templates/deployer/post-deployer-steps.yml
         parameters:
-          deployer_rg_name: "UNIT-EAUS-DEPLOYER-INFRASTRUCTURE"
+          deployer_env: "UNIT"
   - job: createSAPLib
     dependsOn: createDeployer
     steps:
       - template: templates/util/prepare-agent.yml
       - template: templates/util/collect-deployer-info.yml
         parameters:
-          deployer_rg_name: "UNIT-EAUS-DEPLOYER-INFRASTRUCTURE"
+          deployer_env: "UNIT"
       - template: templates/util/add-agent-to-deployer-nsg.yml
         parameters:
-          deployer_rg_name: "UNIT-EAUS-DEPLOYER-INFRASTRUCTURE"
+          deployer_env: "UNIT"
       - template: templates/saplib/create-saplib-steps.yml
         parameters:
           branch_name: $(sourceBranchName)
-          saplib_rg_name: "UNIT-EAUS-SAP_LIBRARY"
+          saplib_env: "UNIT"
       - template: templates/saplib/post-saplib-steps.yml
         parameters:
-          deployer_rg_name: "UNIT-EAUS-DEPLOYER-INFRASTRUCTURE"
-          saplib_rg_name: "UNIT-EAUS-SAP_LIBRARY"
+          deployer_env: "UNIT"
+          saplib_env: "UNIT"
       - template: templates/util/remove-agent-from-deployer-nsg.yml
         parameters:
-          deployer_rg_name: "UNIT-EAUS-DEPLOYER-INFRASTRUCTURE"
+          deployer_env: "UNIT"
   - job: createSAPSystemSLES
     dependsOn: createSAPLib
     steps:
       - template: templates/util/prepare-agent.yml
       - template: templates/util/collect-deployer-info.yml
         parameters:
-          deployer_rg_name: "UNIT-EAUS-DEPLOYER-INFRASTRUCTURE"
+          deployer_env: "UNIT"
       - template: templates/util/add-agent-to-deployer-nsg.yml
         parameters:
-          deployer_rg_name: "UNIT-EAUS-DEPLOYER-INFRASTRUCTURE"
+          deployer_env: "UNIT"
       - template: templates/sapsystem/create-sapsystem-steps.yml
         parameters:
           branch_name: $(sourceBranchName)
-          deployer_rg_name: "UNIT-EAUS-DEPLOYER-INFRASTRUCTURE"
-          saplib_rg_name: "UNIT-EAUS-SAP_LIBRARY"
-          sapsystem_rg_name: "SLES-EAUS-SAP0-PRD"
+          deployer_env: "UNIT"
+          saplib_env: "UNIT"
+          sapsystem_env: "SLES"
           osImage_offer: "sles-sap-12-sp5"
           osImage_publisher: "SUSE"
           osImage_sku: "gen1"
       - template: templates/util/remove-agent-from-deployer-nsg.yml
         parameters:
-          deployer_rg_name: "UNIT-EAUS-DEPLOYER-INFRASTRUCTURE"
+          deployer_env: "UNIT"
   - job: createSAPSystemRHEL
     dependsOn: createSAPLib
     steps:
       - template: templates/util/prepare-agent.yml
       - template: templates/util/collect-deployer-info.yml
         parameters:
-          deployer_rg_name: "UNIT-EAUS-DEPLOYER-INFRASTRUCTURE"
+          deployer_env: "UNIT"
       - template: templates/util/add-agent-to-deployer-nsg.yml
         parameters:
-          deployer_rg_name: "UNIT-EAUS-DEPLOYER-INFRASTRUCTURE"
+          deployer_env: "UNIT"
       - template: templates/sapsystem/create-sapsystem-steps.yml
         parameters:
           branch_name: $(sourceBranchName)
-          deployer_rg_name: "UNIT-EAUS-DEPLOYER-INFRASTRUCTURE"
-          saplib_rg_name: "UNIT-EAUS-SAP_LIBRARY"
-          sapsystem_rg_name: "RHEL-EAUS-SAP0-PRD"
+          deployer_env: "UNIT"
+          saplib_env: "UNIT"
+          sapsystem_env: "RHEL"
           osImage_offer: "RHEL-SAP-HA"
           osImage_publisher: "RedHat"
           osImage_sku: "7.6"
       - template: templates/util/remove-agent-from-deployer-nsg.yml
         parameters:
-          deployer_rg_name: "UNIT-EAUS-DEPLOYER-INFRASTRUCTURE"
+          deployer_env: "UNIT"
   - job: runAnsibleSLES
     timeoutInMinutes: 120
     dependsOn: createSAPSystemSLES
@@ -131,14 +131,14 @@ stages:
       - template: templates/util/prepare-agent.yml
       - template: templates/util/collect-deployer-info.yml
         parameters:
-          deployer_rg_name: "UNIT-EAUS-DEPLOYER-INFRASTRUCTURE"
+          deployer_env: "UNIT"
       - template: templates/util/add-agent-to-deployer-nsg.yml
         parameters:
-          deployer_rg_name: "UNIT-EAUS-DEPLOYER-INFRASTRUCTURE"
+          deployer_env: "UNIT"
       - template: templates/ansible/ansible-playbook-steps.yml
         parameters:
           branch_name: $(sourceBranchName)
-          sapsystem_rg_name: "SLES-EAUS-SAP0-PRD"
+          sapsystem_rg_name: "SLES-EAUS-SAP-PRD"
       - template: templates/util/remove-agent-from-deployer-nsg.yml
         parameters:
-          deployer_rg_name: "UNIT-EAUS-DEPLOYER-INFRASTRUCTURE"
+          deployer_env: "UNIT"

--- a/.pipeline/tf-saplib-test.yml
+++ b/.pipeline/tf-saplib-test.yml
@@ -24,25 +24,25 @@ stages:
       - template: templates/util/prepare-agent.yml
       - template: templates/util/collect-deployer-info.yml
         parameters:
-          deployer_rg_name: "UNIT-EAUS-DEPLOYER-INFRASTRUCTURE"
+          deployer_env: "UNIT"
       - template: templates/util/add-agent-to-deployer-nsg.yml
         parameters:
-          deployer_rg_name: "UNIT-EAUS-DEPLOYER-INFRASTRUCTURE"
+          deployer_env: "UNIT"
       - template: templates/saplib/create-saplib-steps.yml
         parameters:
           branch_name: $(targetBranchName)
-          saplib_rg_name: "$(Build.BuildId)-EAUS-SAP_LIBRARY"
+          saplib_env: "$(Build.BuildId)"
       - template: templates/saplib/validate-saplib-steps.yml
         parameters:
           branch_name: $(sourceBranchName)
-          saplib_rg_name: "$(Build.BuildId)-EAUS-SAP_LIBRARY"
+          saplib_env: "$(Build.BuildId)"
       - template: templates/saplib/create-saplib-steps.yml
         parameters:
           branch_name: $(sourceBranchName)
-          saplib_rg_name: "$(Build.BuildId)-EAUS-SAP_LIBRARY"
+          saplib_env: "$(Build.BuildId)"
       - template: templates/util/remove-agent-from-deployer-nsg.yml
         parameters:
-          deployer_rg_name: "UNIT-EAUS-DEPLOYER-INFRASTRUCTURE"
+          deployer_env: "UNIT"
   - job: deleteSAPLib
     dependsOn: createSAPLib
     condition: or(succeededOrFailed(), always())
@@ -50,14 +50,14 @@ stages:
       - template: templates/util/prepare-agent.yml
       - template: templates/util/collect-deployer-info.yml
         parameters:
-          deployer_rg_name: "UNIT-EAUS-DEPLOYER-INFRASTRUCTURE"
+          deployer_env: "UNIT"
       - template: templates/util/add-agent-to-deployer-nsg.yml
         parameters:
-          deployer_rg_name: "UNIT-EAUS-DEPLOYER-INFRASTRUCTURE"
+          deployer_env: "UNIT"
       - template: templates/saplib/delete-saplib-steps.yml
         parameters:
           branch_name: $(sourceBranchName)
-          saplib_rg_name: "$(Build.BuildId)-EAUS-SAP_LIBRARY"
+          saplib_env: "$(Build.BuildId)"
       - template: templates/util/remove-agent-from-deployer-nsg.yml
         parameters:
-          deployer_rg_name: "UNIT-EAUS-DEPLOYER-INFRASTRUCTURE"
+          deployer_env: "UNIT"

--- a/.pipeline/tf-sapsystem-test.yml
+++ b/.pipeline/tf-sapsystem-test.yml
@@ -23,29 +23,29 @@ stages:
       - template: templates/util/prepare-agent.yml
       - template: templates/util/collect-deployer-info.yml
         parameters:
-          deployer_rg_name: "UNIT-EAUS-DEPLOYER-INFRASTRUCTURE"
+          deployer_env: "UNIT"
       - template: templates/util/add-agent-to-deployer-nsg.yml
         parameters:
-          deployer_rg_name: "UNIT-EAUS-DEPLOYER-INFRASTRUCTURE"
+          deployer_env: "UNIT"
       - template: templates/sapsystem/create-sapsystem-steps.yml
         parameters:
           branch_name: $(targetBranchName)
-          deployer_rg_name: "UNIT-EAUS-DEPLOYER-INFRASTRUCTURE"
-          saplib_rg_name: "UNIT-EAUS-SAP_LIBRARY"
-          sapsystem_rg_name: "$(Build.BuildId)-EAUS-SAP0-PRD"
+          deployer_env: "UNIT"
+          saplib_env: "UNIT"
+          sapsystem_env: "$(Build.BuildId)"
       - template: templates/sapsystem/validate-sapsystem-steps.yml
         parameters:
           branch_name: $(sourceBranchName)
-          sapsystem_rg_name: "$(Build.BuildId)-EAUS-SAP0-PRD"
+          sapsystem_env: "$(Build.BuildId)"
       - template: templates/sapsystem/create-sapsystem-steps.yml
         parameters:
           branch_name: $(sourceBranchName)
-          deployer_rg_name: "UNIT-EAUS-DEPLOYER-INFRASTRUCTURE"
-          saplib_rg_name: "UNIT-EAUS-SAP_LIBRARY"
-          sapsystem_rg_name: "$(Build.BuildId)-EAUS-SAP0-PRD"
+          deployer_env: "UNIT"
+          saplib_env: "UNIT"
+          sapsystem_env: "$(Build.BuildId)"
       - template: templates/util/remove-agent-from-deployer-nsg.yml
         parameters:
-          deployer_rg_name: "UNIT-EAUS-DEPLOYER-INFRASTRUCTURE"
+          deployer_env: "UNIT"
   - job: deleteSAPSystem
     dependsOn: createSAPSystem
     condition: or(succeededOrFailed(), always())
@@ -53,15 +53,15 @@ stages:
       - template: templates/util/prepare-agent.yml
       - template: templates/util/collect-deployer-info.yml
         parameters:
-          deployer_rg_name: "UNIT-EAUS-DEPLOYER-INFRASTRUCTURE"
+          deployer_env: "UNIT"
       - template: templates/util/add-agent-to-deployer-nsg.yml
         parameters:
-          deployer_rg_name: "UNIT-EAUS-DEPLOYER-INFRASTRUCTURE"
+          deployer_env: "UNIT"
       - template: templates/sapsystem/delete-sapsystem-steps.yml
         parameters:
           branch_name: $(sourceBranchName)
-          deployer_rg_name: "UNIT-EAUS-DEPLOYER-INFRASTRUCTURE"
-          sapsystem_rg_name: "$(Build.BuildId)-EAUS-SAP0-PRD"
+          deployer_env: "UNIT"
+          sapsystem_env: "$(Build.BuildId)"
       - template: templates/util/remove-agent-from-deployer-nsg.yml
         parameters:
-          deployer_rg_name: "UNIT-EAUS-DEPLOYER-INFRASTRUCTURE"
+          deployer_env: "UNIT"

--- a/deploy/terraform/terraform-units/modules/sap_system/deployer/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/deployer/variables_local.tf
@@ -50,6 +50,6 @@ locals {
   // Default value follows naming convention
   saplib_resource_group_name   = try(local.deployer_config.saplib_resource_group_name, "${local.environment}-${local.location_short}-sap_library")
   tfstate_storage_account_name = try(local.deployer_config.tfstate_storage_account_name, "")
-  tfstate_container_name       = "saplibrary"
+  tfstate_container_name       = "tfstate"
   deployer_tfstate_key         = try(local.deployer_config.deployer_tfstate_key, "${local.environment}-${local.location_short}-deployer-infrastructure.terraform.tfstate")
 }

--- a/deploy/terraform/terraform-units/modules/sap_system/saplibrary/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/saplibrary/variables_local.tf
@@ -50,7 +50,7 @@ locals {
   // Default value follows naming convention
   saplib_resource_group_name   = try(local.sapbits_config.saplib_resource_group_name, "${local.environment}-${local.location_short}-sap_library")
   tfstate_storage_account_name = try(local.sapbits_config.tfstate_storage_account_name, "")
-  tfstate_container_name       = try(local.sapbits_config.tfstate_container_name, "saplibrary")
+  tfstate_container_name       = try(local.sapbits_config.tfstate_container_name, "tfstate")
   saplib_tfstate_key           = try(local.sapbits_config.saplib_tfstate_key, "${local.environment}-${local.location_short}-sap_library.terraform.tfstate")
 
 }


### PR DESCRIPTION
## Problem
Using buildId as environment causes pipeline failure ([log](https://dev.azure.com/azuresaphana/Azure-SAP-HANA/_build/results?buildId=10063&view=logs&j=3e7c2453-b9e0-5f22-4314-eb3ec9329da1&t=986ce2cf-d4cb-5784-8c1c-ac0cfcf6cbc6)), because of naming limit for KVs.

## Solution
Instead of use buildId, use concat string with U and 4 digits from buildId.
Also there is a limit of 5 chars for environment, apply that as well to make sure length of the environment in pipeline does not exceed.

## Tests
https://dev.azure.com/azuresaphana/Azure-SAP-HANA/_build/results?buildId=10222&view=results
https://dev.azure.com/azuresaphana/Azure-SAP-HANA/_build/results?buildId=10221&view=results
https://dev.azure.com/azuresaphana/Azure-SAP-HANA/_build/results?buildId=10219&view=results
https://dev.azure.com/azuresaphana/Azure-SAP-HANA/_build/results?buildId=10223&view=results

## Notes
This PR also fixed issues that came recent changes in `feature/remote-tfstate`, eg:
- default deployer VNET name is now `MGMT` instead of `DEPLOYER` for `sap_deployer`.
- remote tfstate container is now changed from `saplibrary` to `tfstate`.
- default sap_system VNET name is now `SAP` instead of `SAP0` for `sap_system`. 