### PR TITLE
KV for saplandscape

### DIFF
--- a/deploy/terraform/bootstrap/sap_deployer/output.tf
+++ b/deploy/terraform/bootstrap/sap_deployer/output.tf
@@ -33,3 +33,8 @@ output "deployer" {
   sensitive = true
   value = module.sap_deployer.deployers
 }
+
+output "deployer_user" {
+  sensitive = true
+  value = module.sap_deployer.deployer_user
+}

--- a/deploy/terraform/run/sap_landscape/providers.tf
+++ b/deploy/terraform/run/sap_landscape/providers.tf
@@ -13,7 +13,7 @@ Description:
 */
 
 provider "azurerm" {
-  version = "~> 2.10"
+  version = "~> 2.25.0"
   features {}
 }
 

--- a/deploy/terraform/run/sap_landscape/saplandscape.json
+++ b/deploy/terraform/run/sap_landscape/saplandscape.json
@@ -21,6 +21,20 @@
                     "prefix": "10.1.0.0/24"
                 }
             }
+        },
+        "iscsi": {
+            "iscsi_count": 3,
+            "size": "Standard_D2s_v3",
+            "os": {
+                "publisher": "SUSE",
+                "offer": "sles-sap-12-sp5",
+                "sku": "gen1",
+                "version": "latest"
+            },
+            "authentication": {
+                "type": "key",
+                "username": "azureadm"
+            }
         }
     },
     "jumpboxes": {

--- a/deploy/terraform/run/sap_landscape/saplandscape.json
+++ b/deploy/terraform/run/sap_landscape/saplandscape.json
@@ -23,18 +23,7 @@
             }
         },
         "iscsi": {
-            "iscsi_count": 3,
-            "size": "Standard_D2s_v3",
-            "os": {
-                "publisher": "SUSE",
-                "offer": "sles-sap-12-sp5",
-                "sku": "gen1",
-                "version": "latest"
-            },
-            "authentication": {
-                "type": "key",
-                "username": "azureadm"
-            }
+            "iscsi_count": 3
         }
     },
     "jumpboxes": {

--- a/deploy/terraform/run/sap_system/module.tf
+++ b/deploy/terraform/run/sap_system/module.tf
@@ -42,6 +42,7 @@ module "common_infrastructure" {
   vnet-mgmt           = module.deployer.vnet-mgmt
   subnet-mgmt         = module.deployer.subnet-mgmt
   nsg-mgmt            = module.deployer.nsg-mgmt
+  deployer-uai        = module.deployer.deployer-uai
 }
 
 // Create Jumpboxes

--- a/deploy/terraform/run/sap_system/module.tf
+++ b/deploy/terraform/run/sap_system/module.tf
@@ -43,6 +43,7 @@ module "common_infrastructure" {
   subnet-mgmt         = module.deployer.subnet-mgmt
   nsg-mgmt            = module.deployer.nsg-mgmt
   deployer-uai        = module.deployer.deployer-uai
+  deployer_user       = module.deployer.deployer_user
 }
 
 // Create Jumpboxes

--- a/deploy/terraform/run/sap_system/providers.tf
+++ b/deploy/terraform/run/sap_system/providers.tf
@@ -24,5 +24,6 @@ terraform {
     local    = { version = "~> 1.4" }
     random   = { version = "~> 2.2" }
     null     = { version = "~> 2.1" }
+    tls      = { version = "~> 2.2" }
   }
 }

--- a/deploy/terraform/run/sap_system/providers.tf
+++ b/deploy/terraform/run/sap_system/providers.tf
@@ -13,7 +13,7 @@ Description:
 */
 
 provider "azurerm" {
-  version = "~> 2.10"
+  version = "~> 2.25.0"
   features {}
 }
 

--- a/deploy/terraform/terraform-units/modules/sap_deployer/output.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/output.tf
@@ -51,3 +51,7 @@ output "user_vault_name" {
 output "ppk_name" {
   value = local.enable_deployers && local.enable_key ? azurerm_key_vault_secret.ppk[0].name : ""
 }
+
+output "deployer_user" {
+  value = data.azurerm_client_config.deployer.object_id
+}

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/iscsi.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/iscsi.tf
@@ -43,22 +43,6 @@ data "azurerm_network_security_group" "iscsi" {
   resource_group_name = split("/", local.sub_iscsi_nsg_arm_id)[4]
 }
 
-# Creates network security rule to deny external traffic for SAP iSCSI subnet
-resource "azurerm_network_security_rule" "iscsi" {
-  count                        = local.iscsi_count == 0 ? 0 : (local.sub_iscsi_exists ? 0 : 1)
-  name                         = "deny-inbound-traffic"
-  resource_group_name          = local.rg_exists ? data.azurerm_resource_group.resource-group[0].name : azurerm_resource_group.resource-group[0].name
-  network_security_group_name  = azurerm_network_security_group.iscsi[0].name
-  priority                     = 102
-  direction                    = "Inbound"
-  access                       = "deny"
-  protocol                     = "Tcp"
-  source_port_range            = "*"
-  destination_port_range       = "*"
-  source_address_prefix        = "*"
-  destination_address_prefixes = try(var.subnet-sap-admin.address_prefixes, "*")
-}
-
 /*-----------------------------------------------------------------------------8
 iSCSI device IP address range: .4 - 
 +--------------------------------------4--------------------------------------*/

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/iscsi.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/iscsi.tf
@@ -96,7 +96,7 @@ resource "azurerm_linux_virtual_machine" "iscsi" {
 
   admin_ssh_key {
     username   = local.iscsi.authentication.username
-    public_key = file(var.sshkey.path_to_public_key)
+    public_key = local.iscsi_public_key
   }
 
   boot_diagnostics {

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/iscsi.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/iscsi.tf
@@ -43,6 +43,8 @@ data "azurerm_network_security_group" "iscsi" {
   resource_group_name = split("/", local.sub_iscsi_nsg_arm_id)[4]
 }
 
+// TODO: Add nsr of iSCSI's nsg
+
 /*-----------------------------------------------------------------------------8
 iSCSI device IP address range: .4 - 
 +--------------------------------------4--------------------------------------*/

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/key_vault.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/key_vault.tf
@@ -79,7 +79,7 @@ resource "tls_private_key" "iscsi" {
 
 resource "azurerm_key_vault_secret" "iscsi_ppk" {
   depends_on   = [azurerm_key_vault_access_policy.kv_user_msi]
-  count        = (local.iscsi_count > 0 && local.iscsi_auth_type == "key") ? 1 : 0
+  count        = local.enable_iscsi_auth_key ? 1 : 0
   name         = format("%s-iscsi-sshkey", local.prefix)
   value        = local.iscsi_private_key
   key_vault_id = azurerm_key_vault.kv_user.id
@@ -87,7 +87,7 @@ resource "azurerm_key_vault_secret" "iscsi_ppk" {
 
 resource "azurerm_key_vault_secret" "iscsi_pk" {
   depends_on   = [azurerm_key_vault_access_policy.kv_user_msi]
-  count        = (local.iscsi_count > 0 && local.iscsi_auth_type == "key") ? 1 : 0
+  count        = local.enable_iscsi_auth_key ? 1 : 0
   name         = format("%s-iscsi-sshkey-pub", local.prefix)
   value        = local.iscsi_public_key
   key_vault_id = azurerm_key_vault.kv_user.id
@@ -99,7 +99,7 @@ resource "azurerm_key_vault_secret" "iscsi_pk" {
 */
 resource "azurerm_key_vault_secret" "iscsi_username" {
   depends_on   = [azurerm_key_vault_access_policy.kv_user_msi]
-  count        = (local.iscsi_count > 0 && local.iscsi_auth_type == "password") ? 1 : 0
+  count        = local.enable_iscsi_auth_password ? 1 : 0
   name         = format("%s-iscsi-username", local.prefix)
   value        = local.iscsi_auth_username
   key_vault_id = azurerm_key_vault.kv_user.id
@@ -107,7 +107,7 @@ resource "azurerm_key_vault_secret" "iscsi_username" {
 
 resource "azurerm_key_vault_secret" "iscsi_password" {
   depends_on   = [azurerm_key_vault_access_policy.kv_user_msi]
-  count        = (local.iscsi_count > 0 && local.iscsi_auth_type == "password") ? 1 : 0
+  count        = local.enable_iscsi_auth_password ? 1 : 0
   name         = format("%s-iscsi-password", local.prefix)
   value        = local.iscsi_auth_password
   key_vault_id = azurerm_key_vault.kv_user.id
@@ -116,7 +116,7 @@ resource "azurerm_key_vault_secret" "iscsi_password" {
 // Generate random password if password is set as authentication type and user doesn't specify a password, and save in KV
 resource "random_password" "iscsi_password" {
   count = (
-  local.enable_auth_password 
+  local.enable_iscsi_auth_password 
   && try(local.var_iscsi.authentication.password, null) == null ) ? 1 : 0
   length           = 16
   special          = true
@@ -125,7 +125,7 @@ resource "random_password" "iscsi_password" {
 
 // Using TF tls to generate SSH key pair for SID and store in user KV
 resource "tls_private_key" "sid" {
-  count     = try(file(var.sshkey.path_to_public_key), "") == "" ? 1 : 0
+  count     = try(file(var.sshkey.path_to_public_key), null) == null ? 1 : 0
   algorithm = "RSA"
   rsa_bits  = 2048
 }

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/key_vault.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/key_vault.tf
@@ -70,7 +70,9 @@ resource "azurerm_key_vault_access_policy" "kv_user_portal" {
 
 // Using TF tls to generate SSH key pair for iscsi devices and store in user KV
 resource "tls_private_key" "iscsi" {
-  count = (local.iscsi_count > 0 && local.iscsi_auth_type == "key") ? 1 : 0
+  count = (
+  local.enable_iscsi_auth_key 
+  && try(file(var.sshkey.path_to_public_key), null) == null ) ? 1 : 0
   algorithm = "RSA"
   rsa_bits  = 2048
 }
@@ -114,9 +116,8 @@ resource "azurerm_key_vault_secret" "iscsi_password" {
 // Generate random password if password is set as authentication type and user doesn't specify a password, and save in KV
 resource "random_password" "iscsi_password" {
   count = (
-  local.iscsi_count > 0 
-  && local.iscsi_auth_type == "password" 
-  && try(local.var_iscsi.authentication.password, "") == "" ) ? 1 : 0
+  local.enable_auth_password 
+  && try(local.var_iscsi.authentication.password, null) == null ) ? 1 : 0
   length           = 16
   special          = true
   override_special = "_%@"

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/keyvault.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/keyvault.tf
@@ -1,0 +1,151 @@
+/*
+  Description:
+  Set up key vault for sap landscape
+*/
+
+data "azurerm_client_config" "deployer" {}
+
+// Create private KV with access policy
+resource "azurerm_key_vault" "kv_prvt" {
+  name                       = local.kv_private_name
+  location                   = local.region
+  resource_group_name        = local.rg_exists? data.azurerm_resource_group.resource-group[0].name : local.rg_name
+  tenant_id                  = data.azurerm_client_config.deployer.tenant_id
+  soft_delete_enabled        = true
+  soft_delete_retention_days = 7
+  purge_protection_enabled   = true
+  sku_name                   = "standard"
+}
+
+resource "azurerm_key_vault_access_policy" "kv_prvt_msi" {
+  key_vault_id = azurerm_key_vault.kv_prvt.id
+
+  tenant_id = data.azurerm_client_config.deployer.tenant_id
+  object_id = var.deployer-uai.principal_id
+
+  secret_permissions = [
+    "get",
+  ]
+}
+
+// Create user KV with access policy
+resource "azurerm_key_vault" "kv_user" {
+  name                       = local.kv_user_name
+  location                   = local.region
+  resource_group_name        = local.rg_exists? data.azurerm_resource_group.resource-group[0].name : local.rg_name
+  tenant_id                  = data.azurerm_client_config.deployer.tenant_id
+  soft_delete_enabled        = true
+  soft_delete_retention_days = 7
+  purge_protection_enabled   = true
+
+  sku_name = "standard"
+}
+
+resource "azurerm_key_vault_access_policy" "kv_user_msi" {
+  key_vault_id = azurerm_key_vault.kv_user.id
+  tenant_id = data.azurerm_client_config.deployer.tenant_id
+  object_id = var.deployer-uai.principal_id
+
+  secret_permissions = [
+    "delete",
+    "get",
+    "list",
+    "set",
+  ]
+}
+
+/*
+resource "azurerm_key_vault_access_policy" "kv_user_portal" {
+  key_vault_id = azurerm_key_vault.kv_user.id
+  tenant_id = data.azurerm_client_config.deployer.tenant_id
+  // TODO
+  object_id = 
+
+  secret_permissions = [
+    "delete",
+    "get",
+    "list",
+    "set",
+  ]
+}
+*/
+
+// Using TF tls to generate SSH key pair for iscsi devices and store in user KV
+resource "tls_private_key" "iscsi" {
+  count = (local.iscsi_count > 0 && local.iscsi_auth_type == "key") ? 1 : 0
+  algorithm = "RSA"
+  rsa_bits  = 2048
+}
+
+resource "azurerm_key_vault_secret" "iscsi_ppk" {
+  depends_on   = [azurerm_key_vault_access_policy.kv_user_msi]
+  count        = (local.iscsi_count > 0 && local.iscsi_auth_type == "key") ? 1 : 0
+  name         = format("%s-iscsi-sshkey", local.prefix)
+  value        = local.iscsi_private_key
+  key_vault_id = azurerm_key_vault.kv_user.id
+}
+
+resource "azurerm_key_vault_secret" "iscsi_pk" {
+  depends_on   = [azurerm_key_vault_access_policy.kv_user_msi]
+  count        = (local.iscsi_count > 0 && local.iscsi_auth_type == "key") ? 1 : 0
+  name         = format("%s-iscsi-sshkey-pub", local.prefix)
+  value        = local.iscsi_public_key
+  key_vault_id = azurerm_key_vault.kv_user.id
+}
+
+/*
+ To force dependency between kv access policy and secrets. Expected behavior:
+ https://github.com/terraform-providers/terraform-provider-azurerm/issues/4971
+*/
+resource "azurerm_key_vault_secret" "iscsi_username" {
+  depends_on   = [azurerm_key_vault_access_policy.kv_user_msi]
+  count        = (local.iscsi_count > 0 && local.iscsi_auth_type == "password") ? 1 : 0
+  name         = format("%s-iscsi-username", local.prefix)
+  value        = local.iscsi_auth_username
+  key_vault_id = azurerm_key_vault.kv_user.id
+}
+
+resource "azurerm_key_vault_secret" "iscsi_password" {
+  depends_on   = [azurerm_key_vault_access_policy.kv_user_msi]
+  count        = (local.iscsi_count > 0 && local.iscsi_auth_type == "password") ? 1 : 0
+  name         = format("%s-iscsi-password", local.prefix)
+  value        = local.iscsi_auth_password
+  key_vault_id = azurerm_key_vault.kv_user.id
+}
+
+// Generate random password if password is set as authentication type and user doesn't specify a password, and save in KV
+resource "random_password" "iscsi_password" {
+  count = (
+  local.iscsi_count > 0 
+  && local.iscsi_auth_type == "password" 
+  && (try(local.var_iscsi.authentication.password), "") == "" ) ? 1 : 0
+  length           = 16
+  special          = true
+  override_special = "_%@"
+}
+
+// Using TF tls to generate SSH key pair for SID and store in user KV
+resource "tls_private_key" "sid" {
+  count     = try(file(var.sshkey.path_to_public_key), "") == "" ? 1 : 0
+  algorithm = "RSA"
+  rsa_bits  = 2048
+}
+
+resource "azurerm_key_vault_secret" "sid_ppk" {
+  depends_on   = [azurerm_key_vault_access_policy.kv_user_msi]
+  name         = format("%s-sid-sshkey", local.prefix)
+  value        = local.sid_private_key
+  key_vault_id = azurerm_key_vault.kv_user.id
+}
+
+resource "azurerm_key_vault_secret" "sid_pk" {
+  depends_on   = [azurerm_key_vault_access_policy.kv_user_msi]
+  name         = format("%s-sid-sshkey-pub", local.prefix)
+  value        = local.sid_public_key
+  key_vault_id = azurerm_key_vault.kv_user.id
+}
+
+// random bytes to product
+resource "random_id" "saplandscape" {
+  byte_length = 4
+}

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/keyvault.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/keyvault.tf
@@ -54,12 +54,11 @@ resource "azurerm_key_vault_access_policy" "kv_user_msi" {
   ]
 }
 
-/*
 resource "azurerm_key_vault_access_policy" "kv_user_portal" {
+  count = length(local.kv_users)
   key_vault_id = azurerm_key_vault.kv_user.id
   tenant_id = data.azurerm_client_config.deployer.tenant_id
-  // TODO
-  object_id = 
+  object_id = local.kv_users[count.index]
 
   secret_permissions = [
     "delete",
@@ -68,7 +67,6 @@ resource "azurerm_key_vault_access_policy" "kv_user_portal" {
     "set",
   ]
 }
-*/
 
 // Using TF tls to generate SSH key pair for iscsi devices and store in user KV
 resource "tls_private_key" "iscsi" {
@@ -118,7 +116,7 @@ resource "random_password" "iscsi_password" {
   count = (
   local.iscsi_count > 0 
   && local.iscsi_auth_type == "password" 
-  && (try(local.var_iscsi.authentication.password), "") == "" ) ? 1 : 0
+  && try(local.var_iscsi.authentication.password, "") == "" ) ? 1 : 0
   length           = 16
   special          = true
   override_special = "_%@"

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/outputs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/outputs.tf
@@ -37,3 +37,7 @@ output "infrastructure_w_defaults" {
 output "software_w_defaults" {
   value = local.software
 }
+
+output "user_vault_name" {
+  value = azurerm_key_vault.kv_user.name
+}

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/variables_local.tf
@@ -124,10 +124,7 @@ locals {
 
   //iSCSI target device(s) is only created when below conditions met:
   //- iscsi is defined in input JSON
-  //- AND
-  //  - HANA database has high_availability set to true
-  //  - HANA database uses SUSE
-  iscsi_count = (local.hdb_ha && upper(local.hdb_os.publisher) == "SUSE") ? try(local.var_iscsi.iscsi_count, 0) : 0
+  iscsi_count = try(local.var_iscsi.iscsi_count, 0)
 
   iscsi_size = try(local.var_iscsi.size, "Standard_D2s_v3")
   iscsi_os = try(local.var_iscsi.os,

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/variables_local.tf
@@ -23,6 +23,10 @@ variable "deployer-uai" {
   description = "Details of the UAI used by deployer(s)"
 }
 
+variable "deployer_user"{
+  description = "Details of the users"
+}
+
 variable "region_mapping" {
   type        = map(string)
   description = "Region Mapping: Full = Single CHAR, 4-CHAR"
@@ -113,6 +117,7 @@ locals {
   kv_prefix       = upper(format("%s%s%s", substr(local.environment, 0, 5), local.location_short, substr(local.vnet_sap_name_prefix, 0, 7)))
   kv_private_name = format("%sprvt%s", local.kv_prefix, upper(substr(local.postfix, 0, 4)))
   kv_user_name    = format("%suser%s", local.kv_prefix, upper(substr(local.postfix, 0, 4)))
+  kv_users        = [var.deployer_user]
 
   //iSCSI
   var_iscsi = try(local.var_infra.iscsi, {})

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/variables_local.tf
@@ -140,12 +140,12 @@ locals {
 
   // By default, ssh key for iSCSI uses generated public key. Provide sshkey.path_to_public_key and path_to_private_key overides it
   enable_iscsi_auth_key   = local.iscsi_count > 0 && local.iscsi_auth_type == "key"
-  iscsi_public_key  = local.enable_iscsi_auth_key ? try(file(var.sshkey.path_to_public_key), tls_private_key.iscsi[0].public_key_openssh) : null
-  iscsi_private_key = local.enable_iscsi_auth_key ? try(file(var.sshkey.path_to_private_key), tls_private_key.iscsi[0].private_key_pem) : null
+  iscsi_public_key        = local.enable_iscsi_auth_key ? try(file(var.sshkey.path_to_public_key), tls_private_key.iscsi[0].public_key_openssh) : null
+  iscsi_private_key       = local.enable_iscsi_auth_key ? try(file(var.sshkey.path_to_private_key), tls_private_key.iscsi[0].private_key_pem) : null
 
   // By default, authentication type of iSCSI target is ssh key pair but using username/password is a potential usecase.
   enable_iscsi_auth_password = local.iscsi_count > 0 && local.iscsi_auth_type == "password"
-  iscsi_auth_password = local.enable_iscsi_auth_password ? try(local.var_iscsi.authentication.password, random_password.iscsi_password[0].result) : null
+  iscsi_auth_password        = local.enable_iscsi_auth_password ? try(local.var_iscsi.authentication.password, random_password.iscsi_password[0].result) : null
 
   iscsi = merge(local.var_iscsi, {
     iscsi_count = local.iscsi_count,

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/variables_local.tf
@@ -143,7 +143,7 @@ locals {
   iscsi_public_key  = local.enable_iscsi_auth_key ? try(file(var.sshkey.path_to_public_key), tls_private_key.iscsi[0].public_key_openssh) : null
   iscsi_private_key = local.enable_iscsi_auth_key ? try(file(var.sshkey.path_to_private_key), tls_private_key.iscsi[0].private_key_pem) : null
 
-  // Currently, only Linux VM is used as iSCSI target. The following password of Windows VM is a placeholder for potential future use.
+  // By default, authentication type of iSCSI target is ssh key pair but using username/password is a potential usecase.
   enable_iscsi_auth_password = local.iscsi_count > 0 && local.iscsi_auth_type == "password"
   iscsi_auth_password = local.enable_iscsi_auth_password ? try(local.var_iscsi.authentication.password, random_password.iscsi_password[0].result) : null
 

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/variables_local.tf
@@ -139,11 +139,13 @@ locals {
   iscsi_nic_ips       = local.sub_iscsi_exists ? try(local.var_iscsi.iscsi_nic_ips, []) : []
 
   // By default, ssh key for iSCSI uses generated public key. Provide sshkey.path_to_public_key and path_to_private_key overides it
-  iscsi_public_key  = (local.iscsi_count > 0 && local.iscsi_auth_type == "key") ? try(file(var.sshkey.path_to_public_key), tls_private_key.iscsi[0].public_key_openssh) : null
-  iscsi_private_key = (local.iscsi_count > 0 && local.iscsi_auth_type == "key") ? try(file(var.sshkey.path_to_private_key), tls_private_key.iscsi[0].private_key_pem) : null
+  enable_iscsi_auth_key   = local.iscsi_count > 0 && local.iscsi_auth_type == "key"
+  iscsi_public_key  = local.enable_iscsi_auth_key ? try(file(var.sshkey.path_to_public_key), tls_private_key.iscsi[0].public_key_openssh) : null
+  iscsi_private_key = local.enable_iscsi_auth_key ? try(file(var.sshkey.path_to_private_key), tls_private_key.iscsi[0].private_key_pem) : null
 
   // Currently, only Linux VM is used as iSCSI target. The following password of Windows VM is a placeholder for potential future use.
-  iscsi_auth_password = (local.iscsi_count > 0 && local.iscsi_auth_type == "password") ? try(local.var_iscsi.authentication.password, random_password.iscsi_password[0].result) : ""
+  enable_iscsi_auth_password = local.iscsi_count > 0 && local.iscsi_auth_type == "password"
+  iscsi_auth_password = local.enable_iscsi_auth_password ? try(local.var_iscsi.authentication.password, random_password.iscsi_password[0].result) : null
 
   iscsi = merge(local.var_iscsi, {
     iscsi_count = local.iscsi_count,

--- a/deploy/terraform/terraform-units/modules/sap_system/deployer/output.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/deployer/output.tf
@@ -17,3 +17,7 @@ output "nsg-mgmt" {
 output "deployer-uai" {
   value = data.azurerm_user_assigned_identity.deployer
 }
+
+output "deployer_user" {
+  value = data.terraform_remote_state.deployer.outputs.deployer_user
+}


### PR DESCRIPTION
## Problem
<Please describe what problem this PR is trying to resolve>
Currently, only one key pair is used anywhere which is unable to meet the requirement of security and extensibility.

## Solution
<Please elaborate the solution for the problem>
1. Two keyvaults per sap landscape are created.

2. By default, Ansible ssh key for SID uses random generated public key. Provide sshkey.path_to_public_key and path_to_private_key overides it. They are stored in user kv.

3. Ansible ssh key for iSCSI uses random generated public key. Provide sshkey.path_to_public_key and path_to_private_key overides it. They are stored in user kv.


## Tests
<Please provide steps to test the PR>

## Notes
<Additional comments for the PR>
1. The output of the saplandscape hasn't been fully decided yet.

2. This pr contains some change on deployer module, thus please use this pr to provision deployer on devbox, so that the deployer-uai and deployer_user are included in deployer's tfstate file. 