### PR TITLE
Provision KVs for applications tier, store logon username/password in KV

### DIFF
--- a/deploy/terraform/run/sap_system/module.tf
+++ b/deploy/terraform/run/sap_system/module.tf
@@ -102,6 +102,8 @@ module "app_tier" {
   storage-bootdiag = module.common_infrastructure.storage-bootdiag
   ppg              = module.common_infrastructure.ppg
   random-id        = module.common_infrastructure.random-id
+  deployer-uai     = module.deployer.deployer-uai
+  deployer_user    = module.deployer.deployer_user
 }
 
 // Create anydb database nodes

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/key_vault.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/key_vault.tf
@@ -72,7 +72,7 @@ resource "azurerm_key_vault_access_policy" "kv_user_portal" {
 resource "random_password" "password" {
   count = (
   local.enable_auth_password
-  && try(local.authentication.password, "") == "" ) ? 1 : 0
+  && try(local.authentication.password, null) == null ) ? 1 : 0
   length           = 16
   special          = true
   override_special = "_%@"

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/keyvault.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/keyvault.tf
@@ -1,0 +1,106 @@
+/*
+  Description:
+  Set up key vault for application
+*/
+
+data "azurerm_client_config" "deployer" {}
+
+// Create private KV with access policy
+resource "azurerm_key_vault" "kv_prvt" {
+  name                       = local.kv_private_name
+  location                   = local.region
+  resource_group_name        = var.resource-group[0].name
+  tenant_id                  = data.azurerm_client_config.deployer.tenant_id
+  soft_delete_enabled        = true
+  soft_delete_retention_days = 7
+  purge_protection_enabled   = true
+  sku_name                   = "standard"
+}
+
+resource "azurerm_key_vault_access_policy" "kv_prvt_msi" {
+  key_vault_id = azurerm_key_vault.kv_prvt.id
+
+  tenant_id = data.azurerm_client_config.deployer.tenant_id
+  object_id = var.deployer-uai.principal_id
+
+  secret_permissions = [
+    "get",
+  ]
+}
+
+// Create user KV with access policy
+resource "azurerm_key_vault" "kv_user" {
+  name                       = local.kv_user_name
+  location                   = local.region
+  resource_group_name        = var.resource-group[0].name
+  tenant_id                  = data.azurerm_client_config.deployer.tenant_id
+  soft_delete_enabled        = true
+  soft_delete_retention_days = 7
+  purge_protection_enabled   = true
+
+  sku_name = "standard"
+}
+
+resource "azurerm_key_vault_access_policy" "kv_user_msi" {
+  key_vault_id = azurerm_key_vault.kv_user.id
+  tenant_id = data.azurerm_client_config.deployer.tenant_id
+  object_id = var.deployer-uai.principal_id
+
+  secret_permissions = [
+    "delete",
+    "get",
+    "list",
+    "set",
+  ]
+}
+
+resource "azurerm_key_vault_access_policy" "kv_user_portal" {
+  count = length(local.kv_users)
+  key_vault_id = azurerm_key_vault.kv_user.id
+  tenant_id = data.azurerm_client_config.deployer.tenant_id
+  object_id = local.kv_users[count.index]
+
+  secret_permissions = [
+    "delete",
+    "get",
+    "list",
+    "set",
+  ]
+}
+
+// Generate random password if password is set as authentication type and user doesn't specify a password
+resource "random_password" "password" {
+  count = (
+  local.enable_auth_password
+  && try(local.authentication.password, "") == "" ) ? 1 : 0
+  length           = 16
+  special          = true
+  override_special = "_%@"
+}
+
+// random bytes to product
+resource "random_id" "sapsystem" {
+  byte_length = 4
+}
+
+/*
+ To force dependency between kv access policy and secrets. Expected behavior:
+ https://github.com/terraform-providers/terraform-provider-azurerm/issues/4971
+*/
+// for logon use
+resource "azurerm_key_vault_secret" "auth_username" {
+  depends_on   = [azurerm_key_vault_access_policy.kv_user_msi]
+  count        = local.enable_auth_password ? 1 : 0
+  name         = format("%s-sid-logon-username", local.prefix)
+  value        = local.sid_auth_username
+  key_vault_id = azurerm_key_vault.kv_user.id
+}
+
+// for logon use
+resource "azurerm_key_vault_secret" "auth_password" {
+  depends_on   = [azurerm_key_vault_access_policy.kv_user_msi]
+  count        = local.enable_auth_password ? 1 : 0
+  name         = format("%s-sid-logon-password", local.prefix)
+  value        = local.sid_auth_password
+  key_vault_id = azurerm_key_vault.kv_user.id
+}

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/outputs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/outputs.tf
@@ -9,3 +9,7 @@ output "nics-app" {
 output "nics-web" {
   value = azurerm_network_interface.web
 }
+
+output "user_vault_name" {
+  value = azurerm_key_vault.kv_user
+}

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/variables_local.tf
@@ -22,6 +22,14 @@ variable "random-id" {
   description = "Random hex string"
 }
 
+variable "deployer-uai" {
+  description = "Details of the UAI used by deployer(s)"
+}
+
+variable "deployer_user"{
+  description = "Details of the users"
+}
+
 variable "region_mapping" {
   type        = map(string)
   description = "Region Mapping: Full = Single CHAR, 4-CHAR"
@@ -71,6 +79,18 @@ locals {
   prefix      = try(local.var_infra.resource_group.name, upper(replace(replace(format("%s-%s-%s_%s-%s", local.environment, local.location_short, substr(local.vnet_sap_name_prefix, 0, 7), local.codename, local.sid), "_-", "-"), "--", "-")))
   sa_prefix   = lower(replace(format("%s%s%sdiag", substr(local.environment, 0, 5), local.location_short, substr(local.codename, 0, 7)), "--", "-"))
   vnet_prefix = try(local.var_infra.resource_group.name, format("%s-%s", local.environment, local.location_short))
+
+    // Post fix for all deployed resources
+  postfix = random_id.sapsystem.hex
+
+  // key vault for sap system
+  kv_prefix       = upper(format("%s%s%s", substr(local.environment, 0, 5), local.location_short, substr(local.vnet_sap_name_prefix, 0, 7)))
+  kv_private_name = format("%sSIDp%s", local.kv_prefix, upper(substr(local.postfix, 0, 3)))
+  kv_user_name    = format("%sSIDu%s", local.kv_prefix, upper(substr(local.postfix, 0, 3)))
+  kv_users        = [var.deployer_user]
+  enable_auth_password = local.enable_deployment && local.authentication.type == "password"
+  sid_auth_username    = local.authentication.username
+  sid_auth_password    = local.enable_auth_password ? try(local.authentication.password, random_password.password[0].result) : null
 
   # SAP vnet
   var_infra       = try(var.infrastructure, {})

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/variables_local.tf
@@ -89,7 +89,7 @@ locals {
   kv_user_name    = format("%sSIDu%s", local.kv_prefix, upper(substr(local.postfix, 0, 3)))
   kv_users        = [var.deployer_user]
   enable_auth_password = local.enable_deployment && local.authentication.type == "password"
-  sid_auth_username    = local.authentication.username
+  sid_auth_username    = try(local.authentication.username, "azureadm")
   sid_auth_password    = local.enable_auth_password ? try(local.authentication.password, random_password.password[0].result) : null
 
   # SAP vnet

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-app.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-app.tf
@@ -28,7 +28,8 @@ resource "azurerm_linux_virtual_machine" "app" {
   ]
   size                            = local.app_sizing.compute.vm_size
   admin_username                  = local.sid_auth_username
-  disable_password_authentication = true
+  disable_password_authentication = ! local.enable_auth_password
+  admin_password                  = local.sid_auth_password
 
   os_disk {
     name                 = format("%s_%sapp%02dl%s-osdisk", local.prefix, lower(local.sid), count.index, substr(var.random-id.hex,0,3))

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-app.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-app.tf
@@ -27,7 +27,7 @@ resource "azurerm_linux_virtual_machine" "app" {
     azurerm_network_interface.app[count.index].id
   ]
   size                            = local.app_sizing.compute.vm_size
-  admin_username                  = local.authentication.username
+  admin_username                  = local.sid_auth_username
   disable_password_authentication = true
 
   os_disk {
@@ -48,9 +48,12 @@ resource "azurerm_linux_virtual_machine" "app" {
     }
   }
 
-  admin_ssh_key {
-    username   = local.authentication.username
-    public_key = file(var.sshkey.path_to_public_key)
+  dynamic "admin_ssh_key" {
+    for_each = range(local.enable_auth_password ? 0 : 1)
+    content {
+      username   = local.sid_auth_username
+      public_key = file(var.sshkey.path_to_public_key)
+    }
   }
 
   boot_diagnostics {
@@ -71,8 +74,8 @@ resource "azurerm_windows_virtual_machine" "app" {
     azurerm_network_interface.app[count.index].id
   ]
   size           = local.app_sizing.compute.vm_size
-  admin_username = local.authentication.username
-  admin_password = local.authentication.password
+  admin_username = local.sid_auth_username
+  admin_password = local.sid_auth_password
 
   os_disk {
     name                 = format("%s_%sapp%02dw%s-osdisk", local.prefix, lower(local.sid), count.index, substr(var.random-id.hex,0,3))

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-scs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-scs.tf
@@ -36,7 +36,8 @@ resource "azurerm_linux_virtual_machine" "scs" {
   ]
   size                            = local.scs_sizing.compute.vm_size
   admin_username                  = local.sid_auth_username
-  disable_password_authentication = true
+  disable_password_authentication = ! local.enable_auth_password
+  admin_password                  = local.sid_auth_password
 
   os_disk {
     name                 = format("%s_%sscs%02dl%s-osdisk", local.prefix, lower(local.sid), count.index, substr(var.random-id.hex,0,3))
@@ -63,7 +64,7 @@ resource "azurerm_linux_virtual_machine" "scs" {
       public_key = file(var.sshkey.path_to_public_key)
     }
   }
-
+  
   boot_diagnostics {
     storage_account_uri = var.storage-bootdiag.primary_blob_endpoint
   }

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-scs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-scs.tf
@@ -35,7 +35,7 @@ resource "azurerm_linux_virtual_machine" "scs" {
     azurerm_network_interface.scs[count.index].id
   ]
   size                            = local.scs_sizing.compute.vm_size
-  admin_username                  = local.authentication.username
+  admin_username                  = local.sid_auth_username
   disable_password_authentication = true
 
   os_disk {
@@ -56,9 +56,12 @@ resource "azurerm_linux_virtual_machine" "scs" {
     }
   }
 
-  admin_ssh_key {
-    username   = local.authentication.username
-    public_key = file(var.sshkey.path_to_public_key)
+  dynamic "admin_ssh_key" {
+    for_each = range(local.enable_auth_password ? 0 : 1)
+    content {
+      username   = local.sid_auth_username
+      public_key = file(var.sshkey.path_to_public_key)
+    }
   }
 
   boot_diagnostics {
@@ -79,8 +82,8 @@ resource "azurerm_windows_virtual_machine" "scs" {
     azurerm_network_interface.scs[count.index].id
   ]
   size           = local.scs_sizing.compute.vm_size
-  admin_username = local.authentication.username
-  admin_password = local.authentication.password
+  admin_username = local.sid_auth_username
+  admin_password = local.sid_auth_password
 
   os_disk {
     name                 = format("%s_%sscs%02dw%s", local.prefix, lower(local.sid), count.index, substr(var.random-id.hex,0,3))

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-webdisp.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-webdisp.tf
@@ -28,7 +28,8 @@ resource "azurerm_linux_virtual_machine" "web" {
   ]
   size                            = local.web_sizing.compute.vm_size
   admin_username                  = local.sid_auth_username
-  disable_password_authentication = true
+  disable_password_authentication = ! local.enable_auth_password
+  admin_password                  = local.sid_auth_password
 
   os_disk {
     name                 = format("%s_%sweb%02dl%s-osdisk", local.prefix, lower(local.sid), count.index, substr(var.random-id.hex, 0, 3))

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-webdisp.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-webdisp.tf
@@ -27,7 +27,7 @@ resource "azurerm_linux_virtual_machine" "web" {
     azurerm_network_interface.web[count.index].id
   ]
   size                            = local.web_sizing.compute.vm_size
-  admin_username                  = local.authentication.username
+  admin_username                  = local.sid_auth_username
   disable_password_authentication = true
 
   os_disk {
@@ -48,9 +48,12 @@ resource "azurerm_linux_virtual_machine" "web" {
     }
   }
 
-  admin_ssh_key {
-    username   = local.authentication.username
-    public_key = file(var.sshkey.path_to_public_key)
+  dynamic "admin_ssh_key" {
+    for_each = range(local.enable_auth_password ? 0 : 1)
+    content {
+      username   = local.sid_auth_username
+      public_key = file(var.sshkey.path_to_public_key)
+    }
   }
 
   boot_diagnostics {
@@ -71,8 +74,8 @@ resource "azurerm_windows_virtual_machine" "web" {
     azurerm_network_interface.web[count.index].id
   ]
   size           = local.web_sizing.compute.vm_size
-  admin_username = local.authentication.username
-  admin_password = local.authentication.password
+  admin_username = local.sid_auth_username
+  admin_password = local.sid_auth_password
 
   os_disk {
     name                 = format("%s_%sweb%02dw%s-osdisk", local.prefix, lower(local.sid), count.index, substr(var.random-id.hex, 0, 3))

--- a/deploy/terraform/terraform-units/modules/sap_system/deployer/output.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/deployer/output.tf
@@ -17,3 +17,7 @@ output "nsg-mgmt" {
 output "deployer-uai" {
   value = data.azurerm_user_assigned_identity.deployer
 }
+
+output "deployer_user" {
+  value = data.terraform_remote_state.deployer.outputs.deployer_user
+}

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/outputs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/outputs.tf
@@ -3,11 +3,11 @@ output "subnet-sap-admin" {
 }
 
 output "nics-dbnodes-admin" {
-  value = azurerm_network_interface.nics-dbnodes-admin
+  value = local.enable_deployment ? azurerm_network_interface.nics-dbnodes-admin : []
 }
 
 output "nics-dbnodes-db" {
-  value = azurerm_network_interface.nics-dbnodes-db
+  value = local.enable_deployment ? azurerm_network_interface.nics-dbnodes-db : []
 }
 
 output "loadbalancers" {


### PR DESCRIPTION
## Problem
<Please describe what problem this PR is trying to resolve>
#775

## Solution
<Please elaborate the solution for the problem>
1. Create two KVs for applications.

2. If authentication type = password, a password will be generated unless user specifies one.

## Tests
<Please provide steps to test the PR>

## Notes
<Additional comments for the PR>
Currently ansible_inventory in output_files module doesn't have password printed out. Will have another PR enable this feature to print the password to hosts.yml and hosts.

This pr also modifies the output of hdb module. The reason is because when trying to deploy only application tier, some of the output of hdb module is not empty list which causes the output_files module fail. Will do more tests about this point.

Retrieving the ssh key from saplandscape is not included in this pr.