### PR TITLE
Add object_id for users to be consistent with sap_library

### DIFF
--- a/.pipeline/templates/deployer/create-deployer-steps.yml
+++ b/.pipeline/templates/deployer/create-deployer-steps.yml
@@ -32,6 +32,12 @@ steps:
         nsg: {
           allowed_ips: ["67.160.0.0/16", $allowed_ip]
         }
+      }' \
+      | jq '. += {
+        sshkey: {
+          path_to_public_key: "sshkey.pub",
+          path_to_private_key: "sshkey"
+        }
       }' > ${input}
 
       cat ${input}

--- a/deploy/terraform/bootstrap/sap_deployer/deployer.json
+++ b/deploy/terraform/bootstrap/sap_deployer/deployer.json
@@ -12,10 +12,6 @@
       }
     }
   },
-  "sshkey": {
-    "path_to_public_key": "sshkey.pub",
-    "path_to_private_key": "sshkey"
-  },
   "options": {
     "enable_secure_transfer": true
   }

--- a/deploy/terraform/run/sap_deployer/deployer.json
+++ b/deploy/terraform/run/sap_deployer/deployer.json
@@ -12,10 +12,6 @@
       }
     }
   },
-  "sshkey": {
-    "path_to_public_key": "sshkey.pub",
-    "path_to_private_key": "sshkey"
-  },
   "options": {
     "enable_secure_transfer": true
   }

--- a/deploy/terraform/run/sap_deployer/deployer.json
+++ b/deploy/terraform/run/sap_deployer/deployer.json
@@ -4,6 +4,7 @@
     "environment": "global",
     "vnets": {
       "management": {
+        "name" : "MGMT",
         "address_space": "10.0.0.0/26",
         "subnet_mgmt": {
           "prefix": "10.0.0.16/28"

--- a/deploy/terraform/terraform-units/modules/sap_deployer/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/infrastructure.tf
@@ -118,11 +118,11 @@ resource "azurerm_key_vault_access_policy" "kv_user_msi" {
 }
 
 resource "azurerm_key_vault_access_policy" "kv_user_portal" {
-  count        = local.enable_deployers ? 1 : 0
+  count        = local.enable_deployers ? length(local.deployer_users_id_list) : 0
   key_vault_id = azurerm_key_vault.kv_user[0].id
 
   tenant_id = data.azurerm_client_config.deployer.tenant_id
-  object_id = data.azurerm_client_config.deployer.object_id
+  object_id = local.deployer_users_id_list[count.index]
 
   secret_permissions = [
     "delete",

--- a/deploy/terraform/terraform-units/modules/sap_deployer/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/variables_local.tf
@@ -126,7 +126,10 @@ locals {
         "terraform",
         "ansible"
       ],
-      "private_ip_address" = try(deployer.private_ip_address, cidrhost(local.sub_mgmt_deployed.address_prefixes[0], idx + 4))
+      "private_ip_address" = try(deployer.private_ip_address, cidrhost(local.sub_mgmt_deployed.address_prefixes[0], idx + 4)),
+      "users" = {
+        "object_id" = try(deployer.users.object_id, [])
+      }
     }
   ]
 
@@ -137,4 +140,14 @@ locals {
     }, deployer)
   ]
 
+  // This is to be aligned with sap_library design.
+  // If no additonal user going to be supported, this part needs to be changed.
+  deployer_users_id = distinct(
+    flatten([
+      for deployer in local.deployers :
+      deployer.users.object_id
+    ])
+  )
+  curr_deployer_user_id  = try(data.azurerm_client_config.deployer.object_id, "")
+  deployer_users_id_list = distinct(compact(concat(local.deployer_users_id, [local.curr_deployer_user_id])))
 }


### PR DESCRIPTION
## Problem
No `object_id` on deployer since it uses msi.

## Solution
Add field `object_id` if user wants to add their user/spn back to the KV.
Otherwise, the KV policy for that user will only be used during bootstrap phase.

## Tests
1. Deploy deployer using bootstrap.
1. Deploy sap_library on deployer.
1. Re-init deployer.
1. Plan/apply deployer using ~/Azure_SAP_Automated_Deployment/sap-hana/deploy/terraform/run/sap_deployer/, see that user got removed:

  ```
# module.sap_deployer.azurerm_key_vault_access_policy.kv_user_portal[0] will be destroyed
  - resource "azurerm_key_vault_access_policy" "kv_user_portal" {
      - certificate_permissions = [] -> null
      - id                      = "/subscriptions/XXX/resourceGroups/GLOBAL-EAUS-MGMT-INFRASTRUCTURE/providers/Microsoft.KeyVault/vaults/GLOBAEAUSMGMTuser01D/objectId/XXX" -> null
      - key_permissions         = [] -> null
      - key_vault_id            = "/subscriptions/XXX/resourceGroups/GLOBAL-EAUS-MGMT-INFRASTRUCTURE/providers/Microsoft.KeyVault/vaults/GLOBAEAUSMGMTuser01D" -> null
      - object_id               = "XXX" -> null
      - secret_permissions      = [
          - "delete",
          - "get",
          - "list",
          - "set",
        ] -> null
      - storage_permissions     = [] -> null
      - tenant_id               = "XXX" -> null
    }
```
5. Add object_id in the JSON like below, apply, see the right user added again.
```
  "deployers":[{
    "users": {
      "object_id": ["<object_id>"]
    }
  }],
```

## Notes
Also sync the json under bootstrap and run.
Will have a separate PR to remove the sshkey section since by default we generate key pair.