### PR TITLE
Remove sshkey dict from default json

### DIFF
--- a/.pipeline/templates/deployer/create-deployer-steps.yml
+++ b/.pipeline/templates/deployer/create-deployer-steps.yml
@@ -32,6 +32,12 @@ steps:
         nsg: {
           allowed_ips: ["67.160.0.0/16", $allowed_ip]
         }
+      }' \
+      | jq '. += {
+        sshkey: {
+          path_to_public_key: "sshkey.pub",
+          path_to_private_key: "sshkey"
+        }
       }' > ${input}
 
       cat ${input}

--- a/deploy/terraform/bootstrap/sap_deployer/deployer.json
+++ b/deploy/terraform/bootstrap/sap_deployer/deployer.json
@@ -12,15 +12,6 @@
       }
     }
   },
-  "deployers":[{
-    "users": {
-      "object_id": []
-    }
-  }],
-  "sshkey": {
-    "path_to_public_key": "sshkey.pub",
-    "path_to_private_key": "sshkey"
-  },
   "options": {
     "enable_secure_transfer": true
   }

--- a/deploy/terraform/bootstrap/sap_deployer/deployer.json
+++ b/deploy/terraform/bootstrap/sap_deployer/deployer.json
@@ -12,6 +12,11 @@
       }
     }
   },
+  "deployers":[{
+    "users": {
+      "object_id": []
+    }
+  }],
   "sshkey": {
     "path_to_public_key": "sshkey.pub",
     "path_to_private_key": "sshkey"

--- a/deploy/terraform/run/sap_deployer/deployer.json
+++ b/deploy/terraform/run/sap_deployer/deployer.json
@@ -12,15 +12,6 @@
       }
     }
   },
-  "deployers":[{
-    "users": {
-      "object_id": []
-    }
-  }],
-  "sshkey": {
-    "path_to_public_key": "sshkey.pub",
-    "path_to_private_key": "sshkey"
-  },
   "options": {
     "enable_secure_transfer": true
   }

--- a/deploy/terraform/run/sap_deployer/deployer.json
+++ b/deploy/terraform/run/sap_deployer/deployer.json
@@ -12,6 +12,11 @@
       }
     }
   },
+  "deployers":[{
+    "users": {
+      "object_id": []
+    }
+  }],
   "sshkey": {
     "path_to_public_key": "sshkey.pub",
     "path_to_private_key": "sshkey"


### PR DESCRIPTION
## Problem
By default, should generate sshkey pair.

## Solution
1. Remove sshkey section from default json
1. Before making big changes to the piepline for kv, add sshkey section back to the json to make it backward compatible.

## Tests
https://dev.azure.com/azuresaphana/Azure-SAP-HANA/_build/results?buildId=10597&view=logs&j=3e7c2453-b9e0-5f22-4314-eb3ec9329da1

## Notes
<Additional comments for the PR>