### PR TITLE
Fix broken sles condition in release pipeline

### DIFF
--- a/.pipeline/templates/sapsystem/create-sapsystem-steps.yml
+++ b/.pipeline/templates/sapsystem/create-sapsystem-steps.yml
@@ -35,7 +35,7 @@ steps:
       sapsystem_env=${{parameters.sapsystem_env}}
       sapsystem_isRelease=${sapsystem_env%%$buildId*}
 
-      [[ ${osImage_publisher} == "SUSE" ]] && isSles=true || isSles=false
+      [[ ${{parameters.osImage_publisher}} == "RedHat" ]] && isSles=false || isSles=true
       
       # subnet is decided by buildId if it is unit test.
       # Otherwise, use 10.10.0.0 for sles and 10.10.1.0 for rhel


### PR DESCRIPTION
## Problem
Incorrect usage of parameter osImage_publisher

## Solution
by default (meaning if no value passed) osImage_publisher is SLES, otherwise RHEL.

## Tests
<Please provide steps to test the PR>

## Notes
<Additional comments for the PR>