### PR TITLE
[HOTFIX] Fix incorrect publisher value

### DIFF
--- a/.pipeline/templates/sapsystem/create-sapsystem-steps.yml
+++ b/.pipeline/templates/sapsystem/create-sapsystem-steps.yml
@@ -35,7 +35,8 @@ steps:
       sapsystem_env=${{parameters.sapsystem_env}}
       sapsystem_isRelease=${sapsystem_env%%$buildId*}
 
-      [[ ${{parameters.osImage_publisher}} == "RedHat" ]] && isSles=false || isSles=true
+      [ -z ${{parameters.osImage_publisher}} ] && osImage_publisher="SUSE" || osImage_publisher=${{parameters.osImage_publisher}}
+      [[ ${osImage_publisher} == "SUSE" ]] && isSles=true || isSles=false
       
       # subnet is decided by buildId if it is unit test.
       # Otherwise, use 10.10.0.0 for sles and 10.10.1.0 for rhel


### PR DESCRIPTION
## Problem
https://dev.azure.com/azuresaphana/Azure-SAP-HANA/_build/results?buildId=10784&view=logs&j=ed898bca-1be4-5573-ffb5-764df6a725fe&t=b2df2e5c-bbb4-58ac-5c69-9c523c5033a7

## Solution
By default it deploys SUSE.
Only in release pipeline, it deploys RedHat as well.

## Tests
https://dev.azure.com/azuresaphana/Azure-SAP-HANA/_build/results?buildId=10791&view=logs&j=ed898bca-1be4-5573-ffb5-764df6a725fe

## Notes
The current error in above test will be fixed in PR #789 