### PR TITLE
Remove redirect log in pipeline

### DIFF
--- a/.pipeline/templates/saplandscape/create-saplandscape-steps.yml
+++ b/.pipeline/templates/saplandscape/create-saplandscape-steps.yml
@@ -116,9 +116,7 @@ steps:
         --backend-config "container_name=tfstate" \
         --backend-config "key=${sap_landscape_key}" \
         ${repo_dir}/deploy/terraform/run/sap_system/
-      [ -d ~/.log ] || mkdir -p ~/.log
-      terraform apply -auto-approve -var-file=${input} ${repo_dir}/deploy/terraform/run/sap_system/ 2>~/.log/$(Build.BuildId)_sap_landscape_apply_error.log 2>&1>~/.log/$(Build.BuildId)_sap_landscape_apply.log
-      if [ -s ~/.log/$(Build.BuildId)_sap_landscape_apply_error.log ]; then cat ~/.log/$(Build.BuildId)_sap_landscape_apply_error.log; exit 1; fi;
+      terraform apply -auto-approve -var-file=${input} ${repo_dir}/deploy/terraform/run/sap_system/
       '
     displayName: "Deploy new sap landscape: Branch ${{parameters.branch_name}}"
     condition: or(succeededOrFailed(), always())

--- a/.pipeline/templates/saplandscape/delete-saplandscape-steps.yml
+++ b/.pipeline/templates/saplandscape/delete-saplandscape-steps.yml
@@ -57,10 +57,8 @@ steps:
       
       echo "=== Delete SAP system from deployer with terraform ==="
       echo "=== This may take quite a while, please be patient ==="
-      [ -d ~/.log ] || mkdir -p ~/.log
-      terraform destroy -auto-approve -var-file=${input} ${repo_dir}/deploy/terraform/run/sap_system/ 2>~/.log/$(Build.BuildId)_sap_landscape_destroy_error.log 2>&1>~/.log/$(Build.BuildId)_sap_landscape_destroy.log
-      cat ~/.log/$(Build.BuildId)_sap_landscape_destroy_error.log
-
+      terraform destroy -auto-approve -var-file=${input} ${repo_dir}/deploy/terraform/run/sap_system/
+      
       echo "=== Delete git clone for the build from deployer ==="
       rm -rf ~/${saplandscape_rg}
       '

--- a/.pipeline/templates/saplib/create-saplib-steps.yml
+++ b/.pipeline/templates/saplib/create-saplib-steps.yml
@@ -51,9 +51,7 @@ steps:
       echo "=== This may take quite a while, please be patient ==="
       terraform -version
       terraform init -upgrade=true ${repo_dir}/deploy/terraform/bootstrap/sap_library/
-      [ -d $HOME/.log ] || mkdir -p $HOME/.log
-      terraform apply -auto-approve -var-file=${input} ${repo_dir}/deploy/terraform/bootstrap/sap_library/ 2>$HOME/.log/$(Build.BuildId)_apply_error.log 2>&1>$HOME/.log/$(Build.BuildId)_apply.log
-      if [ -s $HOME/.log/$(Build.BuildId)_apply_error.log ]; then cat $HOME/.log/$(Build.BuildId)_apply_error.log; exit 1; fi;
+      terraform apply -auto-approve -var-file=${input} ${repo_dir}/deploy/terraform/bootstrap/sap_library/
       '
     displayName: "Deploy saplibrary: Branch ${{parameters.branch_name}}"
     condition: or(succeededOrFailed(), always())

--- a/.pipeline/templates/saplib/delete-saplib-steps.yml
+++ b/.pipeline/templates/saplib/delete-saplib-steps.yml
@@ -42,10 +42,8 @@ steps:
 
       echo "=== Delete SAP library from deployer with terraform ==="
       echo "=== This may take quite a while, please be patient ==="
-      [ -d ~/.log ] || mkdir -p ~/.log
-      terraform destroy -auto-approve -var-file=${input} ${repo_dir}/deploy/terraform/bootstrap/sap_library/ 2>~/.log/$(Build.BuildId)_destroy_error.log 2>&1>~/.log/$(Build.BuildId)_destroy.log
-      cat ~/.log/$(Build.BuildId)_apply_error.log;
-
+      terraform destroy -auto-approve -var-file=${input} ${repo_dir}/deploy/terraform/bootstrap/sap_library/
+      
       echo "=== Delete git clone for the build from deployer ==="
       rm -rf ~/${saplib_rg}
 

--- a/.pipeline/templates/sapsystem/create-sapsystem-steps.yml
+++ b/.pipeline/templates/sapsystem/create-sapsystem-steps.yml
@@ -157,9 +157,7 @@ steps:
         --backend-config "container_name=tfstate" \
         --backend-config "key=${sap_system_key}" \
         ${repo_dir}/deploy/terraform/run/sap_system/
-      [ -d ~/.log ] || mkdir -p ~/.log
-      terraform apply -auto-approve -var-file=${input} ${repo_dir}/deploy/terraform/run/sap_system/ 2>~/.log/$(Build.BuildId)_apply_error.log 2>&1>~/.log/$(Build.BuildId)_apply.log
-      if [ -s ~/.log/$(Build.BuildId)_apply_error.log ]; then cat ~/.log/$(Build.BuildId)_apply_error.log; exit 1; fi;
+      terraform apply -auto-approve -var-file=${input} ${repo_dir}/deploy/terraform/run/sap_system/
       '
     displayName: "Deploy new sap system: Branch ${{parameters.branch_name}}"
     condition: or(succeededOrFailed(), always())

--- a/.pipeline/templates/sapsystem/delete-sapsystem-steps.yml
+++ b/.pipeline/templates/sapsystem/delete-sapsystem-steps.yml
@@ -57,9 +57,7 @@ steps:
       
       echo "=== Delete SAP system from deployer with terraform ==="
       echo "=== This may take quite a while, please be patient ==="
-      [ -d ~/.log ] || mkdir -p ~/.log
-      terraform destroy -auto-approve -var-file=${input} ${repo_dir}/deploy/terraform/run/sap_system/ 2>~/.log/$(Build.BuildId)_destroy_error.log 2>&1>~/.log/$(Build.BuildId)_destroy.log
-      cat ~/.log/$(Build.BuildId)_destroy_error.log
+      terraform destroy -auto-approve -var-file=${input} ${repo_dir}/deploy/terraform/run/sap_system/
 
       echo "=== Delete git clone for the build from deployer ==="
       rm -rf ~/${sapsystem_rg}


### PR DESCRIPTION
## Problem
Redirect to log file instead of console seems to cause some trouble to show the right status of jobs in pipeline.

## Solution
No redirect. Output will be directly showing in the pipeline log.

## Tests
https://dev.azure.com/azuresaphana/Azure-SAP-HANA/_build/results?buildId=11000&view=results
https://dev.azure.com/azuresaphana/Azure-SAP-HANA/_build/results?buildId=11001&view=results
https://dev.azure.com/azuresaphana/Azure-SAP-HANA/_build/results?buildId=10998&view=results
https://dev.azure.com/azuresaphana/Azure-SAP-HANA/_build/results?buildId=10999&view=logs&j=ed898bca-1be4-5573-ffb5-764df6a725fe&t=b2df2e5c-bbb4-58ac-5c69-9c523c5033a7

## Notes
Will investigate the error in sap_system pipeline separately.