### PR TITLE
[DO NOT MERGE] Pass naming module output as map

### DIFF
--- a/deploy/terraform/bootstrap/sap_deployer/module.tf
+++ b/deploy/terraform/bootstrap/sap_deployer/module.tf
@@ -4,17 +4,20 @@ Description:
   Example to deploy deployer(s) using local backend.
 */
 module "sap_deployer" {
-  source               = "../../terraform-units/modules/sap_deployer"
-  infrastructure       = var.infrastructure
-  deployers            = var.deployers
-  options              = var.options
-  ssh-timeout          = var.ssh-timeout
-  sshkey               = var.sshkey
+  source         = "../../terraform-units/modules/sap_deployer"
+  infrastructure = var.infrastructure
+  deployers      = var.deployers
+  options        = var.options
+  ssh-timeout    = var.ssh-timeout
+  sshkey         = var.sshkey
+  naming         = module.sap_namegenerator.naming
+  /*
   prefix               = module.sap_namegenerator.prefix["DEPLOYER"]
   storageaccount_names = module.sap_namegenerator.storageaccount_names["DEPLOYER"]
   virtualmachine_names = module.sap_namegenerator.virtualmachine_names["DEPLOYER"]
   keyvault_names       = module.sap_namegenerator.keyvault_names["DEPLOYER"]
   resource_suffixes    = module.sap_namegenerator.resource_extensions
+  */
 }
 
 module "sap_namegenerator" {

--- a/deploy/terraform/bootstrap/sap_deployer/variables_local.tf
+++ b/deploy/terraform/bootstrap/sap_deployer/variables_local.tf
@@ -1,9 +1,9 @@
 locals {
 
-  environment          = lower(try(var.infrastructure.landscape, ""))
-  location             = try(var.infrastructure.region, "")
-  codename             = lower(try(var.infrastructure.codename, ""))
-  
+  environment = lower(try(var.infrastructure.environment, ""))
+  location    = try(var.infrastructure.region, "")
+  codename    = lower(try(var.infrastructure.codename, ""))
+
   // Management vnet
   vnet_mgmt        = try(var.infrastructure.vnets.management, {})
   vnet_mgmt_arm_id = try(local.vnet_mgmt.arm_id, "")

--- a/deploy/terraform/terraform-units/modules/sap_deployer/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/infrastructure.tf
@@ -52,7 +52,7 @@ data "azurerm_subnet" "subnet_mgmt" {
 // Creates boot diagnostics storage account for Deployer
 resource "azurerm_storage_account" "deployer" {
   count                     = local.enable_deployers ? 1 : 0
-  name                      = var.storageaccount_names[0]
+  name                      = local.storageaccount_names
   resource_group_name       = azurerm_resource_group.deployer[0].name
   location                  = azurerm_resource_group.deployer[0].location
   account_replication_type  = "LRS"

--- a/deploy/terraform/terraform-units/modules/sap_deployer/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/variables_local.tf
@@ -3,6 +3,8 @@ Description:
 
   Define local variables.
 */
+
+/*
 variable prefix {
   type        = string
   description = "Resource naming prefix"
@@ -27,10 +29,19 @@ variable keyvault_names {
   type        = list
   description = "Keyvault name list"
 }
+*/
+
+variable naming {
+  description = "naming convention"
+}
 
 
 // Set defaults
 locals {
+  storageaccount_names = var.naming.storageaccount_names.DEPLOYER
+  virtualmachine_names = var.naming.virtualmachine_names.DEPLOYER
+  keyvault_names       = var.naming.keyvault_names.DEPLOYER
+  resource_suffixes    = var.naming.resource_extension
 
 
   // Post fix for all deployed resources
@@ -43,22 +54,22 @@ locals {
 
   region             = try(var.infrastructure.region, "")
   vnet_mgmt_tempname = try(local.vnet_mgmt.name, "")
-  prefix             = try(var.infrastructure.resource_group.name, var.prefix)
-  rg_name            = try(var.infrastructure.resource_group.name, format("%s%s", local.prefix, var.resource_suffixes["deployer-rg"]))
+  prefix             = try(var.infrastructure.resource_group.name, var.naming.prefix.DEPLOYER)
+  rg_name            = try(var.infrastructure.resource_group.name, format("%s%s", local.prefix, local.resource_suffixes["deployer-rg"]))
 
   // Management vnet
   vnet_mgmt        = try(var.infrastructure.vnets.management, {})
   vnet_mgmt_arm_id = try(local.vnet_mgmt.arm_id, "")
   vnet_mgmt_exists = length(local.vnet_mgmt_arm_id) > 0 ? true : false
 
-  vnet_mgmt_name = local.vnet_mgmt_exists ? split("/", local.vnet_mgmt_arm_id)[8] : format("%s%s", local.prefix, var.resource_suffixes["vnet"])
+  vnet_mgmt_name = local.vnet_mgmt_exists ? split("/", local.vnet_mgmt_arm_id)[8] : format("%s%s", local.prefix, local.resource_suffixes["vnet"])
   vnet_mgmt_addr = local.vnet_mgmt_exists ? "" : try(local.vnet_mgmt.address_space, "10.0.0.16/28")
 
   // Management subnet
   sub_mgmt          = try(local.vnet_mgmt.subnet_mgmt, {})
   sub_mgmt_arm_id   = try(local.sub_mgmt.arm_id, "")
   sub_mgmt_exists   = length(local.sub_mgmt_arm_id) > 0 ? true : false
-  sub_mgmt_name     = local.sub_mgmt_exists ? "" : try(local.sub_mgmt.name, format("%s%s", local.prefix, var.resource_suffixes["deployer-subnet"]))
+  sub_mgmt_name     = local.sub_mgmt_exists ? "" : try(local.sub_mgmt.name, format("%s%s", local.prefix, local.resource_suffixes["deployer-subnet"]))
   sub_mgmt_prefix   = local.sub_mgmt_exists ? "" : try(local.sub_mgmt.prefix, "10.0.0.16/28")
   sub_mgmt_deployed = try(local.sub_mgmt_exists ? data.azurerm_subnet.subnet_mgmt[0] : azurerm_subnet.subnet_mgmt[0], null)
 
@@ -66,7 +77,7 @@ locals {
   sub_mgmt_nsg             = try(local.sub_mgmt.nsg, {})
   sub_mgmt_nsg_exists      = try(local.sub_mgmt_nsg.is_existing, false)
   sub_mgmt_nsg_arm_id      = local.sub_mgmt_nsg_exists ? try(local.sub_mgmt_nsg.arm_id, "") : ""
-  sub_mgmt_nsg_name        = local.sub_mgmt_nsg_exists ? "" : try(local.sub_mgmt_nsg.name, format("%s%s", local.prefix, var.resource_suffixes["deployer-subnet-nsg"]))
+  sub_mgmt_nsg_name        = local.sub_mgmt_nsg_exists ? "" : try(local.sub_mgmt_nsg.name, format("%s%s", local.prefix, local.resource_suffixes["deployer-subnet-nsg"]))
   deployer_pip_list        = azurerm_public_ip.deployer[*].ip_address
   sub_mgmt_nsg_allowed_ips = local.sub_mgmt_nsg_exists ? [] : try(concat(local.sub_mgmt_nsg.allowed_ips, local.deployer_pip_list), ["0.0.0.0/0"])
   sub_mgmt_nsg_deployed    = try(local.sub_mgmt_nsg_exists ? data.azurerm_network_security_group.nsg_mgmt[0] : azurerm_network_security_group.nsg_mgmt[0], null)
@@ -78,7 +89,7 @@ locals {
   enable_deployers = length(local.deployer_input) > 0 ? true : false
   deployers = [
     for idx, deployer in local.deployer_input : {
-      "name"                 = var.virtualmachine_names[idx],
+      "name"                 = local.virtualmachine_names[idx],
       "destroy_after_deploy" = true,
       "size"                 = try(deployer.size, "Standard_D2s_v3"),
       "disk_type"            = try(deployer.disk_type, "StandardSSD_LRS")

--- a/deploy/terraform/terraform-units/modules/sap_deployer/vm-deployer.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/vm-deployer.tf
@@ -9,7 +9,7 @@ Description:
 // Public IP addresse and nic for Deployer
 resource "azurerm_public_ip" "deployer" {
   count               = length(local.deployers)
-  name                = length(local.prefix) > 0 ? format("%s_%s%s", local.prefix, local.deployers[count.index].name, var.resource_suffixes["pip"]) : format("%s%s", local.deployers[count.index].name, var.resource_suffixes["pip"])
+  name                = length(local.prefix) > 0 ? format("%s_%s%s", local.prefix, local.deployers[count.index].name, local.resource_suffixes["pip"]) : format("%s%s", local.deployers[count.index].name, local.resource_suffixes["pip"])
   location            = azurerm_resource_group.deployer[0].location
   resource_group_name = azurerm_resource_group.deployer[0].name
   allocation_method   = "Static"
@@ -17,7 +17,7 @@ resource "azurerm_public_ip" "deployer" {
 
 resource "azurerm_network_interface" "deployer" {
   count               = length(local.deployers)
-  name                = length(local.prefix) > 0 ? format("%s_%s%s", local.prefix, local.deployers[count.index].name, var.resource_suffixes["nic"]) : format("%s%s", local.deployers[count.index].name, var.resource_suffixes["nic"])
+  name                = length(local.prefix) > 0 ? format("%s_%s%s", local.prefix, local.deployers[count.index].name, local.resource_suffixes["nic"]) : format("%s%s", local.deployers[count.index].name, local.resource_suffixes["nic"])
   location            = azurerm_resource_group.deployer[0].location
   resource_group_name = azurerm_resource_group.deployer[0].name
 
@@ -57,7 +57,7 @@ resource "azurerm_role_assignment" "sub_user_admin" {
 // Linux Virtual Machine for Deployer
 resource "azurerm_linux_virtual_machine" "deployer" {
   count                           = length(local.deployers)
-  name                            = length(local.prefix) > 0 ? format("%s_%s%s", local.prefix, local.deployers[count.index].name, var.resource_suffixes["vm"]) : format("%s%s", local.deployers[count.index].name, var.resource_suffixes["vm"])
+  name                            = length(local.prefix) > 0 ? format("%s_%s%s", local.prefix, local.deployers[count.index].name, local.resource_suffixes["vm"]) : format("%s%s", local.deployers[count.index].name, local.resource_suffixes["vm"])
   computer_name                   = local.deployers[count.index].name
   location                        = azurerm_resource_group.deployer[0].location
   resource_group_name             = azurerm_resource_group.deployer[0].name
@@ -68,7 +68,7 @@ resource "azurerm_linux_virtual_machine" "deployer" {
   disable_password_authentication = local.deployers[count.index].authentication.type != "password" ? true : false
 
   os_disk {
-    name                 = length(local.prefix) > 0 ? format("%s_%s%s", local.prefix, local.deployers[count.index].name, var.resource_suffixes["osdisk"]) : format("%s%s", local.deployers[count.index].name, var.resource_suffixes["osdisk"])
+    name                 = length(local.prefix) > 0 ? format("%s_%s%s", local.prefix, local.deployers[count.index].name, local.resource_suffixes["osdisk"]) : format("%s%s", local.deployers[count.index].name, local.resource_suffixes["osdisk"])
     caching              = "ReadWrite"
     storage_account_type = local.deployers[count.index].disk_type
   }

--- a/deploy/terraform/terraform-units/modules/sap_namegenerator/output.tf
+++ b/deploy/terraform/terraform-units/modules/sap_namegenerator/output.tf
@@ -1,9 +1,10 @@
+/*
 output prefix {
   value = tomap({ "SDU" = local.sdu_name, "DEPLOYER" = local.deployer_name, "VNET" = local.vnet_name, "LIBRARY" = local.library_name })
 }
 
 output storageaccount_names {
-  value = tomap({ "SDU" = [local.sdu_sa_name], "DEPLOYER" = [local.deployer_sa_name], "VNET" = [local.vnet_sa_name], "LIBRARY" = [local.library_sa_name,local.state_sa_name] })
+  value = tomap({ "SDU" = [local.sdu_sa_name], "DEPLOYER" = [local.deployer_sa_name], "VNET" = [local.vnet_sa_name], "LIBRARY" = [local.library_sa_name, local.state_sa_name] })
 }
 
 output resource_extensions {
@@ -11,9 +12,28 @@ output resource_extensions {
 }
 
 output virtualmachine_names {
-  value = tomap({ "ANYDB" = local.anydb_server_names,  "ANYDB_HA" = local.anydb_server_names_ha, "APP" = local.app_server_names, "DEPLOYER" = local.deployer_names, "HANA" = local.hana_server_names, "HANA_HA" = local.hana_server_names_ha, "SCS" = local.scs_server_names, "WEB" = local.web_server_names })
+  value = tomap({ "ANYDB" = local.anydb_server_names, "ANYDB_HA" = local.anydb_server_names_ha, "APP" = local.app_server_names, "DEPLOYER" = local.deployer_names, "HANA" = local.hana_server_names, "HANA_HA" = local.hana_server_names_ha, "SCS" = local.scs_server_names, "WEB" = local.web_server_names })
 }
 
 output keyvault_names {
   value = tomap({ "SDU" = local.sdu_kvname, "DEPLOYER" = local.deployer_kvname, "VNET" = local.vnet_kvname, "LIBRARY" = local.library_kvname })
+}
+*/
+
+output naming {
+  value = {
+    prefix = {
+      DEPLOYER = local.deployer_name
+    }
+    storageaccount_names = {
+      DEPLOYER = local.deployer_sa_name
+    }
+    resource_extension = var.resource_extension
+    virtualmachine_names = {
+      DEPLOYER = local.deployer_names
+    }
+    keyvault_names = {
+      DEPLOYER = local.deployer_kvname
+    }
+  }
 }


### PR DESCRIPTION
## Problem
Test if we can pass map instead from naming module.

## Solution
<Please elaborate the solution for the problem>

## Tests
Tested on local dev box, deployment of a deployer finished successful.
```
...
module.sap_deployer.null_resource.prepare-deployer[0]: Creation complete after 3m18s [id=5810257607413985790]

Apply complete! Resources: 19 added, 0 changed, 0 destroyed.

The state of your infrastructure has been saved to the path
below. This state is required to modify and destroy your
infrastructure, so keep it safe. To inspect the complete state
use the `terraform show` command.

State path: terraform.tfstate

Outputs:

deployer = <sensitive>
deployer_id = <sensitive>
deployer_uai = <sensitive>
nsg_mgmt = <sensitive>
subnet_mgmt = <sensitive>
vnet_mgmt = <sensitive>
```
## Notes
<Additional comments for the PR>