### PR TITLE
[HOTFIX] Remove all possible public IP assignment in pipeline

### DIFF
--- a/.pipeline/templates/deployer/create-deployer-steps.yml
+++ b/.pipeline/templates/deployer/create-deployer-steps.yml
@@ -16,7 +16,10 @@ steps:
       deployer_rg="${deployer_prefix}-EAUS-MGMT-INFRASTRUCTURE"
       ws_dir=$(Agent.BuildDirectory)/Azure_SAP_Automated_Deployment/WORKSPACES/LOCAL/${deployer_rg}
       input=${ws_dir}/${deployer_rg}.json
-      
+
+      #Only private IP addresses can be added to NSG due to S360 requirement
+      prefix="10.0.0.16/28"
+
       git checkout ${{parameters.branch_name}}
 
       mkdir -p ${ws_dir}; cd $_
@@ -28,9 +31,9 @@ steps:
       [[ -f ${input} ]] ||
       cat deployer.json \
       | jq --arg environment "${deployer_prefix}" .infrastructure.environment\ =\ \$environment \
-      | jq --arg allowed_ip "$(agent_ip)" '.infrastructure.vnets.management.subnet_mgmt += {
+      | jq --arg prefix "${prefix}" --arg agent_ip "$(agent_ip)" '.infrastructure.vnets.management.subnet_mgmt += {
         nsg: {
-          allowed_ips: ["67.160.0.0/16", $allowed_ip]
+          allowed_ips: [$prefix, $agent_ip]
         }
       }' \
       | jq '. += {

--- a/.pipeline/templates/util/remove-agent-from-deployer-nsg.yml
+++ b/.pipeline/templates/util/remove-agent-from-deployer-nsg.yml
@@ -26,6 +26,8 @@ steps:
       echo "=== Update NSG source address by removing agent IP ==="
       prefix_list=$(az network nsg rule show  -g ${rg_name} --nsg-name ${nsg_name} -n ssh | jq -r '.sourceAddressPrefix, (.sourceAddressPrefixes | join(" ")) | select(.!=null)' | sed "s/$(agent_ip)//")
       az network nsg rule update -g ${rg_name} --nsg-name ${nsg_name} -n ssh --source-address-prefixes ${prefix_list} --output none
+      az network nsg rule update -g ${rg_name} --nsg-name ${nsg_name} -n rdp --source-address-prefixes ${prefix_list} --output none
+      az network nsg rule update -g ${rg_name} --nsg-name ${nsg_name} -n winrm --source-address-prefixes ${prefix_list} --output none
 
       echo "=== Assgin ${nsg_name} to deployer ${subnet_name} to avoid NRMS ==="
       az network vnet subnet update -g ${rg_name} -n ${subnet_name} --vnet-name ${vnet_name} --network-security-group ${nsg_name} --output none

--- a/.pipeline/tf-deployer-test.yml
+++ b/.pipeline/tf-deployer-test.yml
@@ -35,3 +35,6 @@ stages:
         parameters:
           branch_name: $(sourceBranchName)
           deployer_env: "$(Build.BuildId)"
+      - template: templates/util/remove-agent-from-deployer-nsg.yml
+        parameters:
+          deployer_env: "UNIT"

--- a/.pipeline/tf-integration-test.yml
+++ b/.pipeline/tf-integration-test.yml
@@ -31,6 +31,9 @@ stages:
       - template: templates/deployer/post-deployer-steps.yml
         parameters:
           deployer_env: "$(Build.BuildId)"
+      - template: templates/util/remove-agent-from-deployer-nsg.yml
+        parameters:
+          deployer_env: "$(Build.BuildId)"
   - job: createSAPLib
     dependsOn: createDeployer
     steps:

--- a/.pipeline/tf-release.yml
+++ b/.pipeline/tf-release.yml
@@ -67,6 +67,9 @@ stages:
       - template: templates/deployer/post-deployer-steps.yml
         parameters:
           deployer_env: "UNIT"
+      - template: templates/util/remove-agent-from-deployer-nsg.yml
+        parameters:
+          deployer_env: "UNIT"
   - job: createSAPLib
     dependsOn: createDeployer
     steps:

--- a/azure-pipelines-cleanup.yaml
+++ b/azure-pipelines-cleanup.yaml
@@ -1,17 +1,21 @@
+trigger: none
+pr: none
 schedules:
-- cron: '0 0 * * *'
-  displayName: Daily midnight clean up (UTC)
+- cron: '0 */2 * * *'
+  displayName: Cleanup resources every 2 hours
   branches:
     include:
     - master
+    - beta/*
+    - feature/*
   always: true
 variables:
   - group: azure-config-variables
   - group: azure-sap-hana-pipeline-secrets
 jobs:
-- job: dailyCleanup
+- job: scheduled_RG_Cleanup
   pool:
-    vmImage: "ubuntu-16.04"
+    vmImage: "ubuntu-18.04"
   steps:
   - script: |
       az login --service-principal --user $(hana-pipeline-spn-id) --password  $(hana-pipeline-spn-pw) --tenant $(landscape-tenant) --output none
@@ -19,11 +23,15 @@ jobs:
       for rg in $groups
       do
         if $(az group exists -n $rg); then
+          echo ${rg}
           az group delete -n $rg --no-wait -y
-          echo $rg
         fi
       done
-    displayName: 'Clean up resource group daily'
+    displayName: 'Clean up resource group'
+- job: scheduled_Peering_Cleanup
+  pool:
+    vmImage: "ubuntu-18.04"
+  steps:
   - script: |
       az login --service-principal --user $(hana-pipeline-spn-id) --password  $(hana-pipeline-spn-pw) --tenant $(landscape-tenant) --output none
       deployer_rg="UNIT-EAUS-MGMT-INFRASTRUCTURE"
@@ -31,8 +39,46 @@ jobs:
       peering_list=$(az network vnet peering list --resource-group ${deployer_rg} --vnet-name ${mgmt_vnet} | jq -c '.[] | select(.peeringState=="Disconnected")' | jq -r .name)
       for peering in ${peering_list}
       do
-        echo ${peering_list}
-        az network vnet peering delete --resource-group ${deployer_rg}  --vnet-name ${mgmt_vnet} --name ${peering} --no-wait -y
+        echo ${peering}
+        az network vnet peering delete --resource-group ${deployer_rg}  --vnet-name ${mgmt_vnet} --name ${peering}
       done
-    displayName: 'Clean up network peering daily'
+    displayName: 'Clean up network peering'
+- job: scheduled_NSG_Cleanup
+  pool:
+    vmImage: "ubuntu-18.04"
+  steps:
+  - script: |
+      az login --service-principal --user $(hana-pipeline-spn-id) --password  $(hana-pipeline-spn-pw) --tenant $(landscape-tenant) --output none
+      
+      rg_name="UNIT-EAUS-MGMT-INFRASTRUCTURE"
+
+      vnet_name=$(az network vnet list --resource-group ${rg_name} | jq -r .[].name)
+      subnet_name=$(az network vnet list --resource-group ${rg_name} | jq -r .[].subnets[].name)
+      nsg_name=$(az network nsg list --resource-group ${rg_name} | jq -r --arg vnet_name "${vnet_name}" '.[] | select(.name | contains($vnet_name) | not) | .name')
+      
+      echo "=== Update NSG source address with only private IP address ==="
+      #Only private IP addresses can be added to NSG due to S360 requirement
+      prefix_list="10.0.0.16/28"
+      az network nsg rule update -g ${rg_name} --nsg-name ${nsg_name} -n ssh --source-address-prefixes ${prefix_list} --output none
+      az network nsg rule update -g ${rg_name} --nsg-name ${nsg_name} -n rdp --source-address-prefixes ${prefix_list} --output none
+      az network nsg rule update -g ${rg_name} --nsg-name ${nsg_name} -n winrm --source-address-prefixes ${prefix_list} --output none
+
+      echo "=== Assgin ${nsg_name} to deployer ${subnet_name} to avoid NRMS ==="
+      az network vnet subnet update -g ${rg_name} -n ${subnet_name} --vnet-name ${vnet_name} --network-security-group ${nsg_name} --output none
+    displayName: 'Clean up NSG'
+- job: scheduled_Subnet_Cleanup
+  pool:
+    vmImage: "ubuntu-18.04"
+  steps:
+  - script: |
+      az login --service-principal --user $(hana-pipeline-spn-id) --password  $(hana-pipeline-spn-pw) --tenant $(landscape-tenant) --output none
+      sap_landscape_rg="UNIT-EAUS-SAP0-INFRASTRUCTURE"
+      sap_vnet=$(az network vnet list --resource-group ${sap_landscape_rg} | jq -r '.[].name')
+      subnet_list=$(az network vnet subnet list --resource-group ${sap_landscape_rg} --vnet-name ${sap_vnet} | jq -c '.[] | select(.name | contains("RHEL") | not) | select(.name | contains("SLES") | not)' | jq -r .name)
+      for subnet in ${subnet_list}
+      do
+        echo ${subnet}
+        az network vnet subnet delete --resource-group ${sap_landscape_rg} --vnet-name ${sap_vnet} --name ${subnet} || :
+      done
+    displayName: 'Clean up subnet'
 

--- a/deploy/terraform/terraform-units/modules/sap_deployer/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/variables_local.tf
@@ -82,8 +82,7 @@ locals {
   sub_mgmt_nsg_exists      = try(local.sub_mgmt_nsg.is_existing, false)
   sub_mgmt_nsg_arm_id      = local.sub_mgmt_nsg_exists ? try(local.sub_mgmt_nsg.arm_id, "") : ""
   sub_mgmt_nsg_name        = local.sub_mgmt_nsg_exists ? "" : try(local.sub_mgmt_nsg.name, format("%s_deploymentSubnet-nsg", local.prefix))
-  deployer_pip_list        = azurerm_public_ip.deployer[*].ip_address
-  sub_mgmt_nsg_allowed_ips = local.sub_mgmt_nsg_exists ? [] : try(concat(local.sub_mgmt_nsg.allowed_ips, local.deployer_pip_list), ["0.0.0.0/0"])
+  sub_mgmt_nsg_allowed_ips = local.sub_mgmt_nsg_exists ? [] : try(local.sub_mgmt_nsg.allowed_ips, ["0.0.0.0/0"])
   sub_mgmt_nsg_deployed    = try(local.sub_mgmt_nsg_exists ? data.azurerm_network_security_group.nsg_mgmt[0] : azurerm_network_security_group.nsg_mgmt[0], null)
 
   // Deployer(s) information from input


### PR DESCRIPTION
## Problem
We need to provide access from azure pipeline agent to deployed VMs. 
The current pipeline removes public IP of the pipeline agent from NSG rule, however it is not complete.
This cause us to have public IP in NSG which violates S360.

## Solution
1. Remove assigning public IP of deployer to NSG - this seems not required.
2. Remove 67.160.0.0/16 which is the corp net address from pipeline deployment, instead add only private IP address space to allowed_ip.
4. Make changes to cleanup job:
    - In case of other pipeline failure, force reset all NSG rules to have only private IP address space in clean up job.
    - Shorten the cleanup job to every 2 hrs.
    - Remove PR/CI trigger from cleanup job, so it does not interfere with running pipeline test.

## Tests
Deployer test: https://dev.azure.com/azuresaphana/Azure-SAP-HANA/_build/results?buildId=11443&view=results
Cleanup job test: https://dev.azure.com/azuresaphana/Azure-SAP-HANA/_build/results?buildId=11449&view=results
Integration test: https://dev.azure.com/azuresaphana/Azure-SAP-HANA/_build/results?buildId=11447&view=results

## Notes
1. I will cherry pick this change to other feature/* branch so we avoid this problem with other concurrent project as well.
2. Temporarily we can add our own IP to NSG to access UNIT deployer for trouble shooting. In the meanwhile, will take a look at other options.
3. Integration test fails with a problem with KV, will fix in separate PR so it does not get cherry picked to other branches.