### PR TITLE
Fix incorrect deployer msi name in pipeline

### DIFF
--- a/.pipeline/templates/deployer/create-deployer-steps.yml
+++ b/.pipeline/templates/deployer/create-deployer-steps.yml
@@ -16,7 +16,10 @@ steps:
       deployer_rg="${deployer_prefix}-EAUS-MGMT-INFRASTRUCTURE"
       ws_dir=$(Agent.BuildDirectory)/Azure_SAP_Automated_Deployment/WORKSPACES/LOCAL/${deployer_rg}
       input=${ws_dir}/${deployer_rg}.json
-      
+
+      #Only private IP addresses can be added to NSG due to S360 requirement
+      prefix="10.0.0.16/28"
+
       git checkout ${{parameters.branch_name}}
 
       mkdir -p ${ws_dir}; cd $_
@@ -28,9 +31,9 @@ steps:
       [[ -f ${input} ]] ||
       cat deployer.json \
       | jq --arg environment "${deployer_prefix}" .infrastructure.environment\ =\ \$environment \
-      | jq --arg allowed_ip "$(agent_ip)" '.infrastructure.vnets.management.subnet_mgmt += {
+      | jq --arg prefix "${prefix}" --arg agent_ip "$(agent_ip)" '.infrastructure.vnets.management.subnet_mgmt += {
         nsg: {
-          allowed_ips: ["67.160.0.0/16", $allowed_ip]
+          allowed_ips: [$prefix, $agent_ip]
         }
       }' \
       | jq '. += {

--- a/.pipeline/templates/saplib/create-saplib-steps.yml
+++ b/.pipeline/templates/saplib/create-saplib-steps.yml
@@ -19,6 +19,8 @@ steps:
       fi
 
       saplib_rg="${saplib_prefix}-EAUS-SAP_LIBRARY"
+      deployer_rg_name="${saplib_prefix}-EAUS-MGMT-INFRASTRUCTURE"
+      msi_name="${saplib_prefix}-EAUS-MGMT-msi"
 
       repo_dir=$HOME/${saplib_rg}/sap-hana
       ws_dir=$HOME/Azure_SAP_Automated_Deployment/WORKSPACES/SAP_LIBRARY/${saplib_rg}
@@ -39,8 +41,8 @@ steps:
       cp ${repo_dir}/deploy/terraform/bootstrap/sap_library/saplibrary.json ${ws_dir}/saplibrary.json
       cat ${ws_dir}/saplibrary.json \
       | jq --arg environment "${saplib_prefix}" .infrastructure.environment\ =\ \$environment \
-      | jq --arg deployer_rg_name "UNIT-EAUS-MGMT-INFRASTRUCTURE" .deployer.resource_group.name\ =\ \$deployer_rg_name \
-      | jq --arg msi_name "UNIT-EAUS-MGMT-msi" .deployer.msi.name\ =\ \$msi_name \
+      | jq --arg deployer_rg_name "${deployer_rg_name}" .deployer.resource_group.name\ =\ \$deployer_rg_name \
+      | jq --arg msi_name "${msi_name}" .deployer.msi.name\ =\ \$msi_name \
       | jq --arg downloader_username "$(hana-smp-nancyc-username)" .software.downloader.credentials.sap_user\ =\ \$downloader_username \
       | jq --arg downloader_password "$(hana-smp-nancyc-password)" .software.downloader.credentials.sap_password\ =\ \$downloader_password \
       > ${input}

--- a/.pipeline/templates/util/remove-agent-from-deployer-nsg.yml
+++ b/.pipeline/templates/util/remove-agent-from-deployer-nsg.yml
@@ -26,6 +26,8 @@ steps:
       echo "=== Update NSG source address by removing agent IP ==="
       prefix_list=$(az network nsg rule show  -g ${rg_name} --nsg-name ${nsg_name} -n ssh | jq -r '.sourceAddressPrefix, (.sourceAddressPrefixes | join(" ")) | select(.!=null)' | sed "s/$(agent_ip)//")
       az network nsg rule update -g ${rg_name} --nsg-name ${nsg_name} -n ssh --source-address-prefixes ${prefix_list} --output none
+      az network nsg rule update -g ${rg_name} --nsg-name ${nsg_name} -n rdp --source-address-prefixes ${prefix_list} --output none
+      az network nsg rule update -g ${rg_name} --nsg-name ${nsg_name} -n winrm --source-address-prefixes ${prefix_list} --output none
 
       echo "=== Assgin ${nsg_name} to deployer ${subnet_name} to avoid NRMS ==="
       az network vnet subnet update -g ${rg_name} -n ${subnet_name} --vnet-name ${vnet_name} --network-security-group ${nsg_name} --output none

--- a/.pipeline/tf-deployer-test.yml
+++ b/.pipeline/tf-deployer-test.yml
@@ -35,3 +35,6 @@ stages:
         parameters:
           branch_name: $(sourceBranchName)
           deployer_env: "$(Build.BuildId)"
+      - template: templates/util/remove-agent-from-deployer-nsg.yml
+        parameters:
+          deployer_env: "UNIT"

--- a/.pipeline/tf-integration-test.yml
+++ b/.pipeline/tf-integration-test.yml
@@ -31,6 +31,9 @@ stages:
       - template: templates/deployer/post-deployer-steps.yml
         parameters:
           deployer_env: "$(Build.BuildId)"
+      - template: templates/util/remove-agent-from-deployer-nsg.yml
+        parameters:
+          deployer_env: "$(Build.BuildId)"
   - job: createSAPLib
     dependsOn: createDeployer
     steps:

--- a/.pipeline/tf-release.yml
+++ b/.pipeline/tf-release.yml
@@ -67,6 +67,9 @@ stages:
       - template: templates/deployer/post-deployer-steps.yml
         parameters:
           deployer_env: "UNIT"
+      - template: templates/util/remove-agent-from-deployer-nsg.yml
+        parameters:
+          deployer_env: "UNIT"
   - job: createSAPLib
     dependsOn: createDeployer
     steps:

--- a/azure-pipelines-cleanup.yaml
+++ b/azure-pipelines-cleanup.yaml
@@ -1,17 +1,21 @@
+trigger: none
+pr: none
 schedules:
-- cron: '0 0 * * *'
-  displayName: Daily midnight clean up (UTC)
+- cron: '0 */2 * * *'
+  displayName: Cleanup resources every 2 hours
   branches:
     include:
     - master
+    - beta/*
+    - feature/*
   always: true
 variables:
   - group: azure-config-variables
   - group: azure-sap-hana-pipeline-secrets
 jobs:
-- job: dailyCleanup
+- job: scheduled_RG_Cleanup
   pool:
-    vmImage: "ubuntu-16.04"
+    vmImage: "ubuntu-18.04"
   steps:
   - script: |
       az login --service-principal --user $(hana-pipeline-spn-id) --password  $(hana-pipeline-spn-pw) --tenant $(landscape-tenant) --output none
@@ -19,11 +23,15 @@ jobs:
       for rg in $groups
       do
         if $(az group exists -n $rg); then
+          echo ${rg}
           az group delete -n $rg --no-wait -y
-          echo $rg
         fi
       done
-    displayName: 'Clean up resource group daily'
+    displayName: 'Clean up resource group'
+- job: scheduled_Peering_Cleanup
+  pool:
+    vmImage: "ubuntu-18.04"
+  steps:
   - script: |
       az login --service-principal --user $(hana-pipeline-spn-id) --password  $(hana-pipeline-spn-pw) --tenant $(landscape-tenant) --output none
       deployer_rg="UNIT-EAUS-MGMT-INFRASTRUCTURE"
@@ -31,8 +39,46 @@ jobs:
       peering_list=$(az network vnet peering list --resource-group ${deployer_rg} --vnet-name ${mgmt_vnet} | jq -c '.[] | select(.peeringState=="Disconnected")' | jq -r .name)
       for peering in ${peering_list}
       do
-        echo ${peering_list}
-        az network vnet peering delete --resource-group ${deployer_rg}  --vnet-name ${mgmt_vnet} --name ${peering} --no-wait -y
+        echo ${peering}
+        az network vnet peering delete --resource-group ${deployer_rg}  --vnet-name ${mgmt_vnet} --name ${peering}
       done
-    displayName: 'Clean up network peering daily'
+    displayName: 'Clean up network peering'
+- job: scheduled_NSG_Cleanup
+  pool:
+    vmImage: "ubuntu-18.04"
+  steps:
+  - script: |
+      az login --service-principal --user $(hana-pipeline-spn-id) --password  $(hana-pipeline-spn-pw) --tenant $(landscape-tenant) --output none
+      
+      rg_name="UNIT-EAUS-MGMT-INFRASTRUCTURE"
+
+      vnet_name=$(az network vnet list --resource-group ${rg_name} | jq -r .[].name)
+      subnet_name=$(az network vnet list --resource-group ${rg_name} | jq -r .[].subnets[].name)
+      nsg_name=$(az network nsg list --resource-group ${rg_name} | jq -r --arg vnet_name "${vnet_name}" '.[] | select(.name | contains($vnet_name) | not) | .name')
+      
+      echo "=== Update NSG source address with only private IP address ==="
+      #Only private IP addresses can be added to NSG due to S360 requirement
+      prefix_list="10.0.0.16/28"
+      az network nsg rule update -g ${rg_name} --nsg-name ${nsg_name} -n ssh --source-address-prefixes ${prefix_list} --output none
+      az network nsg rule update -g ${rg_name} --nsg-name ${nsg_name} -n rdp --source-address-prefixes ${prefix_list} --output none
+      az network nsg rule update -g ${rg_name} --nsg-name ${nsg_name} -n winrm --source-address-prefixes ${prefix_list} --output none
+
+      echo "=== Assgin ${nsg_name} to deployer ${subnet_name} to avoid NRMS ==="
+      az network vnet subnet update -g ${rg_name} -n ${subnet_name} --vnet-name ${vnet_name} --network-security-group ${nsg_name} --output none
+    displayName: 'Clean up NSG'
+- job: scheduled_Subnet_Cleanup
+  pool:
+    vmImage: "ubuntu-18.04"
+  steps:
+  - script: |
+      az login --service-principal --user $(hana-pipeline-spn-id) --password  $(hana-pipeline-spn-pw) --tenant $(landscape-tenant) --output none
+      sap_landscape_rg="UNIT-EAUS-SAP0-INFRASTRUCTURE"
+      sap_vnet=$(az network vnet list --resource-group ${sap_landscape_rg} | jq -r '.[].name')
+      subnet_list=$(az network vnet subnet list --resource-group ${sap_landscape_rg} --vnet-name ${sap_vnet} | jq -c '.[] | select(.name | contains("RHEL") | not) | select(.name | contains("SLES") | not)' | jq -r .name)
+      for subnet in ${subnet_list}
+      do
+        echo ${subnet}
+        az network vnet subnet delete --resource-group ${sap_landscape_rg} --vnet-name ${sap_vnet} --name ${subnet} || :
+      done
+    displayName: 'Clean up subnet'
 

--- a/deploy/terraform/terraform-units/modules/sap_deployer/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/variables_local.tf
@@ -82,8 +82,7 @@ locals {
   sub_mgmt_nsg_exists      = try(local.sub_mgmt_nsg.is_existing, false)
   sub_mgmt_nsg_arm_id      = local.sub_mgmt_nsg_exists ? try(local.sub_mgmt_nsg.arm_id, "") : ""
   sub_mgmt_nsg_name        = local.sub_mgmt_nsg_exists ? "" : try(local.sub_mgmt_nsg.name, format("%s_deploymentSubnet-nsg", local.prefix))
-  deployer_pip_list        = azurerm_public_ip.deployer[*].ip_address
-  sub_mgmt_nsg_allowed_ips = local.sub_mgmt_nsg_exists ? [] : try(concat(local.sub_mgmt_nsg.allowed_ips, local.deployer_pip_list), ["0.0.0.0/0"])
+  sub_mgmt_nsg_allowed_ips = local.sub_mgmt_nsg_exists ? [] : try(local.sub_mgmt_nsg.allowed_ips, ["0.0.0.0/0"])
   sub_mgmt_nsg_deployed    = try(local.sub_mgmt_nsg_exists ? data.azurerm_network_security_group.nsg_mgmt[0] : azurerm_network_security_group.nsg_mgmt[0], null)
 
   // Deployer(s) information from input

--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/variables_local.tf
@@ -126,7 +126,7 @@ locals {
   secret_sid_pk_name = try(local.var_infra.landscape.sid_public_key_secret_name, "")
 
   // Define this variable to make it easier when implementing existing kv.
-  sid_kv_user = var.sid_kv_user[0]
+  sid_kv_user = try(var.sid_kv_user[0], null)
 
   // If custom image is used, we do not overwrite os reference with default value
   anydb_custom_image = try(local.anydb.os.source_image_id, "") != "" ? true : false

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/variables_local.tf
@@ -110,7 +110,7 @@ locals {
   secret_sid_pk_name = try(local.var_infra.landscape.sid_public_key_secret_name, "")
 
   // Define this variable to make it easier when implementing existing kv.
-  sid_kv_user = var.sid_kv_user[0]
+  sid_kv_user = try(var.sid_kv_user[0], null)
 
   # SAP vnet
   var_infra       = try(var.infrastructure, {})

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/outputs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/outputs.tf
@@ -39,11 +39,11 @@ output "software_w_defaults" {
 }
 
 output "sid_kv_user" {
-  value = azurerm_key_vault.sid_kv_user
+  value = local.enable_sid_deployment ? azurerm_key_vault.sid_kv_user : null
 }
 
 output "sid_kv_prvt" {
-  value = azurerm_key_vault.sid_kv_prvt
+  value = local.enable_sid_deployment ? azurerm_key_vault.sid_kv_prvt : null
 }
 
 /*

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/variables_local.tf
@@ -101,7 +101,7 @@ locals {
   secret_sid_pk_name = try(local.var_infra.landscape.sid_public_key_secret_name, "")
 
   // Define this variable to make it easier when implementing existing kv.
-  sid_kv_user = var.sid_kv_user[0]
+  sid_kv_user = try(var.sid_kv_user[0], null)
 
   # SAP vnet
   var_infra       = try(var.infrastructure, {})


### PR DESCRIPTION
## Problem
1. Incorrect deployer msi names are used in integration pipeline.
2. sap_landscape fails due to missing error handling for sid user keyvault

## Solution
1. Dynamically generate deployer msi name in pipeline.
2. Add try to handle situation when sid user keyvault not generated.

## Tests
sap_landscape test: https://dev.azure.com/azuresaphana/Azure-SAP-HANA/_build/results?buildId=11464&view=results
integration test: https://dev.azure.com/azuresaphana/Azure-SAP-HANA/_build/results?buildId=11465&view=results

## Notes
<Additional comments for the PR>