### PR TITLE
Skip check fencing agent when only SBD is used

### DIFF
--- a/deploy/ansible/roles/hana-os-clustering/tasks/pre_checks.yml
+++ b/deploy/ansible/roles/hana-os-clustering/tasks/pre_checks.yml
@@ -1,7 +1,9 @@
 ---
 
 - name: Check the fencing agent configuration variables are set
-  when: hdb_size != "LargeInstance"
+  when: 
+    - hdb_size != "LargeInstance"
+    - groups['iscsi'] | length == 0
   assert:
     that:
       - "sap_hana_fencing_agent_subscription_id is defined"


### PR DESCRIPTION
## Problem
Close #809

## Solution
Skip fencing agent info check if SBD is used.

## Tests
With one iSCSI devices in hosts:
```
[iscsi]
10.11.11.68  ansible_connection=ssh  ansible_user=azureadm
...
[hanadbnodes]
10.11.8.10  ansible_connection=ssh  ansible_user=azureadm
10.11.8.11  ansible_connection=ssh  ansible_user=azureadm
```
See this check skipped:
```
TASK [hana-os-clustering : Check the fencing agent configuration variables are set] ***********************************************
skipping: [10.11.8.10]
skipping: [10.11.8.11]

TASK [hana-os-clustering : Check the required cluster password is set] ************************************************************
ok: [10.11.8.10] => {
    "changed": false,
    "msg": "All assertions passed"
}
ok: [10.11.8.11] => {
    "changed": false,
    "msg": "All assertions passed"
}
```

## Notes
<Additional comments for the PR>