### PR TITLE
Default behavior should not pass sshkey pair from local files

### DIFF
--- a/deploy/terraform/bootstrap/sap_deployer/variables_global.tf
+++ b/deploy/terraform/bootstrap/sap_deployer/variables_global.tf
@@ -26,8 +26,5 @@ variable "ssh-timeout" {
 
 variable "sshkey" {
   description = "Details of ssh key pair"
-  default = {
-    path_to_public_key  = "~/.ssh/id_rsa.pub",
-    path_to_private_key = "~/.ssh/id_rsa"
-  }
+  default     = {}
 }

--- a/deploy/terraform/run/sap_deployer/variables_global.tf
+++ b/deploy/terraform/run/sap_deployer/variables_global.tf
@@ -26,8 +26,5 @@ variable "ssh-timeout" {
 
 variable "sshkey" {
   description = "Details of ssh key pair"
-  default = {
-    path_to_public_key  = "~/.ssh/id_rsa.pub",
-    path_to_private_key = "~/.ssh/id_rsa"
-  }
+  default     = {}
 }


### PR DESCRIPTION
## Problem
Default behavior is to use TF create SSH key pairs.

## Solution
Remove default value for SSH key pairs.

## Tests
<Please provide steps to test the PR>

## Notes
<Additional comments for the PR>