### PR TITLE
Use lifecycle to keep access policy for user/SPN that creates deployer.

### DIFF
--- a/deploy/terraform/bootstrap/sap_deployer/output.tf
+++ b/deploy/terraform/bootstrap/sap_deployer/output.tf
@@ -6,35 +6,38 @@ Description:
 
 output "deployer_id" {
   sensitive = true
-  value = module.sap_deployer.deployer_id
+  value     = module.sap_deployer.deployer_id
 }
 
 output "vnet_mgmt" {
   sensitive = true
-  value = module.sap_deployer.vnet_mgmt
+  value     = module.sap_deployer.vnet_mgmt
 }
 
 output "subnet_mgmt" {
   sensitive = true
-  value = module.sap_deployer.subnet_mgmt
+  value     = module.sap_deployer.subnet_mgmt
 }
 
 output "nsg_mgmt" {
   sensitive = true
-  value = module.sap_deployer.nsg_mgmt
+  value     = module.sap_deployer.nsg_mgmt
 }
 
 output "deployer_uai" {
   sensitive = true
-  value = module.sap_deployer.deployer_uai
+  value     = module.sap_deployer.deployer_uai
 }
 
 output "deployer" {
   sensitive = true
-  value = module.sap_deployer.deployers
+  value     = module.sap_deployer.deployers
 }
 
+// Comment out code with users.object_id for the time being.
+/*
 output "deployer_user" {
   sensitive = true
   value = module.sap_deployer.deployer_user
 }
+*/

--- a/deploy/terraform/bootstrap/sap_deployer/variables_global.tf
+++ b/deploy/terraform/bootstrap/sap_deployer/variables_global.tf
@@ -26,8 +26,5 @@ variable "ssh-timeout" {
 
 variable "sshkey" {
   description = "Details of ssh key pair"
-  default = {
-    path_to_public_key  = "~/.ssh/id_rsa.pub",
-    path_to_private_key = "~/.ssh/id_rsa"
-  }
+  default     = {}
 }

--- a/deploy/terraform/run/sap_deployer/output.tf
+++ b/deploy/terraform/run/sap_deployer/output.tf
@@ -34,7 +34,10 @@ output "deployer" {
   value     = module.sap_deployer.deployers
 }
 
+// Comment out code with users.object_id for the time being.
+/*
 output "deployer_user" {
   sensitive = true
   value = module.sap_deployer.deployer_user
 }
+*/

--- a/deploy/terraform/run/sap_deployer/variables_global.tf
+++ b/deploy/terraform/run/sap_deployer/variables_global.tf
@@ -26,8 +26,5 @@ variable "ssh-timeout" {
 
 variable "sshkey" {
   description = "Details of ssh key pair"
-  default = {
-    path_to_public_key  = "~/.ssh/id_rsa.pub",
-    path_to_private_key = "~/.ssh/id_rsa"
-  }
+  default     = {}
 }

--- a/deploy/terraform/terraform-units/modules/sap_deployer/output.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/output.tf
@@ -56,6 +56,9 @@ output "pwd_name" {
   value = local.enable_deployers && local.enable_password ? azurerm_key_vault_secret.pwd[0].name : ""
 }
 
+// Comment out code with users.object_id for the time being.
+/*
 output "deployer_user" {
   value = local.deployer_users_id_list
 }
+*/

--- a/deploy/terraform/terraform-units/modules/sap_deployer/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/variables_local.tf
@@ -162,6 +162,7 @@ locals {
       deployer.users.object_id
     ])
   )
-  curr_deployer_user_id  = try(data.azurerm_client_config.deployer.object_id, "")
-  deployer_users_id_list = distinct(compact(concat(local.deployer_users_id, [local.curr_deployer_user_id])))
+
+  // Comment out code with users.object_id for the time being.
+  // deployer_users_id_list = distinct(compact(concat(local.deployer_users_id)))
 }


### PR DESCRIPTION
## Problem
The access policy for user/SPN who creates deployer should not be removed.

## Solution
Use lifecycle to ignore changes in the object_id when on deployer.

## Tests
1. Deploy deployer
2. Deployer sap_library from deployer
3. Re-init deployer to use remote tfstate
4. Deploy deployer on deployer, see no changes to the access policy

## Notes
Also comment out code in sap_deployer that is related to users -> object_id as discussed.