### PR TITLE
Pass deployer msi info with naming convention

### DIFF
--- a/.pipeline/templates/saplib/create-saplib-steps.yml
+++ b/.pipeline/templates/saplib/create-saplib-steps.yml
@@ -17,8 +17,8 @@ steps:
       else
         deployer_prefix=${deployer_env}
       fi
-      deployer_rg_name="${deployer_prefix}-EAUS-MGMT-INFRASTRUCTURE"
-      msi_name="${deployer_prefix}-EAUS-MGMT-msi"
+      
+      deployer_environment=${deployer_prefix}
 
       # Modify environment value so it starts with u and with length of 5
       saplib_env=${{parameters.saplib_env}}
@@ -52,8 +52,7 @@ steps:
       cp ${repo_dir}/deploy/terraform/bootstrap/sap_library/saplibrary.json ${ws_dir}/saplibrary.json
       cat ${ws_dir}/saplibrary.json \
       | jq --arg environment "${saplib_prefix}" .infrastructure.environment\ =\ \$environment \
-      | jq --arg deployer_rg_name "${deployer_rg_name}" .deployer.resource_group.name\ =\ \$deployer_rg_name \
-      | jq --arg msi_name "${msi_name}" .deployer.msi.name\ =\ \$msi_name \
+      | jq --arg deployer_environment "${deployer_environment}" .deployer.environment\ =\ \$deployer_environment \
       > ${input}
 
       cat ${input}

--- a/deploy/terraform/bootstrap/sap_library/saplibrary.json
+++ b/deploy/terraform/bootstrap/sap_library/saplibrary.json
@@ -8,15 +8,9 @@
         }
     },
     "deployer": {
-        "resource_group": {
-            "name": ""
-        },
-        "msi": {
-            "name": ""
-        },
-        "users": {
-            "object_id": []
-        }
+        "environment": "global",
+        "region": "eastus",
+        "vnet": "MGMT"
     },
     "software": {
         "downloader": {

--- a/deploy/terraform/terraform-units/modules/sap_library/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_library/variables_local.tf
@@ -92,21 +92,25 @@ locals {
   sa_tfstate_container_name   = "tfstate"
 
   // deployer
-  deployer = try(var.deployer, "")
-  deployer_rg_name = try(local.deployer.resource_group.name, "")
-  deployer_msi = try(local.deployer.msi, "")
-  deployer_msi_name = try(local.deployer_msi.name, "")
+  deployer                = try(var.deployer, {})
+  deployer_environment    = try(local.deployer.environment, "")
+  deployer_location_short = try(var.region_mapping[local.deployer.region], "unkn")
+  deployer_vnet           = try(local.deployer.vnet, "")
+  deployer_prefix         = upper(format("%s-%s-%s", local.deployer_environment, local.deployer_location_short, substr(local.deployer_vnet, 0, 7)))
+  // If custom names are used for deployer, provide resource_group_name and msi_name will override the naming convention
+  deployer_rg_name  = try(local.deployer.resource_group_name, format("%s-INFRASTRUCTURE", local.deployer_prefix))
+  deployer_msi_name = try(local.deployer.msi_name, format("%s-msi", local.deployer_prefix))
   deployer_users_id = try(local.deployer.users.object_id, [])
 
   // key vault for saplibrary
-  kv_prefix                           = upper(format("%s%s", substr(local.environment, 0, 5), local.location_short))
-  kv_private_name                     = format("%sSAPLIBprvt%s", local.kv_prefix, local.postfix)
-  kv_user_name                        = format("%sSAPLIBuser%s", local.kv_prefix, local.postfix)
+  kv_prefix       = upper(format("%s%s", substr(local.environment, 0, 5), local.location_short))
+  kv_private_name = format("%sSAPLIBprvt%s", local.kv_prefix, local.postfix)
+  kv_user_name    = format("%sSAPLIBuser%s", local.kv_prefix, local.postfix)
   // credential for sap downloader
-  secret_downloader_username_name     = format("%s-downloader-username", local.kv_prefix)
-  secret_downloader_password_name     = format("%s-downloader-password", local.kv_prefix)
-  downloader_username                 = try(var.software.downloader.credentials.sap_user, "sap_smp_user")
-  downloader_password                 = try(var.software.downloader.credentials.sap_password, "sap_smp_password")
+  secret_downloader_username_name = format("%s-downloader-username", local.kv_prefix)
+  secret_downloader_password_name = format("%s-downloader-password", local.kv_prefix)
+  downloader_username             = try(var.software.downloader.credentials.sap_user, "sap_smp_user")
+  downloader_password             = try(var.software.downloader.credentials.sap_password, "sap_smp_password")
 
 }
 


### PR DESCRIPTION
## Problem
Default behavior should deduct msi name with naming convention.

## Solution
1. Add additional deployer info in the input JSON to support naming convention.
1. If customized name is used, we support overrides.

## Tests
<Please provide steps to test the PR>

## Notes
Will have a separate PR to remove unused variable for smp credential.