### PR TITLE
Add IMDS to working branch for Fe

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_deployer/IMDS.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/IMDS.tf
@@ -1,0 +1,40 @@
+variable "api-version" {
+  description = "IMDS API Version"
+  default     = "2019-04-30"
+}
+
+variable "auto-deploy-version" {
+  description = "Version for automated deployment"
+  default     = "Fe"
+}
+
+variable "scenario" {
+  description = "Deployment Scenario"
+  default     = "sap_deployer"
+}
+
+variable "max_timeout" {
+  description = "Maximum time allowed to spend for curl"
+  default     = 10
+}
+
+// Registers the current deployment state with Azure's Metadata Service (IMDS)
+resource "null_resource" "IMDS" {
+  depends_on = [azurerm_linux_virtual_machine.deployer]
+  count      = length(local.deployers)
+
+  connection {
+    type        = "ssh"
+    host        = azurerm_public_ip.deployer[count.index].ip_address
+    user        = local.deployers[count.index].authentication.username
+    private_key = local.deployers[count.index].authentication.type == "key" ? local.deployers[count.index].authentication.sshkey.private_key : null
+    password    = lookup(local.deployers[count.index].authentication, "password", null)
+    timeout     = var.ssh-timeout
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "curl --silent --max-time ${var.max_timeout} -i -H \"Metadata: \"true\"\" -H \"user-agent: SAP AutoDeploy/${var.auto-deploy-version}; scenario=${var.scenario}; deploy-status=Terraform_${var.scenario}\" http://169.254.169.254/metadata/instance?api-version=${var.api-version} || true"
+    ]
+  }
+}

--- a/deploy/terraform/terraform-units/modules/sap_library/IMDS.tf
+++ b/deploy/terraform/terraform-units/modules/sap_library/IMDS.tf
@@ -1,0 +1,26 @@
+variable "api-version" {
+  description = "IMDS API Version"
+  default     = "2019-04-30"
+}
+
+variable "auto-deploy-version" {
+  description = "Version for automated deployment"
+  default     = "Fe"
+}
+
+variable "scenario" {
+  description = "Deployment Scenario"
+  default     = "sap_library"
+}
+
+variable "max_timeout" {
+  description = "Maximum time allowed to spend for curl"
+  default     = 10
+}
+
+// Registers the current deployment state with Azure's Metadata Service (IMDS)
+resource "null_resource" "IMDS" {
+  provisioner "local-exec" {
+    command = "curl --silent --max-time ${var.max_timeout} -i -H \"Metadata: \"true\"\" -H \"user-agent: SAP AutoDeploy/${var.auto-deploy-version}; scenario=${var.scenario}; deploy-status=Terraform_${var.scenario}\" http://169.254.169.254/metadata/instance?api-version=${var.api-version} || true"
+  }
+}

--- a/deploy/terraform/terraform-units/modules/sap_library/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_library/variables_local.tf
@@ -1,3 +1,9 @@
+/*
+Description:
+
+  Define local variables.
+*/
+
 // Input arguments 
 variable "region_mapping" {
   type        = map(string)

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/IMDS.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/IMDS.tf
@@ -1,0 +1,26 @@
+variable "api-version" {
+  description = "IMDS API Version"
+  default     = "2019-04-30"
+}
+
+variable "auto-deploy-version" {
+  description = "Version for automated deployment"
+  default     = "Fe"
+}
+
+variable "scenario" {
+  description = "Deployment Scenario"
+  default     = "sap_system"
+}
+
+variable "max_timeout" {
+  description = "Maximum time allowed to spend for curl"
+  default     = 10
+}
+
+// Registers the current deployment state with Azure's Metadata Service (IMDS)
+resource "null_resource" "IMDS" {
+  provisioner "local-exec" {
+    command = "curl --silent --max-time ${var.max_timeout} -i -H \"Metadata: \"true\"\" -H \"user-agent: SAP AutoDeploy/${var.auto-deploy-version}; scenario=${var.scenario}; deploy-status=Terraform_${var.scenario}\" http://169.254.169.254/metadata/instance?api-version=${var.api-version} || true"
+  }
+}

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/variables_local.tf
@@ -1,3 +1,9 @@
+/*
+Description:
+
+  Define local variables.
+*/
+
 variable "is_single_node_hana" {
   description = "Checks if single node hana architecture scenario is being deployed"
   default     = false


### PR DESCRIPTION
## Problem
We need the same tracking as v1 and v2.

## Solution
Since now we are separating the deployment from E2E to several steps, we can not track the E2E start/finish of terraform.
Therefore, we no longer track the full terraform deployment, but just check if a deployment happens or not for each module.

1. Add version Fe to all IMDS calls.
1. Add separate IMDS calls for sap_deployer/sap_library/sap_system (even if sap_library/sap_system is executed locally, it will not interrupt the deployment since it always return true).
1. Separate IMDS into separate tf so easy to modify/remove if required.

## Tests
There is a delay of 12 hrs for data to show in kusto.
Ping me directly if you need the sample query.

## Notes
Will cherry-pick this change to all feature/* and beta/* branches.