### PR TITLE
Support spn when deploying sap library

### DIFF
--- a/deploy/terraform/bootstrap/sap_deployer/output.tf
+++ b/deploy/terraform/bootstrap/sap_deployer/output.tf
@@ -46,3 +46,11 @@ output "deployer_kv_user_arm_id" {
   sensitive = true
   value     = module.sap_deployer.deployer_kv_user_arm_id
 }
+
+output "deployer_kv_prvt_name" {
+  value     = module.sap_deployer.prvt_vault_name
+}
+
+output "deployer_kv_user_name" {
+  value     = module.sap_deployer.user_vault_name
+}

--- a/deploy/terraform/bootstrap/sap_deployer/output.tf
+++ b/deploy/terraform/bootstrap/sap_deployer/output.tf
@@ -41,3 +41,8 @@ output "deployer_user" {
   value = module.sap_deployer.deployer_user
 }
 */
+
+output "deployer_kv_user_arm_id" {
+  sensitive = true
+  value = module.sap_deployer.deployer_kv_user_arm_id
+}

--- a/deploy/terraform/bootstrap/sap_deployer/output.tf
+++ b/deploy/terraform/bootstrap/sap_deployer/output.tf
@@ -44,5 +44,5 @@ output "deployer_user" {
 
 output "deployer_kv_user_arm_id" {
   sensitive = true
-  value = module.sap_deployer.deployer_kv_user_arm_id
+  value     = module.sap_deployer.deployer_kv_user_arm_id
 }

--- a/deploy/terraform/bootstrap/sap_deployer/output.tf
+++ b/deploy/terraform/bootstrap/sap_deployer/output.tf
@@ -48,9 +48,25 @@ output "deployer_kv_user_arm_id" {
 }
 
 output "deployer_kv_prvt_name" {
-  value     = module.sap_deployer.prvt_vault_name
+  value = module.sap_deployer.prvt_vault_name
 }
 
 output "deployer_kv_user_name" {
-  value     = module.sap_deployer.user_vault_name
+  value = module.sap_deployer.user_vault_name
+}
+
+output "deployer_public_key_secret_name" {
+  value = module.sap_deployer.ppk_name
+}
+
+output "deployer_private_key_secret_name" {
+  value = module.sap_deployer.pk_name
+}
+
+output "deployer_rg_name" {
+  value = module.sap_deployer.deployer_rg_name
+}
+
+output "deployer_public_ip_address" {
+  value = module.sap_deployer.deployer_public_ip_address
 }

--- a/deploy/terraform/bootstrap/sap_library/imports.tf
+++ b/deploy/terraform/bootstrap/sap_library/imports.tf
@@ -3,10 +3,10 @@
       Import deployer resources
 */
 
-data "terraform_remote_state" "local_deployer" {
+data "terraform_remote_state" "deployer" {
   backend = "local"
-  config  = {
-    path  = "${abspath(path.cwd)}/../../LOCAL/${local.deployer_rg_name}/terraform.tfstate"
+  config = {
+    path = "${abspath(path.cwd)}/../../LOCAL/${local.deployer_rg_name}/terraform.tfstate"
   }
 }
 

--- a/deploy/terraform/bootstrap/sap_library/imports.tf
+++ b/deploy/terraform/bootstrap/sap_library/imports.tf
@@ -1,0 +1,35 @@
+/*
+    Description:
+      Import deployer resources
+*/
+
+data "terraform_remote_state" "local_deployer" {
+  backend = "local"
+  config = {
+    path = "$../../LOCAL/${local.deployer_rg_name}/terraform.tfstate"
+  }
+}
+
+data "azurerm_key_vault_secret" "subscription_id" {
+  provider     = azurerm.deployer
+  name         = "deployer-subscription-id"
+  key_vault_id = local.deployer_key_vault_arm_id
+}
+
+data "azurerm_key_vault_secret" "client_id" {
+  provider     = azurerm.deployer
+  name         = "deployer-client-id"
+  key_vault_id = local.deployer_key_vault_arm_id
+}
+
+data "azurerm_key_vault_secret" "client_secret" {
+  provider     = azurerm.deployer
+  name         = "deployer-client-secret"
+  key_vault_id = local.deployer_key_vault_arm_id
+}
+
+data "azurerm_key_vault_secret" "tenant_id" {
+  provider     = azurerm.deployer
+  name         = "deployer-tenant-id"
+  key_vault_id = local.deployer_key_vault_arm_id
+}

--- a/deploy/terraform/bootstrap/sap_library/imports.tf
+++ b/deploy/terraform/bootstrap/sap_library/imports.tf
@@ -12,24 +12,24 @@ data "terraform_remote_state" "local_deployer" {
 
 data "azurerm_key_vault_secret" "subscription_id" {
   provider     = azurerm.deployer
-  name         = "deployer-subscription-id"
+  name         = format("%s-subscription-id", local.environment)
   key_vault_id = local.deployer_key_vault_arm_id
 }
 
 data "azurerm_key_vault_secret" "client_id" {
   provider     = azurerm.deployer
-  name         = "deployer-client-id"
+  name         = format("%s-client-id", local.environment)
   key_vault_id = local.deployer_key_vault_arm_id
 }
 
 data "azurerm_key_vault_secret" "client_secret" {
   provider     = azurerm.deployer
-  name         = "deployer-client-secret"
+  name         = format("%s-client-secret", local.environment)
   key_vault_id = local.deployer_key_vault_arm_id
 }
 
 data "azurerm_key_vault_secret" "tenant_id" {
   provider     = azurerm.deployer
-  name         = "deployer-tenant-id"
+  name         = format("%s-tenant-id", local.environment)
   key_vault_id = local.deployer_key_vault_arm_id
 }

--- a/deploy/terraform/bootstrap/sap_library/imports.tf
+++ b/deploy/terraform/bootstrap/sap_library/imports.tf
@@ -5,8 +5,8 @@
 
 data "terraform_remote_state" "local_deployer" {
   backend = "local"
-  config = {
-    path = "../../LOCAL/${local.deployer_rg_name}/terraform.tfstate"
+  config  = {
+    path  = "${abspath(path.cwd)}/../../LOCAL/${local.deployer_rg_name}/terraform.tfstate"
   }
 }
 

--- a/deploy/terraform/bootstrap/sap_library/module.tf
+++ b/deploy/terraform/bootstrap/sap_library/module.tf
@@ -9,4 +9,5 @@ module "sap_library" {
   storage_account_tfstate = var.storage_account_tfstate
   software                = var.software
   deployer                = var.deployer
+  spn                     = local.spn
 }

--- a/deploy/terraform/bootstrap/sap_library/module.tf
+++ b/deploy/terraform/bootstrap/sap_library/module.tf
@@ -10,4 +10,5 @@ module "sap_library" {
   software                = var.software
   deployer                = var.deployer
   spn                     = local.spn
+  deployer_tfstate        = data.terraform_remote_state.deployer
 }

--- a/deploy/terraform/bootstrap/sap_library/output.tf
+++ b/deploy/terraform/bootstrap/sap_library/output.tf
@@ -42,3 +42,11 @@ output "remote_state_storage_account_name" {
 output "remote_state_container_name" {
   value = module.sap_library.remote_state_container_name
 }
+
+output "saplibrary_environment" {
+  value = local.environment
+}
+
+output "saplibrary_subscription_id" {
+  value = local.spn.subscription_id
+}

--- a/deploy/terraform/bootstrap/sap_library/providers.tf
+++ b/deploy/terraform/bootstrap/sap_library/providers.tf
@@ -16,6 +16,16 @@ Description:
 provider "azurerm" {
   version = "~> 2.10"
   features {}
+  subscription_id = data.azurerm_key_vault_secret.subscription_id.value
+  client_id       = data.azurerm_key_vault_secret.client_id.value
+  client_secret   = data.azurerm_key_vault_secret.client_secret.value
+  tenant_id       = data.azurerm_key_vault_secret.tenant_id.value
+}
+
+provider "azurerm" {
+  version = "~> 2.10"
+  features {}
+  alias = "deployer"
 }
 
 terraform {

--- a/deploy/terraform/bootstrap/sap_library/providers.tf
+++ b/deploy/terraform/bootstrap/sap_library/providers.tf
@@ -16,10 +16,10 @@ Description:
 provider "azurerm" {
   version = "~> 2.10"
   features {}
-  subscription_id = data.azurerm_key_vault_secret.subscription_id.value
-  client_id       = data.azurerm_key_vault_secret.client_id.value
-  client_secret   = data.azurerm_key_vault_secret.client_secret.value
-  tenant_id       = data.azurerm_key_vault_secret.tenant_id.value
+  subscription_id = local.spn.subscription_id
+  client_id       = local.spn.client_id
+  client_secret   = local.spn.client_secret
+  tenant_id       = local.spn.tenant_id
 }
 
 provider "azurerm" {

--- a/deploy/terraform/bootstrap/sap_library/saplibrary.json
+++ b/deploy/terraform/bootstrap/sap_library/saplibrary.json
@@ -1,11 +1,7 @@
 {
     "infrastructure": {
         "region": "eastus",
-        "environment": "np",
-        "resource_group": {
-            "is_existing": "false",
-            "arm_id": ""
-        }
+        "environment": "np"
     },
     "deployer": {
         "environment": "np",

--- a/deploy/terraform/bootstrap/sap_library/variables_local.tf
+++ b/deploy/terraform/bootstrap/sap_library/variables_local.tf
@@ -2,6 +2,7 @@
 locals {
 
   deployer                  = try(var.deployer, "")
+  environment               = try(var.infrastructure.environment, "")
   deployer_rg_name          = try(local.deployer.resource_group.name, "")
   deployer_key_vault_arm_id = try(data.terraform_remote_state.local_deployer.outputs.deployer_kv_user_arm_id, "")
 

--- a/deploy/terraform/bootstrap/sap_library/variables_local.tf
+++ b/deploy/terraform/bootstrap/sap_library/variables_local.tf
@@ -50,6 +50,7 @@ locals {
   // If custom names are used for deployer, providing resource_group_name and msi_name will override the naming convention
   deployer_rg_name = try(local.deployer.resource_group_name, format("%s-INFRASTRUCTURE", local.deployer_prefix))
 
+  // Retrieve the arm_id of deployer's Key Vault from deployer's terraform.tfstate
   deployer_key_vault_arm_id = try(data.terraform_remote_state.local_deployer.outputs.deployer_kv_user_arm_id, "")
 
   spn = {

--- a/deploy/terraform/bootstrap/sap_library/variables_local.tf
+++ b/deploy/terraform/bootstrap/sap_library/variables_local.tf
@@ -1,9 +1,55 @@
-// If the local terraform tfstate contains the arm id of deployer's KeyVault, it will be used. Otherwise, the information will be fetched from remote tfstate.
-locals {
+// Input arguments 
+variable "region_mapping" {
+  type        = map(string)
+  description = "Region Mapping: Full = Single CHAR, 4-CHAR"
 
-  deployer                  = try(var.deployer, "")
-  environment               = try(var.infrastructure.environment, "")
-  deployer_rg_name          = try(local.deployer.resource_group.name, "")
+  # 28 Regions 
+
+  default = {
+    westus             = "weus"
+    westus2            = "wus2"
+    centralus          = "ceus"
+    eastus             = "eaus"
+    eastus2            = "eus2"
+    northcentralus     = "ncus"
+    southcentralus     = "scus"
+    westcentralus      = "wcus"
+    northeurope        = "noeu"
+    westeurope         = "weeu"
+    eastasia           = "eaas"
+    southeastasia      = "seas"
+    brazilsouth        = "brso"
+    japaneast          = "jpea"
+    japanwest          = "jpwe"
+    centralindia       = "cein"
+    southindia         = "soin"
+    westindia          = "wein"
+    uksouth2           = "uks2"
+    uknorth            = "ukno"
+    canadacentral      = "cace"
+    canadaeast         = "caea"
+    australiaeast      = "auea"
+    australiasoutheast = "ause"
+    uksouth            = "ukso"
+    ukwest             = "ukwe"
+    koreacentral       = "koce"
+    koreasouth         = "koso"
+  }
+}
+
+locals {
+  // Sap library's environment
+  environment = upper(try(var.infrastructure.environment, ""))
+
+  // Derive resource group name for deployer
+  deployer                = try(var.deployer, {})
+  deployer_environment    = try(local.deployer.environment, "")
+  deployer_location_short = try(var.region_mapping[local.deployer.region], "unkn")
+  deployer_vnet           = try(local.deployer.vnet, "")
+  deployer_prefix         = upper(format("%s-%s-%s", local.deployer_environment, local.deployer_location_short, substr(local.deployer_vnet, 0, 7)))
+  // If custom names are used for deployer, providing resource_group_name and msi_name will override the naming convention
+  deployer_rg_name = try(local.deployer.resource_group_name, format("%s-INFRASTRUCTURE", local.deployer_prefix))
+
   deployer_key_vault_arm_id = try(data.terraform_remote_state.local_deployer.outputs.deployer_kv_user_arm_id, "")
 
   spn = {

--- a/deploy/terraform/bootstrap/sap_library/variables_local.tf
+++ b/deploy/terraform/bootstrap/sap_library/variables_local.tf
@@ -1,1 +1,8 @@
+// If the local terraform tfstate contains the arm id of deployer's KeyVault, it will be used. Otherwise, the information will be fetched from remote tfstate.
+locals {
 
+  deployer                  = try(var.deployer, "")
+  deployer_rg_name          = try(local.deployer.resource_group.name, "")
+  deployer_key_vault_arm_id = try(data.terraform_remote_state.local_deployer.outputs.deployer_kv_user_arm_id, "")
+
+}

--- a/deploy/terraform/bootstrap/sap_library/variables_local.tf
+++ b/deploy/terraform/bootstrap/sap_library/variables_local.tf
@@ -5,4 +5,11 @@ locals {
   deployer_rg_name          = try(local.deployer.resource_group.name, "")
   deployer_key_vault_arm_id = try(data.terraform_remote_state.local_deployer.outputs.deployer_kv_user_arm_id, "")
 
+  spn = {
+    subscription_id = data.azurerm_key_vault_secret.subscription_id.value,
+    client_id       = data.azurerm_key_vault_secret.client_id.value,
+    client_secret   = data.azurerm_key_vault_secret.client_secret.value,
+    tenant_id       = data.azurerm_key_vault_secret.tenant_id.value,
+  }
+
 }

--- a/deploy/terraform/bootstrap/sap_library/variables_local.tf
+++ b/deploy/terraform/bootstrap/sap_library/variables_local.tf
@@ -51,7 +51,7 @@ locals {
   deployer_rg_name = try(local.deployer.resource_group_name, format("%s-INFRASTRUCTURE", local.deployer_prefix))
 
   // Retrieve the arm_id of deployer's Key Vault from deployer's terraform.tfstate
-  deployer_key_vault_arm_id = try(data.terraform_remote_state.local_deployer.outputs.deployer_kv_user_arm_id, "")
+  deployer_key_vault_arm_id = try(data.terraform_remote_state.deployer.outputs.deployer_kv_user_arm_id, "")
 
   spn = {
     subscription_id = data.azurerm_key_vault_secret.subscription_id.value,

--- a/deploy/terraform/run/sap_deployer/output.tf
+++ b/deploy/terraform/run/sap_deployer/output.tf
@@ -41,3 +41,8 @@ output "deployer_user" {
   value = module.sap_deployer.deployer_user
 }
 */
+
+output "deployer_kv_user_arm_id" {
+  sensitive = true
+  value     = module.sap_deployer.deployer_kv_user_arm_id
+}

--- a/deploy/terraform/run/sap_deployer/output.tf
+++ b/deploy/terraform/run/sap_deployer/output.tf
@@ -46,3 +46,11 @@ output "deployer_kv_user_arm_id" {
   sensitive = true
   value     = module.sap_deployer.deployer_kv_user_arm_id
 }
+
+output "deployer_kv_prvt_name" {
+  value     = module.sap_deployer.prvt_vault_name
+}
+
+output "deployer_kv_user_name" {
+  value     = module.sap_deployer.user_vault_name
+}

--- a/deploy/terraform/run/sap_deployer/output.tf
+++ b/deploy/terraform/run/sap_deployer/output.tf
@@ -48,9 +48,25 @@ output "deployer_kv_user_arm_id" {
 }
 
 output "deployer_kv_prvt_name" {
-  value     = module.sap_deployer.prvt_vault_name
+  value = module.sap_deployer.prvt_vault_name
 }
 
 output "deployer_kv_user_name" {
-  value     = module.sap_deployer.user_vault_name
+  value = module.sap_deployer.user_vault_name
+}
+
+output "deployer_public_key_secret_name" {
+  value = module.sap_deployer.ppk_name
+}
+
+output "deployer_private_key_secret_name" {
+  value = module.sap_deployer.pk_name
+}
+
+output "deployer_rg_name" {
+  value = module.sap_deployer.deployer_rg_name
+}
+
+output "deployer_public_ip_address" {
+  value = module.sap_deployer.deployer_public_ip_address
 }

--- a/deploy/terraform/run/sap_library/imports.tf
+++ b/deploy/terraform/run/sap_library/imports.tf
@@ -10,6 +10,7 @@ data "terraform_remote_state" "remote_deployer" {
     storage_account_name = local.tfstate_storage_account_name
     container_name       = local.tfstate_container_name
     key                  = local.deployer_tfstate_key
+    use_msi              = true
   }
 }
 

--- a/deploy/terraform/run/sap_library/imports.tf
+++ b/deploy/terraform/run/sap_library/imports.tf
@@ -3,33 +3,36 @@
       Import deployer resources
 */
 
-data "terraform_remote_state" "local_deployer" {
-  backend = "local"
+data "terraform_remote_state" "remote_deployer" {
+  backend = "azurerm"
   config = {
-    path = "../../LOCAL/${local.deployer_rg_name}/terraform.tfstate"
+    resource_group_name  = local.saplib_resource_group_name
+    storage_account_name = local.tfstate_storage_account_name
+    container_name       = local.tfstate_container_name
+    key                  = local.deployer_tfstate_key
   }
 }
 
 data "azurerm_key_vault_secret" "subscription_id" {
   provider     = azurerm.deployer
-  name         = "deployer-subscription-id"
+  name         = format("%s-subscription-id", local.environment)
   key_vault_id = local.deployer_key_vault_arm_id
 }
 
 data "azurerm_key_vault_secret" "client_id" {
   provider     = azurerm.deployer
-  name         = "deployer-client-id"
+  name         = format("%s-client-id", local.environment)
   key_vault_id = local.deployer_key_vault_arm_id
 }
 
 data "azurerm_key_vault_secret" "client_secret" {
   provider     = azurerm.deployer
-  name         = "deployer-client-secret"
+  name         = format("%s-client-secret", local.environment)
   key_vault_id = local.deployer_key_vault_arm_id
 }
 
 data "azurerm_key_vault_secret" "tenant_id" {
   provider     = azurerm.deployer
-  name         = "deployer-tenant-id"
+  name         = format("%s-tenant-id", local.environment)
   key_vault_id = local.deployer_key_vault_arm_id
 }

--- a/deploy/terraform/run/sap_library/imports.tf
+++ b/deploy/terraform/run/sap_library/imports.tf
@@ -3,13 +3,14 @@
       Import deployer resources
 */
 
-data "terraform_remote_state" "remote_deployer" {
+data "terraform_remote_state" "deployer" {
   backend = "azurerm"
   config = {
     resource_group_name  = local.saplib_resource_group_name
     storage_account_name = local.tfstate_storage_account_name
     container_name       = local.tfstate_container_name
     key                  = local.deployer_tfstate_key
+    subscription_id      = var.saplibrary_subscription_id
     use_msi              = true
   }
 }

--- a/deploy/terraform/run/sap_library/module.tf
+++ b/deploy/terraform/run/sap_library/module.tf
@@ -9,4 +9,5 @@ module "sap_library" {
   storage_account_tfstate = var.storage_account_tfstate
   software                = var.software
   deployer                = var.deployer
+  spn                     = local.spn
 }

--- a/deploy/terraform/run/sap_library/module.tf
+++ b/deploy/terraform/run/sap_library/module.tf
@@ -10,4 +10,5 @@ module "sap_library" {
   software                = var.software
   deployer                = var.deployer
   spn                     = local.spn
+  deployer_tfstate        = data.terraform_remote_state.deployer
 }

--- a/deploy/terraform/run/sap_library/output.tf
+++ b/deploy/terraform/run/sap_library/output.tf
@@ -31,14 +31,22 @@ output "user_vault_name" {
   value     = module.sap_library.user_vault_name
 }
 
-output "remote_state_resource_group_name" {
-  value = module.sap_library.remote_state_resource_group_name
-}
-
 output "remote_state_storage_account_name" {
   value = module.sap_library.remote_state_storage_account_name
 }
 
 output "remote_state_container_name" {
   value = module.sap_library.remote_state_container_name
+}
+
+output "saplibrary_rg_name" {
+  value = local.rg_name
+}
+
+output "tfstate_storage_account_name" {
+  value = local.deployer.tfstate_storage_account_name
+}
+
+output "deployer_tfstate_key" {
+  value = format("%s%s", local.deployer_rg_name, ".terraform.tfstate")
 }

--- a/deploy/terraform/run/sap_library/output.tf
+++ b/deploy/terraform/run/sap_library/output.tf
@@ -46,3 +46,12 @@ output "remote_state_resource_group_name" {
 output "deployer_tfstate_key" {
   value = format("%s%s", local.deployer_rg_name, ".terraform.tfstate")
 }
+
+
+output "saplibrary_environment" {
+  value = local.environment
+}
+
+output "saplibrary_subscription_id" {
+  value = var.saplibrary_subscription_id
+}

--- a/deploy/terraform/run/sap_library/output.tf
+++ b/deploy/terraform/run/sap_library/output.tf
@@ -39,12 +39,8 @@ output "remote_state_container_name" {
   value = module.sap_library.remote_state_container_name
 }
 
-output "saplibrary_rg_name" {
-  value = local.rg_name
-}
-
-output "tfstate_storage_account_name" {
-  value = local.deployer.tfstate_storage_account_name
+output "remote_state_resource_group_name" {
+  value = module.sap_library.remote_state_resource_group_name
 }
 
 output "deployer_tfstate_key" {

--- a/deploy/terraform/run/sap_library/providers.tf
+++ b/deploy/terraform/run/sap_library/providers.tf
@@ -16,6 +16,16 @@ Description:
 provider "azurerm" {
   version = "~> 2.10"
   features {}
+  subscription_id = local.spn.subscription_id
+  client_id       = local.spn.client_id
+  client_secret   = local.spn.client_secret
+  tenant_id       = local.spn.tenant_id
+}
+
+provider "azurerm" {
+  version = "~> 2.10"
+  features {}
+  alias = "deployer"
 }
 
 terraform {

--- a/deploy/terraform/run/sap_library/saplibrary.json
+++ b/deploy/terraform/run/sap_library/saplibrary.json
@@ -1,15 +1,13 @@
 {
     "infrastructure": {
         "region": "eastus",
+        "environment": "np"
+    },
+    "deployer": {
         "environment": "np",
-        "resource_group": {
-            "is_existing": "false",
-            "arm_id": ""
-        },
-        "deployer": {
-            "environment": "np",
-            "region": "eastus",
-            "vnet": "MGMT"
-        }
-    }
+        "region": "eastus",
+        "vnet": "MGMT"
+    },
+    "tfstate_resource_group_name": "",
+    "tfstate_storage_account_name": ""
 }

--- a/deploy/terraform/run/sap_library/saplibrary.json
+++ b/deploy/terraform/run/sap_library/saplibrary.json
@@ -4,7 +4,7 @@
         "environment": "np"
     },
     "deployer": {
-        "environment": "adm",
+        "environment": "np",
         "region": "eastus",
         "vnet": "MGMT"
     },

--- a/deploy/terraform/run/sap_library/saplibrary.json
+++ b/deploy/terraform/run/sap_library/saplibrary.json
@@ -4,7 +4,7 @@
         "environment": "np"
     },
     "deployer": {
-        "environment": "np",
+        "environment": "adm",
         "region": "eastus",
         "vnet": "MGMT"
     },

--- a/deploy/terraform/run/sap_library/variables_local.tf
+++ b/deploy/terraform/run/sap_library/variables_local.tf
@@ -46,7 +46,8 @@ variable "tfstate_storage_account_name" {
 }
 
 locals {
-  // Derive resource group name for saplibrary
+  // Sap library's environment
+  environment    = upper(try(var.infrastructure.environment, ""))
   # var_infra      = try(var.infrastructure, {})
   # region         = try(local.var_infra.region, "")
   # environment    = upper(try(var.infrastructure.environment, ""))

--- a/deploy/terraform/run/sap_library/variables_local.tf
+++ b/deploy/terraform/run/sap_library/variables_local.tf
@@ -37,17 +37,25 @@ variable "region_mapping" {
   }
 }
 
+variable "tfstate_resource_group_name" {
+  description = "The name of resource group where tfstate is stored"
+}
+
+variable "tfstate_storage_account_name" {
+  description = "The name of storage account where tfstate is stored"
+}
+
 locals {
   // Derive resource group name for saplibrary
-  var_infra      = try(var.infrastructure, {})
-  region         = try(local.var_infra.region, "")
-  environment    = upper(try(var.infrastructure.environment, ""))
-  location_short = try(var.region_mapping[local.region], "unkn")
-  prefix         = upper(format("%s-%s", local.environment, local.location_short))
-  var_rg         = try(local.var_infra.resource_group, {})
-  rg_exists      = try(local.var_rg.is_existing, false)
-  rg_arm_id      = local.rg_exists ? try(local.var_rg.arm_id, "") : ""
-  rg_name        = local.rg_exists ? "" : try(local.var_rg.name, format("%s-SAP_LIBRARY", local.prefix))
+  # var_infra      = try(var.infrastructure, {})
+  # region         = try(local.var_infra.region, "")
+  # environment    = upper(try(var.infrastructure.environment, ""))
+  # location_short = try(var.region_mapping[local.region], "unkn")
+  # prefix         = upper(format("%s-%s", local.environment, local.location_short))
+  # var_rg         = try(local.var_infra.resource_group, {})
+  # rg_exists      = try(local.var_rg.is_existing, false)
+  # rg_arm_id      = local.rg_exists ? try(local.var_rg.arm_id, "") : ""
+  # rg_name        = local.rg_exists ? "" : try(local.var_rg.name, format("%s-SAP_LIBRARY", local.prefix))
 
   // Derive resource group name for deployer
   deployer                = try(var.deployer, {})
@@ -61,8 +69,8 @@ locals {
   // Retrieve the arm_id of deployer's Key Vault from deployer's terraform.tfstate
   deployer_key_vault_arm_id = try(data.terraform_remote_state.remote_deployer.outputs.deployer_kv_user_arm_id, "")
 
-  saplib_resource_group_name   = local.rg_name
-  tfstate_storage_account_name = local.deployer.tfstate_storage_account_name
+  saplib_resource_group_name   = try(var.tfstate_resource_group_name, "")
+  tfstate_storage_account_name = try(var.tfstate_storage_account_name, "")
   tfstate_container_name       = "tfstate"
   deployer_tfstate_key         = format("%s%s", local.deployer_rg_name, ".terraform.tfstate")
 

--- a/deploy/terraform/run/sap_library/variables_local.tf
+++ b/deploy/terraform/run/sap_library/variables_local.tf
@@ -62,7 +62,7 @@ locals {
   deployer_key_vault_arm_id = try(data.terraform_remote_state.remote_deployer.outputs.deployer_kv_user_arm_id, "")
 
   saplib_resource_group_name   = local.rg_name
-  tfstate_storage_account_name = try(var.tfstate_storage_account_name, "")
+  tfstate_storage_account_name = try(local.deployer.tfstate_storage_account_name, "")
   tfstate_container_name       = "tfstate"
   deployer_tfstate_key         = try(format("%s.terraform.tfstate", local.deployer.deployer_tfstate_key), "")
 

--- a/deploy/terraform/run/sap_library/variables_local.tf
+++ b/deploy/terraform/run/sap_library/variables_local.tf
@@ -58,6 +58,7 @@ locals {
   // If custom names are used for deployer, providing resource_group_name and msi_name will override the naming convention
   deployer_rg_name = try(local.deployer.resource_group_name, format("%s-INFRASTRUCTURE", local.deployer_prefix))
 
+  // Retrieve the arm_id of deployer's Key Vault from deployer's terraform.tfstate
   deployer_key_vault_arm_id = try(data.terraform_remote_state.remote_deployer.outputs.deployer_kv_user_arm_id, "")
 
   saplib_resource_group_name   = local.rg_name

--- a/deploy/terraform/run/sap_library/variables_local.tf
+++ b/deploy/terraform/run/sap_library/variables_local.tf
@@ -1,13 +1,69 @@
-// If the local terraform tfstate contains the arm id of deployer's KeyVault, it will be used. Otherwise, the information will be fetched from remote tfstate.
+// Input arguments 
+variable "region_mapping" {
+  type        = map(string)
+  description = "Region Mapping: Full = Single CHAR, 4-CHAR"
+
+  # 28 Regions 
+
+  default = {
+    westus             = "weus"
+    westus2            = "wus2"
+    centralus          = "ceus"
+    eastus             = "eaus"
+    eastus2            = "eus2"
+    northcentralus     = "ncus"
+    southcentralus     = "scus"
+    westcentralus      = "wcus"
+    northeurope        = "noeu"
+    westeurope         = "weeu"
+    eastasia           = "eaas"
+    southeastasia      = "seas"
+    brazilsouth        = "brso"
+    japaneast          = "jpea"
+    japanwest          = "jpwe"
+    centralindia       = "cein"
+    southindia         = "soin"
+    westindia          = "wein"
+    uksouth2           = "uks2"
+    uknorth            = "ukno"
+    canadacentral      = "cace"
+    canadaeast         = "caea"
+    australiaeast      = "auea"
+    australiasoutheast = "ause"
+    uksouth            = "ukso"
+    ukwest             = "ukwe"
+    koreacentral       = "koce"
+    koreasouth         = "koso"
+  }
+}
+
 locals {
-  environment                  = upper(try(var.infrastructure.environment, ""))
-  deployer                     = try(var.deployer, "")
-  deployer_rg_name             = try(local.deployer.resource_group.name, "")
-  deployer_key_vault_arm_id    = try(data.terraform_remote_state.remote_deployer.outputs.deployer_kv_user_arm_id, "")
-  saplib_resource_group_name   = try(local.deployer.saplib_resource_group_name, "")
-  tfstate_storage_account_name = try(local.deployer.tfstate_storage_account_name, "")
+  // Derive resource group name for saplibrary
+  var_infra      = try(var.infrastructure, {})
+  region         = try(local.var_infra.region, "")
+  environment    = upper(try(var.infrastructure.environment, ""))
+  location_short = try(var.region_mapping[local.region], "unkn")
+  prefix         = upper(format("%s-%s", local.environment, local.location_short))
+  var_rg         = try(local.var_infra.resource_group, {})
+  rg_exists      = try(local.var_rg.is_existing, false)
+  rg_arm_id      = local.rg_exists ? try(local.var_rg.arm_id, "") : ""
+  rg_name        = local.rg_exists ? "" : try(local.var_rg.name, format("%s-SAP_LIBRARY", local.prefix))
+
+  // Derive resource group name for deployer
+  deployer                = try(var.deployer, {})
+  deployer_environment    = try(local.deployer.environment, "")
+  deployer_location_short = try(var.region_mapping[local.deployer.region], "unkn")
+  deployer_vnet           = try(local.deployer.vnet, "")
+  deployer_prefix         = upper(format("%s-%s-%s", local.deployer_environment, local.deployer_location_short, substr(local.deployer_vnet, 0, 7)))
+  // If custom names are used for deployer, providing resource_group_name and msi_name will override the naming convention
+  deployer_rg_name = try(local.deployer.resource_group_name, format("%s-INFRASTRUCTURE", local.deployer_prefix))
+
+  deployer_key_vault_arm_id = try(data.terraform_remote_state.remote_deployer.outputs.deployer_kv_user_arm_id, "")
+
+  saplib_resource_group_name   = local.rg_name
+  tfstate_storage_account_name = try(var.tfstate_storage_account_name, "")
   tfstate_container_name       = "tfstate"
-  deployer_tfstate_key         = try(local.deployer.deployer_tfstate_key, "")
+  deployer_tfstate_key         = try(format("%s.terraform.tfstate", local.deployer.deployer_tfstate_key), "")
 
   spn = {
     subscription_id = data.azurerm_key_vault_secret.subscription_id.value,

--- a/deploy/terraform/run/sap_library/variables_local.tf
+++ b/deploy/terraform/run/sap_library/variables_local.tf
@@ -45,18 +45,17 @@ variable "tfstate_storage_account_name" {
   description = "The name of storage account where tfstate is stored"
 }
 
+variable "saplibrary_subscription_id" {
+  description = "Input $subscription_id of sap library"
+}
+/*
+variable "saplibrary_environment" {
+  description = "Fetch $environment of sap library"
+}
+*/
 locals {
   // Sap library's environment
   environment    = upper(try(var.infrastructure.environment, ""))
-  # var_infra      = try(var.infrastructure, {})
-  # region         = try(local.var_infra.region, "")
-  # environment    = upper(try(var.infrastructure.environment, ""))
-  # location_short = try(var.region_mapping[local.region], "unkn")
-  # prefix         = upper(format("%s-%s", local.environment, local.location_short))
-  # var_rg         = try(local.var_infra.resource_group, {})
-  # rg_exists      = try(local.var_rg.is_existing, false)
-  # rg_arm_id      = local.rg_exists ? try(local.var_rg.arm_id, "") : ""
-  # rg_name        = local.rg_exists ? "" : try(local.var_rg.name, format("%s-SAP_LIBRARY", local.prefix))
 
   // Derive resource group name for deployer
   deployer                = try(var.deployer, {})
@@ -68,7 +67,7 @@ locals {
   deployer_rg_name = try(local.deployer.resource_group_name, format("%s-INFRASTRUCTURE", local.deployer_prefix))
 
   // Retrieve the arm_id of deployer's Key Vault from deployer's terraform.tfstate
-  deployer_key_vault_arm_id = try(data.terraform_remote_state.remote_deployer.outputs.deployer_kv_user_arm_id, "")
+  deployer_key_vault_arm_id = try(data.terraform_remote_state.deployer.outputs.deployer_kv_user_arm_id, "")
 
   saplib_resource_group_name   = try(var.tfstate_resource_group_name, "")
   tfstate_storage_account_name = try(var.tfstate_storage_account_name, "")

--- a/deploy/terraform/run/sap_library/variables_local.tf
+++ b/deploy/terraform/run/sap_library/variables_local.tf
@@ -64,7 +64,7 @@ locals {
   saplib_resource_group_name   = local.rg_name
   tfstate_storage_account_name = try(local.deployer.tfstate_storage_account_name, "")
   tfstate_container_name       = "tfstate"
-  deployer_tfstate_key         = try(format("%s.terraform.tfstate", local.deployer.deployer_tfstate_key), "")
+  deployer_tfstate_key         = try(format("%s%s", local.deployer.deployer_rg_name, ".terraform.tfstate"), "")
 
   spn = {
     subscription_id = data.azurerm_key_vault_secret.subscription_id.value,

--- a/deploy/terraform/run/sap_library/variables_local.tf
+++ b/deploy/terraform/run/sap_library/variables_local.tf
@@ -1,0 +1,18 @@
+// If the local terraform tfstate contains the arm id of deployer's KeyVault, it will be used. Otherwise, the information will be fetched from remote tfstate.
+locals {
+  environment                  = try(var.infrastructure.environment, "")
+  deployer                     = try(var.deployer, "")
+  deployer_key_vault_arm_id    = try(data.terraform_remote_state.remote_deployer.outputs.deployer_kv_user_arm_id, "")
+  saplib_resource_group_name   = try(local.deployer.saplib_resource_group_name, "")
+  tfstate_storage_account_name = try(local.deployer.tfstate_storage_account_name, "")
+  tfstate_container_name       = "tfstate"
+  deployer_tfstate_key         = try(local.deployer.deployer_tfstate_key, "")
+
+  spn = {
+    subscription_id = data.azurerm_key_vault_secret.subscription_id.value,
+    client_id       = data.azurerm_key_vault_secret.client_id.value,
+    client_secret   = data.azurerm_key_vault_secret.client_secret.value,
+    tenant_id       = data.azurerm_key_vault_secret.tenant_id.value,
+  }
+
+}

--- a/deploy/terraform/run/sap_library/variables_local.tf
+++ b/deploy/terraform/run/sap_library/variables_local.tf
@@ -62,9 +62,9 @@ locals {
   deployer_key_vault_arm_id = try(data.terraform_remote_state.remote_deployer.outputs.deployer_kv_user_arm_id, "")
 
   saplib_resource_group_name   = local.rg_name
-  tfstate_storage_account_name = try(local.deployer.tfstate_storage_account_name, "")
+  tfstate_storage_account_name = local.deployer.tfstate_storage_account_name
   tfstate_container_name       = "tfstate"
-  deployer_tfstate_key         = try(format("%s%s", local.deployer.deployer_rg_name, ".terraform.tfstate"), "")
+  deployer_tfstate_key         = format("%s%s", local.deployer_rg_name, ".terraform.tfstate")
 
   spn = {
     subscription_id = data.azurerm_key_vault_secret.subscription_id.value,

--- a/deploy/terraform/run/sap_library/variables_local.tf
+++ b/deploy/terraform/run/sap_library/variables_local.tf
@@ -1,6 +1,6 @@
 // If the local terraform tfstate contains the arm id of deployer's KeyVault, it will be used. Otherwise, the information will be fetched from remote tfstate.
 locals {
-  environment                  = try(var.infrastructure.environment, "")
+  environment                  = upper(try(var.infrastructure.environment, ""))
   deployer                     = try(var.deployer, "")
   deployer_rg_name             = try(local.deployer.resource_group.name, "")
   deployer_key_vault_arm_id    = try(data.terraform_remote_state.remote_deployer.outputs.deployer_kv_user_arm_id, "")

--- a/deploy/terraform/run/sap_library/variables_local.tf
+++ b/deploy/terraform/run/sap_library/variables_local.tf
@@ -2,6 +2,7 @@
 locals {
   environment                  = try(var.infrastructure.environment, "")
   deployer                     = try(var.deployer, "")
+  deployer_rg_name             = try(local.deployer.resource_group.name, "")
   deployer_key_vault_arm_id    = try(data.terraform_remote_state.remote_deployer.outputs.deployer_kv_user_arm_id, "")
   saplib_resource_group_name   = try(local.deployer.saplib_resource_group_name, "")
   tfstate_storage_account_name = try(local.deployer.tfstate_storage_account_name, "")

--- a/deploy/terraform/terraform-units/modules/sap_deployer/output.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/output.tf
@@ -62,3 +62,7 @@ output "deployer_user" {
   value = local.deployer_users_id_list
 }
 */
+
+output "deployer_kv_user_arm_id" {
+  value = local.enable_deployers? azurerm_key_vault.kv_user[0].id : ""
+}

--- a/deploy/terraform/terraform-units/modules/sap_deployer/output.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/output.tf
@@ -6,7 +6,7 @@ Description:
 
 // Deployer resource group name
 output "deployer_rg_name" {
-  value = azurerm_resource_group.deployer[0].name
+  value = local.enable_deployers ? azurerm_resource_group.deployer[0].name : ""
 }
 
 // Unique ID for deployer
@@ -52,8 +52,14 @@ output "prvt_vault_name" {
   value = azurerm_key_vault.kv_prvt[0].name
 }
 
+// output the secret name of public key
 output "ppk_name" {
   value = local.enable_deployers && local.enable_key ? azurerm_key_vault_secret.ppk[0].name : ""
+}
+
+// output the secret name of private key
+output "pk_name" {
+  value = local.enable_deployers && local.enable_key ? azurerm_key_vault_secret.pk[0].name : ""
 }
 
 output "pwd_name" {
@@ -68,5 +74,9 @@ output "deployer_user" {
 */
 
 output "deployer_kv_user_arm_id" {
-  value = local.enable_deployers? azurerm_key_vault.kv_user[0].id : ""
+  value = local.enable_deployers ? azurerm_key_vault.kv_user[0].id : ""
+}
+
+output "deployer_public_ip_address" {
+  value = local.enable_deployers ? local.deployer_public_ip_address_list : []
 }

--- a/deploy/terraform/terraform-units/modules/sap_deployer/output.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/output.tf
@@ -48,6 +48,10 @@ output "user_vault_name" {
   value = azurerm_key_vault.kv_user[0].name
 }
 
+output "prvt_vault_name" {
+  value = azurerm_key_vault.kv_prvt[0].name
+}
+
 output "ppk_name" {
   value = local.enable_deployers && local.enable_key ? azurerm_key_vault_secret.ppk[0].name : ""
 }

--- a/deploy/terraform/terraform-units/modules/sap_deployer/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/variables_local.tf
@@ -163,6 +163,12 @@ locals {
     ])
   )
 
+  // public ip address list of deployers
+  deployer_public_ip_address_list = distinct(flatten([
+    for pip_deployer in azurerm_public_ip.deployer :
+    pip_deployer.ip_address
+  ]))
+
   // Comment out code with users.object_id for the time being.
   // deployer_users_id_list = distinct(compact(concat(local.deployer_users_id)))
 }

--- a/deploy/terraform/terraform-units/modules/sap_library/key_vault.tf
+++ b/deploy/terraform/terraform-units/modules/sap_library/key_vault.tf
@@ -3,30 +3,30 @@
   Set up key vault for sap library 
 */
 
-data "azurerm_client_config" "deployer" {}
+# data "azurerm_client_config" "deployer" {}
 
-data "azurerm_user_assigned_identity" "deployer" {
-  name                = local.deployer_msi_name
-  resource_group_name = local.deployer_rg_name
-}
+# data "azurerm_user_assigned_identity" "deployer" {
+#   name                = local.deployer_msi_name
+#   resource_group_name = local.deployer_rg_name
+# }
 
 // Create private KV with access policy
 resource "azurerm_key_vault" "kv_prvt" {
   name                       = local.kv_private_name
   location                   = local.region
   resource_group_name        = local.rg_exists ? data.azurerm_resource_group.library[0].name : local.rg_name
-  tenant_id                  = data.azurerm_client_config.deployer.tenant_id
+  tenant_id = local.spn.tenant_id
   soft_delete_enabled        = true
   soft_delete_retention_days = 7
   purge_protection_enabled   = true
   sku_name                   = "standard"
 }
 
-resource "azurerm_key_vault_access_policy" "kv_prvt_msi" {
+resource "azurerm_key_vault_access_policy" "kv_prvt_spn" {
   key_vault_id = azurerm_key_vault.kv_prvt.id
 
-  tenant_id = data.azurerm_client_config.deployer.tenant_id
-  object_id = data.azurerm_user_assigned_identity.deployer.principal_id
+  tenant_id = local.spn.tenant_id
+  object_id = local.spn.client_id
 
   secret_permissions = [
     "get",
@@ -38,7 +38,7 @@ resource "azurerm_key_vault" "kv_user" {
   name                       = local.kv_user_name
   location                   = local.region
   resource_group_name        = local.rg_exists ? data.azurerm_resource_group.library[0].name : local.rg_name
-  tenant_id                  = data.azurerm_client_config.deployer.tenant_id
+  tenant_id = local.spn.tenant_id
   soft_delete_enabled        = true
   soft_delete_retention_days = 7
   purge_protection_enabled   = true
@@ -46,10 +46,10 @@ resource "azurerm_key_vault" "kv_user" {
   sku_name = "standard"
 }
 
-resource "azurerm_key_vault_access_policy" "kv_user_msi" {
+resource "azurerm_key_vault_access_policy" "kv_user_spn" {
   key_vault_id = azurerm_key_vault.kv_user.id
-  tenant_id    = data.azurerm_client_config.deployer.tenant_id
-  object_id    = data.azurerm_user_assigned_identity.deployer.principal_id
+  tenant_id = local.spn.tenant_id
+  object_id = local.spn.client_id
 
   secret_permissions = [
     "delete",

--- a/deploy/terraform/terraform-units/modules/sap_library/key_vault.tf
+++ b/deploy/terraform/terraform-units/modules/sap_library/key_vault.tf
@@ -3,19 +3,12 @@
   Set up key vault for sap library 
 */
 
-# data "azurerm_client_config" "deployer" {}
-
-# data "azurerm_user_assigned_identity" "deployer" {
-#   name                = local.deployer_msi_name
-#   resource_group_name = local.deployer_rg_name
-# }
-
 // Create private KV with access policy
 resource "azurerm_key_vault" "kv_prvt" {
   name                       = local.kv_private_name
   location                   = local.region
   resource_group_name        = local.rg_exists ? data.azurerm_resource_group.library[0].name : local.rg_name
-  tenant_id = local.spn.tenant_id
+  tenant_id                  = local.spn.tenant_id
   soft_delete_enabled        = true
   soft_delete_retention_days = 7
   purge_protection_enabled   = true
@@ -38,7 +31,7 @@ resource "azurerm_key_vault" "kv_user" {
   name                       = local.kv_user_name
   location                   = local.region
   resource_group_name        = local.rg_exists ? data.azurerm_resource_group.library[0].name : local.rg_name
-  tenant_id = local.spn.tenant_id
+  tenant_id                  = local.spn.tenant_id
   soft_delete_enabled        = true
   soft_delete_retention_days = 7
   purge_protection_enabled   = true
@@ -48,8 +41,8 @@ resource "azurerm_key_vault" "kv_user" {
 
 resource "azurerm_key_vault_access_policy" "kv_user_spn" {
   key_vault_id = azurerm_key_vault.kv_user.id
-  tenant_id = local.spn.tenant_id
-  object_id = local.spn.client_id
+  tenant_id    = local.spn.tenant_id
+  object_id    = local.spn.client_id
 
   secret_permissions = [
     "delete",

--- a/deploy/terraform/terraform-units/modules/sap_library/storage_accounts.tf
+++ b/deploy/terraform/terraform-units/modules/sap_library/storage_accounts.tf
@@ -86,6 +86,18 @@ resource "azurerm_storage_share" "fileshare_sapbits" {
   storage_account_name = local.sa_sapbits_exists ? data.azurerm_storage_account.storage_sapbits[0].name : azurerm_storage_account.storage_sapbits[0].name
 }
 
+/* 
+TBD: two options
+1. deployer msi has contributor role(or less powerful role: Storage Account Contributor) to all the subscriptions it manages
+2. when deploying storage accounts, deployer msi will be assgined a role as Storage Account Contributor, so it can move the terraform.tfstate from local to the storage account.
+*/
+// Assign contributor role to deployer's msi to access tfstate storage account
+resource "azurerm_role_assignment" "deployer_msi_sa_tfstate" {
+  scope              = local.sa_sapbits_exists ? data.azurerm_storage_account.storage_tfstate[0].id : azurerm_storage_account.storage_tfstate[0].id
+  role_definition_name = "Storage Account Contributor" 
+  principal_id       = local.deployer_msi_principal_id
+}
+
 // Generates random text for storage account name
 resource "random_id" "post_fix" {
   keepers = {

--- a/deploy/terraform/terraform-units/modules/sap_library/variables_global.tf
+++ b/deploy/terraform/terraform-units/modules/sap_library/variables_global.tf
@@ -3,3 +3,4 @@ variable "storage_account_sapbits" {}
 variable "storage_account_tfstate" {}
 variable "software" {}
 variable "deployer" {}
+variable "spn" {}

--- a/deploy/terraform/terraform-units/modules/sap_library/variables_global.tf
+++ b/deploy/terraform/terraform-units/modules/sap_library/variables_global.tf
@@ -3,4 +3,3 @@ variable "storage_account_sapbits" {}
 variable "storage_account_tfstate" {}
 variable "software" {}
 variable "deployer" {}
-variable "spn" {}

--- a/deploy/terraform/terraform-units/modules/sap_library/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_library/variables_local.tf
@@ -113,11 +113,6 @@ locals {
   kv_prefix       = upper(format("%s%s", substr(local.environment, 0, 5), local.location_short))
   kv_private_name = format("%sSAPLIBprvt%s", local.kv_prefix, local.postfix)
   kv_user_name    = format("%sSAPLIBuser%s", local.kv_prefix, local.postfix)
-  // credential for sap downloader
-  secret_downloader_username_name = format("%s-downloader-username", local.kv_prefix)
-  secret_downloader_password_name = format("%s-downloader-password", local.kv_prefix)
-  downloader_username             = try(var.software.downloader.credentials.sap_user, "sap_smp_user")
-  downloader_password             = try(var.software.downloader.credentials.sap_password, "sap_smp_password")
 
 }
 

--- a/deploy/terraform/terraform-units/modules/sap_library/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_library/variables_local.tf
@@ -43,6 +43,10 @@ variable "region_mapping" {
   }
 }
 
+variable "deployer_tfstate" {
+  description = "terraform.tfstate of deployer"
+}
+
 locals {
 
   // Post fix for all deployed resources
@@ -103,9 +107,7 @@ locals {
   deployer_location_short = try(var.region_mapping[local.deployer.region], "unkn")
   deployer_vnet           = try(local.deployer.vnet, "")
   deployer_prefix         = upper(format("%s-%s-%s", local.deployer_environment, local.deployer_location_short, substr(local.deployer_vnet, 0, 7)))
-  // If custom names are used for deployer, provide resource_group_name and msi_name will override the naming convention
-  # deployer_rg_name  = try(local.deployer.resource_group_name, format("%s-INFRASTRUCTURE", local.deployer_prefix))
-  # deployer_msi_name = try(local.deployer.msi_name, format("%s-msi", local.deployer_prefix))
+
   // Comment out code with users.object_id for the time being.
   // deployer_users_id = try(local.deployer.users.object_id, [])
 
@@ -115,7 +117,11 @@ locals {
   kv_user_name    = format("%sSAPLIBuser%s", local.kv_prefix, local.postfix)
 
   // spn
-  spn = try(var.spn, {})  
+  spn = try(var.spn, {})
+
+  // deployer terraform.tfstate
+  deployer_tfstate          = var.deployer_tfstate
+  deployer_msi_principal_id = local.deployer_tfstate.outputs.deployer_uai.principal_id
 
 }
 

--- a/deploy/terraform/terraform-units/modules/sap_library/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_library/variables_local.tf
@@ -104,8 +104,8 @@ locals {
   deployer_vnet           = try(local.deployer.vnet, "")
   deployer_prefix         = upper(format("%s-%s-%s", local.deployer_environment, local.deployer_location_short, substr(local.deployer_vnet, 0, 7)))
   // If custom names are used for deployer, provide resource_group_name and msi_name will override the naming convention
-  deployer_rg_name  = try(local.deployer.resource_group_name, format("%s-INFRASTRUCTURE", local.deployer_prefix))
-  deployer_msi_name = try(local.deployer.msi_name, format("%s-msi", local.deployer_prefix))
+  # deployer_rg_name  = try(local.deployer.resource_group_name, format("%s-INFRASTRUCTURE", local.deployer_prefix))
+  # deployer_msi_name = try(local.deployer.msi_name, format("%s-msi", local.deployer_prefix))
   // Comment out code with users.object_id for the time being.
   // deployer_users_id = try(local.deployer.users.object_id, [])
 
@@ -113,6 +113,9 @@ locals {
   kv_prefix       = upper(format("%s%s", substr(local.environment, 0, 5), local.location_short))
   kv_private_name = format("%sSAPLIBprvt%s", local.kv_prefix, local.postfix)
   kv_user_name    = format("%sSAPLIBuser%s", local.kv_prefix, local.postfix)
+
+  // spn
+  spn = try(var.spn, {})  
 
 }
 


### PR DESCRIPTION
## Problem
<Please describe what problem this PR is trying to resolve>
The SPN needs to be retrieved from deployer's KV and used when deploying resources in sap_library.
#825 is closed. Use this PR for review.

## Solution
<Please elaborate the solution for the problem>
Use multi providers. First provider will be used to retrieve secrets. Second(default) provider will be used to deploy resources.

The deployer_msi should be assigned a contributor role to have access to the tfstate storage account. Otherwise, there will be a following error:
![image](https://user-images.githubusercontent.com/62584551/95926456-336a4480-0d71-11eb-8f2f-d53116f6031b.png)

Also, when trying to reinitialize, the subscription_id should be included in the command. Because currently multi-subscription is involved, deployer needs to know which subscription users are trying to deploy to.
Otherwise, there will be a following error:
![image](https://user-images.githubusercontent.com/62584551/95926852-24d05d00-0d72-11eb-9c44-e6bf509566fc.png)



## Tests
<Please provide steps to test the PR>
Fetch and checkout to yunzzha_spn branch

1. Bootstrap deployer
```
{
  "infrastructure": {
    "region": "eastus",
    "environment": "np",
    "vnets": {
      "management": {
        "name": "MGMT",
        "address_space": "10.0.0.0/26",
        "subnet_mgmt": {
          "prefix": "10.0.0.16/28"
        }
      }
    }
  },
  "options": {
    "enable_secure_transfer": true
  }
}

```
terraform init ../../../sap-hana/deploy/terraform/bootstrap/sap_deployer/
terraform plan -var-file=NP-EAUS-MGMT-INFRASTRUCTURE.json ../../../sap-hana/deploy/terraform/bootstrap/sap_deployer/
terraform apply -var-file=NP-EAUS-MGMT-INFRASTRUCTURE.json ../../../sap-hana/deploy/terraform/bootstrap/sap_deployer/

2. 

Fetch the ssh key, and log on to the deployer.
On deployer, fetch and checkout to yunzzha_spn branch. 

Manually run the following commands to create SPN and assign Contributor role and User Access Administrator role to the SPN
`az ad sp create-for-rbac --role="Contributor" --scopes="/subscriptions/XXXX" --name="DeploymentAccount-NP"`
`az role assignment create --assignee <APP_ID> --role "User Access Administrator"`

Note: To support multi-subscription, each SPN should have Contributor role on its environment's corresponding subscription. 
The deployer is using MSI and the subscription of current session is set as the subscription of deployer by default. The deployer's msi is allowed to create a Service Principal only **within deployer's subscription**. If the user wants to create Service Principle with a scope covering other subscriptions, please use other methods, eg: Azure Portal, "az login"... etc. to switch to a user who has the authorization over those subscriptions, then create the Service Principle. 

Result:
{
"appId": "00000000-0000-0000-0000-000000000000",
"displayName": "azure-cli-2017-06-05-10-41-15",
"name": "http://azure-cli-2017-06-05-10-41-15",
"password": "0000-0000-0000-0000-000000000000",
"tenant": "00000000-0000-0000-0000-000000000000"
}

appId is the client_id below.
password is the client_secret below.
tenant is the tenant_id below.

Then manually or run the following commands to store SPN into the deployer's KV.
Note: 
**Make sure the subscription of current session is the subscription of deployer** before running the following commands. 
Follow the naming convention: {environment}-subscription-id ...

az keyvault secret set --name "NP-subscription-id" --vault-name "NPEAUSMGMTuser86E" --value "";
az keyvault secret set --name "NP-client-id" --vault-name "NPEAUSMGMTuser86E" --value "";
az keyvault secret set --name "NP-client-secret" --vault-name "NPEAUSMGMTuser86E" --value "";
az keyvault secret set --name "NP-tenant-id" --vault-name "NPEAUSMGMTuser86E" --value "";

![image](https://user-images.githubusercontent.com/62584551/95617862-f294c780-0a20-11eb-8a41-2a5c6c3bfeb2.png)

Then bootstrap sap_library.
An example of input json for multi-subscription, with minimum set of parameters:
```
{
    "infrastructure": {
        "region": "eastus",
        "environment": "test"
    },
    "deployer": {
        "environment": "np",
        "region": "eastus",
        "vnet": "MGMT"
    }
}
```
An example of input json for single-subscription, with minimum set of parameters:
```
{
    "infrastructure": {
        "region": "eastus",
        "environment": "np"
    },
    "deployer": {
        "environment": "np",
        "region": "eastus",
        "vnet": "MGMT"
    }
}
```

Run the following commands based on your needs.
terraform init ../../../sap-hana/deploy/terraform/bootstrap/sap_library/
terraform plan -var-file=TEST-EAUS-SAP_LIBRARY.json ../../../sap-hana/deploy/terraform/bootstrap/sap_library/
terraform apply -var-file=TEST-EAUS-SAP_LIBRARY.json ../../../sap-hana/deploy/terraform/bootstrap/sap_library/

3. Run the following commands to reinitialize sap_deployer
Note: 
In multi-subscription scenario, the subscription of deployer is different from subscription of saplibrary, thus, subscription_id of sap library should be specified in the command, otherwise tfstate storage account can not be located.
In single-subscription scenario, the subscription id doesn't need to be specified in the terraform init command.

terraform init --force-copy **--backend-config "subscription_id=91a338db-aa0d-4a34-aed0-dbbbc698de30"** --backend-config "resource_group_name=TEST-EAUS-SAP_LIBRARY" --backend-config "storage_account_name=testeaustfstatef80a" --backend-config "container_name=tfstate" --backend-config "key=NP-EAUS-MGMT-INFRASTRUCTURE.terraform.tfstate" ../../../sap-hana/deploy/terraform/run/sap_deployer/

terraform plan -var-file=NP-EAUS-MGMT-INFRASTRUCTURE.json ../../../sap-hana/deploy/terraform/run/sap_deployer/

terraform apply -var-file=NP-EAUS-MGMT-INFRASTRUCTURE.json ../../../sap-hana/deploy/terraform/run/sap_deployer/


4. Manually add the following fields into input json of sap_library
"tfstate_resource_group_name": "",
"tfstate_storage_account_name": ""

Note: if these two variables are not specified in the input json, they will be asked again when running the following terraform plan/run commands.

Then use the following commands to reinitialize sap_library.
Note: 
In multi-subscription scenario, the subscription of deployer is different from subscription of saplibrary, thus subscription_id of sap library needs to be specified in the command, otherwise tfstate storage account can not be located.
In single-subscription scenario, the subscription id doesn't need to be specified in the terraform init command.

terraform init --force-copy \
**--backend-config "subscription_id=91a338db-aa0d-4a34-aed0-dbbbc698de30"** \
--backend-config "resource_group_name=TEST-EAUS-SAP_LIBRARY" \
--backend-config "storage_account_name=testeaustfstatef80a" \
--backend-config "container_name=tfstate" \
--backend-config "key=TEST-EAUS-SAP_LIBRARY.terraform.tfstate" \
../../../sap-hana/deploy/terraform/run/sap_library/

terraform plan -var-file=TEST-EAUS-SAP_LIBRARY.json ../../../sap-hana/deploy/terraform/run/sap_library/

![image](https://user-images.githubusercontent.com/62584551/96179123-3dad4f80-0ee5-11eb-86f7-e11629f1286c.png)
Input the subscription id of sap library.

terraform apply -var-file=TEST-EAUS-SAP_LIBRARY.json ../../../sap-hana/deploy/terraform/run/sap_library/
Input the subscription id of sap library.

## Notes
<Additional comments for the PR>

1. This pr also removes downloader passwords related logic.

2. Some useful az cli commands:
https://docs.microsoft.com/en-us/cli/azure/role/assignment?view=azure-cli-latest#az_role_assignment_create
az role assignment create --assignee "XXXX" --role "Contributor" --scope "/subscriptions/xxx"
az ad sp create-for-rbac --role "Contributor" --scopes /subscriptions/XXXX subscriptions/YYYY --name "DeploymentAccount"

3. When using az cli command to generate service principal on subscriptions, make sure the user have a proper role on these subscriptions.