### PR TITLE
Correct saplibrary variables when conditional expression is used

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_library/output.tf
+++ b/deploy/terraform/terraform-units/modules/sap_library/output.tf
@@ -1,13 +1,13 @@
 output "tfstate_storage_account" {
-  value = local.sa_tfstate
+  value = local.sa_tfstate_name
 }
 
 output "sapbits_storage_account" {
-  value = local.sa_sapbits
+  value = local.sa_sapbits_name
 }
 
 output "storagecontainer_tfstate" {
-  value = local.storagecontainer_tfstate
+  value = local.sa_tfstate_container_name
 }
 
 output "storagecontainer_sapbits" {

--- a/deploy/terraform/terraform-units/modules/sap_library/storage_accounts.tf
+++ b/deploy/terraform/terraform-units/modules/sap_library/storage_accounts.tf
@@ -14,8 +14,8 @@ data "azurerm_storage_account" "storage_tfstate" {
 resource "azurerm_storage_account" "storage_tfstate" {
   count                     = local.sa_tfstate_exists ? 0 : 1
   name                      = local.sa_tfstate_name
-  resource_group_name       = local.rg_library.name
-  location                  = local.rg_library.location
+  resource_group_name       = local.rg_name
+  location                  = local.rg_library_location
   account_replication_type  = local.sa_tfstate_account_replication_type
   account_tier              = local.sa_tfstate_account_tier
   account_kind              = local.sa_tfstate_account_kind
@@ -31,14 +31,14 @@ resource "azurerm_storage_account" "storage_tfstate" {
 data "azurerm_storage_container" "storagecontainer_tfstate" {
   count                = local.sa_tfstate_container_exists ? 1 : 0
   name                 = local.sa_tfstate_container_name
-  storage_account_name = local.sa_tfstate.name
+  storage_account_name = local.sa_tfstate_name
 }
 
 // Creates the storage container inside the storage account for sapsystem
 resource "azurerm_storage_container" "storagecontainer_tfstate" {
   count                 = local.sa_tfstate_container_exists ? 0 : 1
   name                  = local.sa_tfstate_container_name
-  storage_account_name  = local.sa_tfstate.name
+  storage_account_name  = local.sa_tfstate_name
   container_access_type = local.sa_tfstate_container_access_type
 }
 
@@ -53,8 +53,8 @@ data "azurerm_storage_account" "storage_sapbits" {
 resource "azurerm_storage_account" "storage_sapbits" {
   count                     = local.sa_sapbits_exists ? 0 : 1
   name                      = local.sa_sapbits_name
-  resource_group_name       = local.rg_library.name
-  location                  = local.rg_library.location
+  resource_group_name       = local.rg_name
+  location                  = local.rg_library_location
   account_replication_type  = local.sa_sapbits_account_replication_type
   account_tier              = local.sa_sapbits_account_tier
   account_kind              = local.sa_sapbits_account_kind
@@ -68,14 +68,14 @@ resource "azurerm_storage_account" "storage_sapbits" {
 data "azurerm_storage_container" "storagecontainer_sapbits" {
   count                = (local.sa_sapbits_blob_container_enable && local.sa_sapbits_blob_container_exists) ? 1 : 0
   name                 = local.sa_sapbits_blob_container_name
-  storage_account_name = local.sa_sapbits.name
+  storage_account_name = local.sa_sapbits_name
 }
 
 // Creates the storage container inside the storage account for SAP bits
 resource "azurerm_storage_container" "storagecontainer_sapbits" {
   count                 = (local.sa_sapbits_blob_container_enable && ! local.sa_sapbits_blob_container_exists) ? 1 : 0
   name                  = local.sa_sapbits_blob_container_name
-  storage_account_name  = local.sa_sapbits.name
+  storage_account_name  = local.sa_sapbits_name
   container_access_type = local.sa_sapbits_container_access_type
 }
 
@@ -83,7 +83,7 @@ resource "azurerm_storage_container" "storagecontainer_sapbits" {
 resource "azurerm_storage_share" "fileshare_sapbits" {
   count                = (local.sa_sapbits_file_share_enable && ! local.sa_sapbits_file_share_exists) ? 1 : 0
   name                 = local.sa_sapbits_file_share_name
-  storage_account_name = local.sa_sapbits.name
+  storage_account_name = local.sa_sapbits_name
 }
 
 // Generates random text for storage account name

--- a/deploy/terraform/terraform-units/modules/sap_library/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_library/variables_local.tf
@@ -52,11 +52,11 @@ locals {
   var_rg    = try(local.var_infra.resource_group, {})
   rg_exists = try(local.var_rg.is_existing, false)
   rg_arm_id = local.rg_exists ? try(local.var_rg.arm_id, "") : ""
-  rg_name   = local.rg_exists ? "" : try(local.var_rg.name, format("%s-SAP_LIBRARY", local.prefix))
+  rg_name   = local.rg_exists ? split("/", local.rg_arm_id)[4] : try(local.var_rg.name, format("%s-SAP_LIBRARY", local.prefix))
 
   // Storage account for sapbits
   sa_sapbits_exists                   = try(var.storage_account_sapbits.is_existing, false)
-  sa_sapbits_name                     = lower(format("%s%ssaplib%s", substr(local.environment, 0, 5), local.location_short, substr(random_id.post_fix.hex, 0, 4)))
+  sa_sapbits_name                     = local.sa_sapbits_exists ? split("/", local.sa_sapbits_arm_id)[8] : lower(format("%s%ssaplib%s", substr(local.environment, 0, 5), local.location_short, substr(random_id.post_fix.hex, 0, 4)))
   sa_sapbits_account_tier             = local.sa_sapbits_exists ? "" : try(var.storage_account_sapbits.account_tier, "Standard")
   sa_sapbits_account_replication_type = local.sa_sapbits_exists ? "" : try(var.storage_account_sapbits.account_replication_type, "LRS")
   sa_sapbits_account_kind             = local.sa_sapbits_exists ? "" : try(var.storage_account_sapbits.account_kind, "StorageV2")
@@ -74,27 +74,23 @@ locals {
   sa_sapbits_blob_container_name   = try(var.storage_account_sapbits.sapbits_blob_container.name, "sapbits")
   sa_sapbits_container_access_type = "private"
 
-  // Storage account for saplandscape, sapsystem, deployer, saplibrary
+  // Storage account for tfstate
   sa_tfstate_exists                   = try(var.storage_account_tfstate.is_existing, false)
-  sa_tfstate_account_tier             = local.sa_sapbits_exists ? "" : try(var.storage_account_tfstate.account_tier, "Standard")
-  sa_tfstate_account_replication_type = local.sa_sapbits_exists ? "" : try(var.storage_account_tfstate.account_replication_type, "LRS")
-  sa_tfstate_account_kind             = local.sa_sapbits_exists ? "" : try(var.storage_account_tfstate.account_kind, "StorageV2")
+  sa_tfstate_account_tier             = local.sa_tfstate_exists ? "" : try(var.storage_account_tfstate.account_tier, "Standard")
+  sa_tfstate_account_replication_type = local.sa_tfstate_exists ? "" : try(var.storage_account_tfstate.account_replication_type, "LRS")
+  sa_tfstate_account_kind             = local.sa_tfstate_exists ? "" : try(var.storage_account_tfstate.account_kind, "StorageV2")
   sa_tfstate_container_access_type    = "private"
-  sa_tfstate_name                     = lower(format("%s%stfstate%s", substr(local.environment, 0, 5), local.location_short, substr(random_id.post_fix.hex, 0, 4)))
-  sa_tfstate_arm_id                   = local.sa_sapbits_exists ? try(var.storage_account_tfstate.arm_id, "") : ""
+  sa_tfstate_name                     = local.sa_tfstate_exists ? split("/", local.sa_tfstate_arm_id)[8] : lower(format("%s%stfstate%s", substr(local.environment, 0, 5), local.location_short, substr(random_id.post_fix.hex, 0, 4)))
+  sa_tfstate_arm_id                   = local.sa_tfstate_exists ? try(var.storage_account_tfstate.arm_id, "") : ""
   sa_tfstate_enable_secure_transfer   = true
   sa_tfstate_delete_retention_policy  = 7
 
-  sa_tfstate_container_exists = try(var.storage_account_tfstate.saplibrary_blob_container.is_existing, false)
-  sa_tfstate_container_name   = "tfstate"
+  sa_tfstate_container_exists = try(var.storage_account_tfstate.tfstate_blob_container.is_existing, false)
+  sa_tfstate_container_name   = try(var.storage_account_sapbits.tfstate_blob_container.name, "tfstate")
 }
 
-// Output objects 
 locals {
-  rg_library               = local.rg_exists ? data.azurerm_resource_group.library[0] : azurerm_resource_group.library[0]
-  sa_tfstate               = local.sa_tfstate_exists ? data.azurerm_storage_account.storage_tfstate[0] : azurerm_storage_account.storage_tfstate[0]
-  sa_sapbits               = local.sa_sapbits_exists ? data.azurerm_storage_account.storage_sapbits[0] : azurerm_storage_account.storage_sapbits[0]
-  storagecontainer_tfstate = local.sa_tfstate_container_exists ? data.azurerm_storage_container.storagecontainer_tfstate[0] : azurerm_storage_container.storagecontainer_tfstate[0]
-  storagecontainer_sapbits = ! local.sa_sapbits_blob_container_enable ? null : (local.sa_sapbits_blob_container_exists ? data.azurerm_storage_container.storagecontainer_sapbits[0] : azurerm_storage_container.storagecontainer_sapbits[0])
+  rg_library_location      = local.rg_exists ? data.azurerm_resource_group.library[0].location : azurerm_resource_group.library[0].location
+  storagecontainer_sapbits = ! local.sa_sapbits_blob_container_enable ? null : local.sa_sapbits_blob_container_name
   fileshare_sapbits_name   = local.sa_sapbits_file_share_enable ? local.sa_sapbits_file_share_name : null
 }


### PR DESCRIPTION
## Problem
<Please describe what problem this PR is trying to resolve>
1. There's error when using existing storage accounts.

```
{
    "infrastructure": {
        "region": "eastus",
        "environment": "np",
        "resource_group":{
            "is_existing": "true",
            "arm_id": "/subscriptions/xx/resourceGroups/UNIT-EAUS-SAP_LIBRARY"
        }
    },
"storage_account_sapbits": {
            "is_existing": true,
                "arm_id": "/subscriptions/xx/resourceGroups/NP-EAUS-SAP_LIBRARY/providers/Microsoft.Storage/storageAccounts/npeaussaplib2b33",
                    "file_share": { "is_existing": true },
                        "sapbits_blob_container": {
                                      "is_existing": true
                                          }
                                            },
                                              "storage_account_tfstate": {
                                                          "is_existing": true,
                                                              "arm_id": "/subscriptions/xx/resourceGroups/NP-EAUS-SAP_LIBRARY/providers/Microsoft.Storage/storageAccounts/npeaustfstate2b33",
                                                                  "saplibrary_blob_container": {
                                                                                "is_existing": true
                                                                                    }
                                                                                      }
}

```

![image](https://user-images.githubusercontent.com/62584551/95627150-84f09780-0a30-11eb-9b27-b615a3edea8d.png)


## Solution
<Please elaborate the solution for the problem>
1. Root cause:
A data source is a special type of resource, which is not necessarily same as the corresponding resource type.

https://github.com/hashicorp/terraform/issues/22450

"While it is true that Terraform only evaluates the value on the chosen side of the conditional, Terraform does still require both sides to be convertible to some common type so that Terraform can know what the result type will be even if it doesn't yet know which of the expressions will be selected. "

Thus, in this pr, the type in conditional expression is updated to be primitive type -- String, instead of object.



## Tests
<Please provide steps to test the PR>

## Notes
<Additional comments for the PR>


"saplibrary_blob_container" in input json is changed to "tfstate_blob_container" for consistent reason