### PR TITLE
Remove user object_id completely from sap_system

### DIFF
--- a/.pipeline/tf-release.yml
+++ b/.pipeline/tf-release.yml
@@ -64,6 +64,9 @@ stages:
       - template: templates/util/collect-deployer-info.yml
         parameters:
           deployer_env: "UNIT"
+      - template: templates/util/add-agent-to-deployer-nsg.yml
+        parameters:
+          deployer_env: "UNIT"
       - template: templates/deployer/post-deployer-steps.yml
         parameters:
           deployer_env: "UNIT"

--- a/deploy/terraform/run/sap_system/module.tf
+++ b/deploy/terraform/run/sap_system/module.tf
@@ -43,7 +43,8 @@ module "common_infrastructure" {
   subnet-mgmt         = module.deployer.subnet-mgmt
   nsg-mgmt            = module.deployer.nsg-mgmt
   deployer-uai        = module.deployer.deployer-uai
-  deployer_user       = module.deployer.deployer_user
+  // Comment out code with users.object_id for the time being.
+  // deployer_user       = module.deployer.deployer_user
 }
 
 // Create Jumpboxes
@@ -88,7 +89,8 @@ module "hdb_node" {
   sid_kv_user      = module.common_infrastructure.sid_kv_user
   sid_kv_user_msi  = module.common_infrastructure.sid_kv_user_msi
   deployer-uai     = module.deployer.deployer-uai
-  deployer_user    = module.deployer.deployer_user
+  // Comment out code with users.object_id for the time being.
+  // deployer_user    = module.deployer.deployer_user
 }
 
 // Create Application Tier nodes
@@ -111,7 +113,8 @@ module "app_tier" {
   sid_kv_user      = module.common_infrastructure.sid_kv_user
   sid_kv_user_msi  = module.common_infrastructure.sid_kv_user_msi
   deployer-uai     = module.deployer.deployer-uai
-  deployer_user    = module.deployer.deployer_user
+  // Comment out code with users.object_id for the time being.  
+  // deployer_user    = module.deployer.deployer_user
 }
 
 // Create anydb database nodes

--- a/deploy/terraform/terraform-units/modules/sap_system/deployer/output.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/deployer/output.tf
@@ -18,6 +18,9 @@ output "deployer-uai" {
   value = data.azurerm_user_assigned_identity.deployer
 }
 
+// Comment out code with users.object_id for the time being.
+/*
 output "deployer_user" {
   value = data.terraform_remote_state.deployer.outputs.deployer_user
 }
+*/


### PR DESCRIPTION
## Problem
User object_id was commented out in PR #817 . However it is not cleared up in sap_system.

## Solution
1. Comment out related code to user object_id in sap_system.
1. Add missing step in release pipeline to temporarily add pip to NSG.

## Tests
Integration test: https://dev.azure.com/azuresaphana/Azure-SAP-HANA/_build/results?buildId=12031&view=results
Release pipeline: https://dev.azure.com/azuresaphana/Azure-SAP-HANA/_build/results?buildId=12030&view=results

## Notes
<Additional comments for the PR>