### PR TITLE
Comment out users' object_id functionality in saplibrary saplandscape sapsystem

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_library/key_vault.tf
+++ b/deploy/terraform/terraform-units/modules/sap_library/key_vault.tf
@@ -59,6 +59,7 @@ resource "azurerm_key_vault_access_policy" "kv_user_msi" {
   ]
 }
 
+/* Comment out code with users.object_id for the time being
 resource "azurerm_key_vault_access_policy" "kv_user_portal" {
   count        = length(local.deployer_users_id)
   key_vault_id = azurerm_key_vault.kv_user.id
@@ -72,3 +73,4 @@ resource "azurerm_key_vault_access_policy" "kv_user_portal" {
     "set",
   ]
 }
+*/

--- a/deploy/terraform/terraform-units/modules/sap_library/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_library/variables_local.tf
@@ -100,7 +100,8 @@ locals {
   // If custom names are used for deployer, provide resource_group_name and msi_name will override the naming convention
   deployer_rg_name  = try(local.deployer.resource_group_name, format("%s-INFRASTRUCTURE", local.deployer_prefix))
   deployer_msi_name = try(local.deployer.msi_name, format("%s-msi", local.deployer_prefix))
-  deployer_users_id = try(local.deployer.users.object_id, [])
+  // Comment out code with users.object_id for the time being.
+  // deployer_users_id = try(local.deployer.users.object_id, [])
 
   // key vault for saplibrary
   kv_prefix       = upper(format("%s%s", substr(local.environment, 0, 5), local.location_short))

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/key_vault_sap_landscape.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/key_vault_sap_landscape.tf
@@ -58,6 +58,7 @@ resource "azurerm_key_vault_access_policy" "kv_user_msi" {
   ]
 }
 
+/* Comment out code with users.object_id for the time being
 resource "azurerm_key_vault_access_policy" "kv_user_portal" {
   count        = local.enable_landscape_kv ? length(local.kv_users) : 0
   key_vault_id = azurerm_key_vault.kv_user[0].id
@@ -71,7 +72,7 @@ resource "azurerm_key_vault_access_policy" "kv_user_portal" {
     "set",
   ]
 }
-
+*/
 // Using TF tls to generate SSH key pair for iscsi devices and store in user KV
 resource "tls_private_key" "iscsi" {
   count = (

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/key_vault_sap_system.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/key_vault_sap_system.tf
@@ -57,6 +57,7 @@ resource "azurerm_key_vault_access_policy" "sid_kv_user_msi" {
   ]
 }
 
+/* Comment out code with users.object_id for the time being
 resource "azurerm_key_vault_access_policy" "sid_kv_user_portal" {
   count        = local.enable_sid_deployment ? length(local.kv_users) : 0
   key_vault_id = azurerm_key_vault.sid_kv_user[0].id
@@ -70,7 +71,7 @@ resource "azurerm_key_vault_access_policy" "sid_kv_user_portal" {
     "set",
   ]
 }
-
+*/
 // random bytes to product
 resource "random_id" "sapsystem" {
   byte_length = 4

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/variables_local.tf
@@ -22,12 +22,12 @@ variable "nsg-mgmt" {
 variable "deployer-uai" {
   description = "Details of the UAI used by deployer(s)"
 }
-
+/* Comment out code with users.object_id for the time being
 variable "deployer_user" {
   description = "Details of the users"
   default     = []
 }
-
+*/
 variable "region_mapping" {
   type        = map(string)
   description = "Region Mapping: Full = Single CHAR, 4-CHAR"
@@ -134,9 +134,10 @@ locals {
   // Post fix for all deployed resources
   postfix = random_id.saplandscape.hex
 
+/* Comment out code with users.object_id for the time being
   // Additional users add to user KV
   kv_users = var.deployer_user
-
+*/
   // kv for sap landscape
   kv_prefix       = upper(format("%s%s%s", substr(local.environment, 0, 5), local.location_short, substr(local.vnet_sap_name_prefix, 0, 7)))
   kv_private_name = format("%sprvt%s", local.kv_prefix, upper(substr(local.postfix, 0, 3)))

--- a/deploy/terraform/terraform-units/modules/sap_system/deployer/output.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/deployer/output.tf
@@ -18,8 +18,7 @@ output "deployer-uai" {
   value = data.azurerm_user_assigned_identity.deployer
 }
 
-// Comment out code with users.object_id for the time being.
-/*
+/* comment out user'object id related logic
 output "deployer_user" {
   value = data.terraform_remote_state.deployer.outputs.deployer_user
 }


### PR DESCRIPTION
## Problem
<Please describe what problem this PR is trying to resolve>
The access policy of users accessing keyvault should not be configured through Terraform. 

## Solution
<Please elaborate the solution for the problem>
Comment out relevant codes in saplibrary, saplandscape and sapsystem

## Tests
<Please provide steps to test the PR>

https://dev.azure.com/azuresaphana/Azure-SAP-HANA/_build/results?buildId=12203&view=results

## Notes
<Additional comments for the PR>