### PR TITLE
Support HANA 2.00.050 on RHEL 7.6

### DIFF
--- a/deploy/ansible/roles/os-preparation/tasks/RedHat/RHEL-7/os_config.yml
+++ b/deploy/ansible/roles/os-preparation/tasks/RedHat/RHEL-7/os_config.yml
@@ -91,7 +91,16 @@
   loop:
       - compat-sap-c++-7
       - libatomic
-  when: hana_database.db_version is regex("2.\d{2}.0([4-9]\d|[0-9]\d{2,})")
+  when: hana_database.db_version is regex("2.\d{2}.04\d")
+
+- name: SAP Note 2886607 - Linux - Running SAP applications compiled with GCC 9.x
+  package:
+    name: "{{ item }}"
+    state: present
+  loop:
+      - compat-sap-c++-9
+      - libatomic
+  when: hana_database.db_version is regex("2.\d{2}.0([5-9]\d|[0-9]\d{2,})")
 
 - name: SAP Note 2292690 - SAP HANA DB Recommended OS settings for RHEL 7 - Tuned profile 1
   systemd:

--- a/deploy/template_samples/clustered_hana.json
+++ b/deploy/template_samples/clustered_hana.json
@@ -68,7 +68,7 @@
   "databases": [
     {
       "platform": "HANA",
-      "db_version": "2.00.043",
+      "db_version": "2.00.050",
       "os": {
         "publisher": "suse",
         "offer": "sles-sap-12-sp5",

--- a/deploy/template_samples/clustered_hana_use_custom_image_with_sbd.json
+++ b/deploy/template_samples/clustered_hana_use_custom_image_with_sbd.json
@@ -90,7 +90,7 @@
   "databases": [
     {
       "platform": "HANA",
-      "db_version": "2.00.043",
+      "db_version": "2.00.050",
       "os": {
         "source_image_id": "/subscriptions/xxx/resourceGroups/xxx/providers/Microsoft.Compute/images/xxx",
         "//": "publisher will be required if it is a SUSE custom image and you would like to use sbd fencing",

--- a/deploy/template_samples/clustered_hana_with_sbd.json
+++ b/deploy/template_samples/clustered_hana_with_sbd.json
@@ -91,7 +91,7 @@
   "databases": [
     {
       "platform": "HANA",
-      "db_version": "2.00.043",
+      "db_version": "2.00.050",
       "os": {
         "publisher": "suse",
         "offer": "sles-sap-12-sp5",

--- a/deploy/template_samples/clustered_hana_with_sbd_in_existing_subnet.json
+++ b/deploy/template_samples/clustered_hana_with_sbd_in_existing_subnet.json
@@ -96,7 +96,7 @@
   "databases": [
     {
       "platform": "HANA",
-      "db_version": "2.00.043",
+      "db_version": "2.00.050",
       "os": {
         "publisher": "suse",
         "offer": "sles-sap-12-sp5",

--- a/deploy/template_samples/saplandscaperunner.json
+++ b/deploy/template_samples/saplandscaperunner.json
@@ -81,7 +81,7 @@
     "databases": [
         {
             "platform": "HANA",
-            "db_version": "2.00.040",
+            "db_version": "2.00.050",
             "os": {
                 "publisher": "SUSE",
                 "offer": "sles-sap-12-sp5",

--- a/deploy/template_samples/single_node_hana.json
+++ b/deploy/template_samples/single_node_hana.json
@@ -68,7 +68,7 @@
   "databases": [
     {
       "platform": "HANA",
-      "db_version": "2.00.043",
+      "db_version": "2.00.050",
       "os": {
         "publisher": "suse",
         "offer": "sles-sap-12-sp5",

--- a/deploy/template_samples/single_node_hana_with_custom_image.json
+++ b/deploy/template_samples/single_node_hana_with_custom_image.json
@@ -68,7 +68,7 @@
   "databases": [
     {
       "platform": "HANA",
-      "db_version": "2.00.043",
+      "db_version": "2.00.050",
       "os": {
         "source_image_id": "/subscriptions/xxx/resourceGroups/xxx/providers/Microsoft.Compute/images/xxx"
       },

--- a/deploy/template_samples/single_node_hana_with_jumpboxes.json
+++ b/deploy/template_samples/single_node_hana_with_jumpboxes.json
@@ -108,7 +108,7 @@
   "databases": [
     {
       "platform": "HANA",
-      "db_version": "2.00.043",
+      "db_version": "2.00.050",
       "os": {
         "publisher": "suse",
         "offer": "sles-sap-12-sp5",

--- a/deploy/template_samples/single_node_hana_with_xsa.json
+++ b/deploy/template_samples/single_node_hana_with_xsa.json
@@ -68,7 +68,7 @@
   "databases": [
     {
       "platform": "HANA",
-      "db_version": "2.00.043",
+      "db_version": "2.00.050",
       "os": {
         "publisher": "suse",
         "offer": "sles-sap-12-sp5",

--- a/templates/tempGen/template-daily.json
+++ b/templates/tempGen/template-daily.json
@@ -127,7 +127,7 @@
   "databases": [
     {
       "platform": "HANA",
-      "db_version": "2.00.043",
+      "db_version": "2.00.050",
       "os": {var-os-image},
       "size": "Demo",
       "filesystem": "xfs",

--- a/templates/tempGen/template.json
+++ b/templates/tempGen/template.json
@@ -88,7 +88,7 @@
   "databases": [
     {
       "platform": "HANA",
-      "db_version": "2.00.043",
+      "db_version": "2.00.050",
       "os": {var-os-image},
       "size": "Demo",
       "filesystem": "xfs",


### PR DESCRIPTION
## Problem
To install HDB 2.00.050 which is the current HDB version with our downloader, compat-sap-c++-9 is required.

## Solution
- For RHEL 7.6 
    - install compat-sap-c++-7 for HDB 2.00.04x
    - install compat-sap-c++-9 for HDB 2.00.05x or above if it comes.
- Update all templates to 2.00.050 since this is the current version we install with our downloader.

## Tests
Manually switch to run ansible with current branch in daily pipeline and HDB installation finishes fine:
https://dev.azure.com/azuresaphana/Azure-SAP-HANA/_build/results?buildId=12307&view=logs&j=26e8545f-7bba-59d4-7560-ea013f161a02&t=3e918b22-2714-5e1f-1ffe-76382fc3f8f1

## Notes
Will cherry-pick this fix to all other branches.