### PR TITLE
Fix release pipeline

### DIFF
--- a/.pipeline/templates/ansible/ansible-playbook-steps.yml
+++ b/.pipeline/templates/ansible/ansible-playbook-steps.yml
@@ -11,13 +11,18 @@ steps:
       repo_dir=$HOME/Azure_SAP_Automated_Deployment/sap-hana
       ws_dir=$HOME/Azure_SAP_Automated_Deployment/WORKSPACES/SAP_SYSTEM/${sapsystem_rg_name}
 
-      echo "=== Retrieving SSH key from sap_landscape KV ==="
+      echo "=== Retrieving SSH key pairs from sap_landscape KV ==="
       landscape_kv_name=$(az keyvault list --resource-group ${saplandscape_rg} | jq -r "'".[] | select(.name | contains(\\\"user\\\")).name"'")
       sid_private_key_secret_name=$(az keyvault secret list --vault-name ${landscape_kv_name} | jq -r "'".[] | select(.name | contains(\\\"iscsi\\\") | not) | select(.name | contains(\\\"pub\\\") | not).name"'")
+      sid_public_key_secret_name=$(az keyvault secret list --vault-name ${landscape_kv_name} | jq -r "'".[] | select(.name | contains(\\\"iscsi\\\") | not) | select(.name | contains(\\\"pub\\\")).name"'")
 
       rm -f ${ws_dir}/sshkey
       az keyvault secret show --vault-name ${landscape_kv_name} --name ${sid_private_key_secret_name} | jq -r .value > ${ws_dir}/sshkey
       chmod 600 ${ws_dir}/sshkey
+
+      rm -f ${ws_dir}/sshkey.pub
+      az keyvault secret show --vault-name ${landscape_kv_name} --name ${sid_public_key_secret_name} | jq -r .value > ${ws_dir}/sshkey.pub
+      chmod 644 ${ws_dir}/sshkey.pub
 
       echo "=== Checkout required branch ${{parameters.branch_name}} ==="
       cd ${repo_dir} && git pull && git checkout ${{parameters.branch_name}}

--- a/.pipeline/tf-release.yml
+++ b/.pipeline/tf-release.yml
@@ -174,6 +174,7 @@ stages:
       - template: templates/ansible/ansible-playbook-steps.yml
         parameters:
           branch_name: $(sourceBranchName)
+          saplandscape_rg_name: "UNIT-EAUS-SAP0-INFRASTRUCTURE"
           sapsystem_rg_name: "SLES-EAUS-SAP-PRD"
       - template: templates/util/remove-agent-from-deployer-nsg.yml
         parameters:

--- a/deploy/terraform/bootstrap/sap_library/output.tf
+++ b/deploy/terraform/bootstrap/sap_library/output.tf
@@ -4,8 +4,7 @@ output "tfstate_storage_account" {
 }
 
 output "sapbits_storage_account_name" {
-  sensitive = true
-  value     = module.sap_library.sapbits_storage_account_name
+  value = module.sap_library.sapbits_storage_account_name
 }
 
 output "sapbits_sa_resource_group_name" {
@@ -20,11 +19,6 @@ output "storagecontainer_tfstate" {
 output "storagecontainer_sapbits_name" {
   sensitive = true
   value     = module.sap_library.storagecontainer_sapbits_name
-}
-
-output "storagecontainer_sapbits_sa_name" {
-  sensitive = true
-  value     = module.sap_library.storagecontainer_sapbits_sa_name
 }
 
 output "fileshare_sapbits_name" {

--- a/deploy/terraform/bootstrap/sap_library/output.tf
+++ b/deploy/terraform/bootstrap/sap_library/output.tf
@@ -3,9 +3,13 @@ output "tfstate_storage_account" {
   value     = module.sap_library.tfstate_storage_account
 }
 
-output "sapbits_storage_account" {
+output "sapbits_storage_account_name" {
   sensitive = true
-  value     = module.sap_library.sapbits_storage_account
+  value     = module.sap_library.sapbits_storage_account_name
+}
+
+output "sapbits_sa_resource_group_name" {
+  value = module.sap_library.sapbits_sa_resource_group_name
 }
 
 output "storagecontainer_tfstate" {
@@ -13,9 +17,14 @@ output "storagecontainer_tfstate" {
   value     = module.sap_library.storagecontainer_tfstate
 }
 
-output "storagecontainer_sapbits" {
+output "storagecontainer_sapbits_name" {
   sensitive = true
-  value     = module.sap_library.storagecontainer_sapbits
+  value     = module.sap_library.storagecontainer_sapbits_name
+}
+
+output "storagecontainer_sapbits_sa_name" {
+  sensitive = true
+  value     = module.sap_library.storagecontainer_sapbits_sa_name
 }
 
 output "fileshare_sapbits_name" {

--- a/deploy/terraform/run/sap_library/output.tf
+++ b/deploy/terraform/run/sap_library/output.tf
@@ -4,8 +4,7 @@ output "tfstate_storage_account" {
 }
 
 output "sapbits_storage_account_name" {
-  sensitive = true
-  value     = module.sap_library.sapbits_storage_account_name
+  value = module.sap_library.sapbits_storage_account_name
 }
 
 output "sapbits_sa_resource_group_name" {
@@ -20,11 +19,6 @@ output "storagecontainer_tfstate" {
 output "storagecontainer_sapbits_name" {
   sensitive = true
   value     = module.sap_library.storagecontainer_sapbits_name
-}
-
-output "storagecontainer_sapbits_sa_name" {
-  sensitive = true
-  value     = module.sap_library.storagecontainer_sapbits_sa_name
 }
 
 output "fileshare_sapbits_name" {

--- a/deploy/terraform/run/sap_library/output.tf
+++ b/deploy/terraform/run/sap_library/output.tf
@@ -3,9 +3,13 @@ output "tfstate_storage_account" {
   value     = module.sap_library.tfstate_storage_account
 }
 
-output "sapbits_storage_account" {
+output "sapbits_storage_account_name" {
   sensitive = true
-  value     = module.sap_library.sapbits_storage_account
+  value     = module.sap_library.sapbits_storage_account_name
+}
+
+output "sapbits_sa_resource_group_name" {
+  value = module.sap_library.sapbits_sa_resource_group_name
 }
 
 output "storagecontainer_tfstate" {
@@ -13,9 +17,14 @@ output "storagecontainer_tfstate" {
   value     = module.sap_library.storagecontainer_tfstate
 }
 
-output "storagecontainer_sapbits" {
+output "storagecontainer_sapbits_name" {
   sensitive = true
-  value     = module.sap_library.storagecontainer_sapbits
+  value     = module.sap_library.storagecontainer_sapbits_name
+}
+
+output "storagecontainer_sapbits_sa_name" {
+  sensitive = true
+  value     = module.sap_library.storagecontainer_sapbits_sa_name
 }
 
 output "fileshare_sapbits_name" {

--- a/deploy/terraform/run/sap_system/variables_global.tf
+++ b/deploy/terraform/run/sap_system/variables_global.tf
@@ -37,8 +37,5 @@ variable "ssh-timeout" {
 
 variable "sshkey" {
   description = "Details of ssh key pair"
-  default = {
-    path_to_public_key  = "~/.ssh/id_rsa.pub",
-    path_to_private_key = "~/.ssh/id_rsa"
-  }
+  default     = {}
 }

--- a/deploy/terraform/terraform-units/modules/sap_library/output.tf
+++ b/deploy/terraform/terraform-units/modules/sap_library/output.tf
@@ -2,16 +2,24 @@ output "tfstate_storage_account" {
   value = local.sa_tfstate_name
 }
 
-output "sapbits_storage_account" {
+output "sapbits_storage_account_name" {
   value = local.sa_sapbits_name
+}
+
+output "sapbits_sa_resource_group_name" {
+  value = local.rg_name
 }
 
 output "storagecontainer_tfstate" {
   value = local.sa_tfstate_container_name
 }
 
-output "storagecontainer_sapbits" {
-  value = local.storagecontainer_sapbits
+output "storagecontainer_sapbits_name" {
+  value = local.storagecontainer_sapbits_name
+}
+
+output "storagecontainer_sapbits_sa_name" {
+  value = local.sa_sapbits_exists ? data.azurerm_storage_account.storage_sapbits[0].name : azurerm_storage_account.storage_sapbits[0].name
 }
 
 output "fileshare_sapbits_name" {

--- a/deploy/terraform/terraform-units/modules/sap_library/output.tf
+++ b/deploy/terraform/terraform-units/modules/sap_library/output.tf
@@ -18,10 +18,6 @@ output "storagecontainer_sapbits_name" {
   value = local.storagecontainer_sapbits_name
 }
 
-output "storagecontainer_sapbits_sa_name" {
-  value = local.sa_sapbits_exists ? data.azurerm_storage_account.storage_sapbits[0].name : azurerm_storage_account.storage_sapbits[0].name
-}
-
 output "fileshare_sapbits_name" {
   value = local.fileshare_sapbits_name
 }

--- a/deploy/terraform/terraform-units/modules/sap_library/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_library/variables_local.tf
@@ -122,7 +122,7 @@ locals {
 }
 
 locals {
-  rg_library_location      = local.rg_exists ? data.azurerm_resource_group.library[0].location : azurerm_resource_group.library[0].location
-  storagecontainer_sapbits = ! local.sa_sapbits_blob_container_enable ? null : local.sa_sapbits_blob_container_name
-  fileshare_sapbits_name   = local.sa_sapbits_file_share_enable ? local.sa_sapbits_file_share_name : null
+  rg_library_location           = local.rg_exists ? data.azurerm_resource_group.library[0].location : azurerm_resource_group.library[0].location
+  storagecontainer_sapbits_name = local.sa_sapbits_blob_container_enable ? local.sa_sapbits_blob_container_name : null
+  fileshare_sapbits_name        = local.sa_sapbits_file_share_enable ? local.sa_sapbits_file_share_name : null
 }

--- a/deploy/terraform/terraform-units/modules/sap_system/saplibrary/imports.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/saplibrary/imports.tf
@@ -15,13 +15,13 @@ data "terraform_remote_state" "saplibrary" {
 
 // Import SA for sap bits
 data "azurerm_storage_account" "saplibrary" {
-  name                = data.terraform_remote_state.saplibrary.outputs.sapbits_storage_account.name
-  resource_group_name = data.terraform_remote_state.saplibrary.outputs.sapbits_storage_account.resource_group_name
+  name                = data.terraform_remote_state.saplibrary.outputs.sapbits_storage_account_name
+  resource_group_name = data.terraform_remote_state.saplibrary.outputs.sapbits_sa_resource_group_name
 }
 
 // Import storage container for sap bits if exists
 data "azurerm_storage_container" "storagecontainer-sapbits" {
   count                = local.blob_container_exists ? 1 : 0
-  name                 = data.terraform_remote_state.saplibrary.outputs.storagecontainer_sapbits.name
-  storage_account_name = data.terraform_remote_state.saplibrary.outputs.storagecontainer_sapbits.storage_account_name
+  name                 = data.terraform_remote_state.saplibrary.outputs.storagecontainer_sapbits_name
+  storage_account_name = data.terraform_remote_state.saplibrary.outputs.storagecontainer_sapbits_sa_name
 }

--- a/deploy/terraform/terraform-units/modules/sap_system/saplibrary/imports.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/saplibrary/imports.tf
@@ -23,5 +23,5 @@ data "azurerm_storage_account" "saplibrary" {
 data "azurerm_storage_container" "storagecontainer-sapbits" {
   count                = local.blob_container_exists ? 1 : 0
   name                 = data.terraform_remote_state.saplibrary.outputs.storagecontainer_sapbits_name
-  storage_account_name = data.terraform_remote_state.saplibrary.outputs.storagecontainer_sapbits_sa_name
+  storage_account_name = data.terraform_remote_state.saplibrary.outputs.sapbits_storage_account_name
 }

--- a/deploy/terraform/terraform-units/modules/sap_system/saplibrary/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/saplibrary/variables_local.tf
@@ -57,7 +57,7 @@ locals {
 
 locals {
   file_share_exists          = try(data.terraform_remote_state.saplibrary.outputs.fileshare_sapbits_name, null) == null ? false : true
-  blob_container_exists      = try(data.terraform_remote_state.saplibrary.outputs.storagecontainer_sapbits, null) == null ? false : true
+  blob_container_exists      = try(data.terraform_remote_state.saplibrary.outputs.storagecontainer_sapbits_name, null) == null ? false : true
   storagecontainer_sapsystem = try(data.terraform_remote_state.saplibrary.outputs.storagecontainer_sapsystem, null)
   sa_tfstate                 = try(data.terraform_remote_state.saplibrary.outputs.tfstate_storage_account, null)
 


### PR DESCRIPTION
## Problem
Release pipeline has problem after sap_library deployment.

## Solution
There are several problem fixed in this PR which fixed the release pipeline:
     - add sap_land info into release pipeline, otherwise ansible test does not know where to pull the SSH keypair for SID VMs.
     - fix output change from pr #834
     - change default ssh key path for sap_system - it should not point to local files. 
     - download ssh key pair to deployer in ansible test
 
## Tests
https://dev.azure.com/azuresaphana/Azure-SAP-HANA/_build/results?buildId=12321&view=results

## Notes
Why we need the key pair?

For the first attempt to ssh from deployer to a target VM, it requires to have the public key so this can be added to the `authorized_keys` of target VM. Otherwise, the first attempt to connect the target will fail although private key is given. Then it will ask for password as second logon method.

After the first connection, the public key is no longer required to establish an ssh connection with the target VM.