### PR TITLE
Fix SQL SERVER casing

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/variables_local.tf
@@ -230,7 +230,7 @@ locals {
     "DB2" = [
       "62500"
     ]
-    "SQLServer" = [
+    "SQLSERVER" = [
       "59999"
     ]
     "NONE" = [


### PR DESCRIPTION
SQLSERVER casing was wrong

## Problem
The casing for SQLServer was wrong

on ..\..\..\..\sap-hana\deploy\terraform\terraform-units\modules\sap_system\anydb_node\variables_local.tf line 242, in locals: 
242: for port in local.lb_ports[upper(local.anydb_platform)] : { 
|---------------- 
| local.anydb_platform is "SQLSERVER" 
| local.lb_ports is object with 5 attributes 

The given key does not identify an element in this collection value. 


## Solution
The map has a key of SQLServer and not SQLSERVER

## Tests
Try to deploy a SQL

## Notes
<Additional comments for the PR>