### PR TITLE
Read scs_count from json file

### DIFF
--- a/deploy/terraform/run/sap_system/variables_local.tf
+++ b/deploy/terraform/run/sap_system/variables_local.tf
@@ -85,9 +85,9 @@ locals {
   db_server_count     = try(length(var.databases[0].dbnodes), 1)
   app_server_count    = try(var.application.application_server_count, 0)
   webdispatcher_count = try(var.application.webdispatcher_count, 0)
-  scs_server_count    = try(var.application.scs_high_availability, false) ? 2 : 1
+  scs_server_count    = try(var.application.scs_server_count, local.scs_high_availability ? 2 : 1)
 
-  zones = try (var.databases[0].zones, [])
-  
+  zones = try(var.databases[0].zones, [])
+
 
 }

--- a/deploy/terraform/run/sap_system/variables_local.tf
+++ b/deploy/terraform/run/sap_system/variables_local.tf
@@ -80,12 +80,13 @@ locals {
   db_sid         = length(local.hana-databases) > 0 ? local.hanadb_sid : local.anydb_sid
   sap_sid        = upper(try(var.application.sid, local.db_sid))
 
-  app_ostype          = try(var.application.os.os_type, "LINUX")
-  db_ostype           = try(var.databases[0].os.os_type, "LINUX")
-  db_server_count     = try(length(var.databases[0].dbnodes), 1)
-  app_server_count    = try(var.application.application_server_count, 0)
-  webdispatcher_count = try(var.application.webdispatcher_count, 0)
-  scs_server_count    = try(var.application.scs_server_count, 1) * local.scs_high_availability ? 2 : 1
+  app_ostype            = try(var.application.os.os_type, "LINUX")
+  db_ostype             = try(var.databases[0].os.os_type, "LINUX")
+  db_server_count       = try(length(var.databases[0].dbnodes), 1)
+  app_server_count      = try(var.application.application_server_count, 0)
+  webdispatcher_count   = try(var.application.webdispatcher_count, 0)
+  scs_high_availability = try(var.application.scs_high_availability, false)
+  scs_server_count      = try(var.application.scs_server_count, 1) * local.scs_high_availability ? 2 : 1
 
   zones = try(var.databases[0].zones, [])
 

--- a/deploy/terraform/run/sap_system/variables_local.tf
+++ b/deploy/terraform/run/sap_system/variables_local.tf
@@ -86,9 +86,8 @@ locals {
   app_server_count      = try(var.application.application_server_count, 0)
   webdispatcher_count   = try(var.application.webdispatcher_count, 0)
   scs_high_availability = try(var.application.scs_high_availability, false)
-  scs_server_count      = try(var.application.scs_server_count, 1) * local.scs_high_availability ? 2 : 1
+  scs_server_count      = try(var.application.scs_server_count, 1) * (local.scs_high_availability ? 2 : 1)
 
   zones = try(var.databases[0].zones, [])
-
 
 }

--- a/deploy/terraform/run/sap_system/variables_local.tf
+++ b/deploy/terraform/run/sap_system/variables_local.tf
@@ -85,7 +85,7 @@ locals {
   db_server_count     = try(length(var.databases[0].dbnodes), 1)
   app_server_count    = try(var.application.application_server_count, 0)
   webdispatcher_count = try(var.application.webdispatcher_count, 0)
-  scs_server_count    = try(var.application.scs_server_count, local.scs_high_availability ? 2 : 1)
+  scs_server_count    = try(var.application.scs_server_count, 1) * local.scs_high_availability ? 2 : 1
 
   zones = try(var.databases[0].zones, [])
 

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/variables_local.tf
@@ -105,7 +105,7 @@ locals {
   ers_instance_number      = try(var.application.ers_instance_number, "02")
   scs_high_availability    = try(var.application.scs_high_availability, false)
   application_server_count = try(var.application.application_server_count, 0)
-  scs_server_count         = local.scs_high_availability ? 2 : 1
+  scs_server_count         = try(var.application.scs_server_count, local.scs_high_availability ? 2 : 1)
   webdispatcher_count      = try(var.application.webdispatcher_count, 0)
   vm_sizing                = try(var.application.vm_sizing, "Default")
   app_nic_ips              = try(var.application.app_nic_ips, [])

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/variables_local.tf
@@ -276,7 +276,7 @@ locals {
   ) : []
 
   scs-data-disks = flatten([
-    for vm_counter in range(local.scs_high_availability ? 2 : 1) : [
+    for vm_counter in range(local.scs_server_count) : [
       for idx, datadisk in local.app-data-disk-per-dbnode : {
         suffix                    = datadisk.suffix
         vm_index                  = vm_counter

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/variables_local.tf
@@ -105,7 +105,7 @@ locals {
   ers_instance_number      = try(var.application.ers_instance_number, "02")
   scs_high_availability    = try(var.application.scs_high_availability, false)
   application_server_count = try(var.application.application_server_count, 0)
-  scs_server_count         = try(var.application.scs_server_count, local.scs_high_availability ? 2 : 1)
+  scs_server_count         = try(var.application.scs_server_count, 1) * local.scs_high_availability ? 2 : 1
   webdispatcher_count      = try(var.application.webdispatcher_count, 0)
   vm_sizing                = try(var.application.vm_sizing, "Default")
   app_nic_ips              = try(var.application.app_nic_ips, [])

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/variables_local.tf
@@ -30,11 +30,11 @@ variable "custom_disk_sizes_filename" {
 
 locals {
   // Imports Disk sizing sizing information
-  sizes      = jsondecode(file(length(var.custom_disk_sizes_filename) > 0 ? var.custom_disk_sizes_filename : "${path.module}/../../../../../configs/app_sizes.json"))
+  sizes = jsondecode(file(length(var.custom_disk_sizes_filename) > 0 ? var.custom_disk_sizes_filename : "${path.module}/../../../../../configs/app_sizes.json"))
 
   app_virtualmachine_names = var.naming.virtualmachine_names.APP_COMPUTERNAME
   scs_virtualmachine_names = var.naming.virtualmachine_names.SCS_COMPUTERNAME
-  web_virtualmachine_names = var.naming.virtualmachine_names.WEB_COMPUTERNAME   
+  web_virtualmachine_names = var.naming.virtualmachine_names.WEB_COMPUTERNAME
   resource_suffixes        = var.naming.resource_suffixes
 
   region  = try(var.infrastructure.region, "")
@@ -105,7 +105,7 @@ locals {
   ers_instance_number      = try(var.application.ers_instance_number, "02")
   scs_high_availability    = try(var.application.scs_high_availability, false)
   application_server_count = try(var.application.application_server_count, 0)
-  scs_server_count         = try(var.application.scs_server_count, 1) * local.scs_high_availability ? 2 : 1
+  scs_server_count         = try(var.application.scs_server_count, 1) * (local.scs_high_availability ? 2 : 1)
   webdispatcher_count      = try(var.application.webdispatcher_count, 0)
   vm_sizing                = try(var.application.vm_sizing, "Default")
   app_nic_ips              = try(var.application.app_nic_ips, [])

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-scs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-scs.tf
@@ -81,7 +81,7 @@ resource "azurerm_linux_virtual_machine" "scs" {
 
 # Create the SCS Windows VM(s)
 resource "azurerm_windows_virtual_machine" "scs" {
-  count               = local.enable_deployment ? (upper(local.app_ostype) == "WINDOWS" ? (local.scs_high_availability ? 2 : 1) : 0) : 0
+  count               = local.enable_deployment ? (upper(local.app_ostype) == "WINDOWS" ? local.scs_server_count : 0) : 0
   name                = format("%s_%s%s", local.prefix, local.scs_virtualmachine_names[count.index], local.resource_suffixes.vm)
   computer_name       = local.scs_virtualmachine_names[count.index]
   location            = var.resource-group[0].location

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-scs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-scs.tf
@@ -24,7 +24,7 @@ resource "azurerm_network_interface_backend_address_pool_association" "scs" {
 
 # Create the SCS Linux VM(s)
 resource "azurerm_linux_virtual_machine" "scs" {
-  count               = local.enable_deployment ? (upper(local.app_ostype) == "LINUX" ? local.scs_server_count : 0) : 0
+  count               = local.enable_deployment && (upper(local.app_ostype) == "LINUX") ? local.scs_server_count : 0
   name                = format("%s_%s%s", local.prefix, local.scs_virtualmachine_names[count.index], local.resource_suffixes.vm)
   computer_name       = local.scs_virtualmachine_names[count.index]
   location            = var.resource-group[0].location
@@ -81,7 +81,7 @@ resource "azurerm_linux_virtual_machine" "scs" {
 
 # Create the SCS Windows VM(s)
 resource "azurerm_windows_virtual_machine" "scs" {
-  count               = local.enable_deployment ? (upper(local.app_ostype) == "WINDOWS" ? local.scs_server_count : 0) : 0
+  count               = local.enable_deployment && (upper(local.app_ostype) == "WINDOWS") ? local.scs_server_count : 0
   name                = format("%s_%s%s", local.prefix, local.scs_virtualmachine_names[count.index], local.resource_suffixes.vm)
   computer_name       = local.scs_virtualmachine_names[count.index]
   location            = var.resource-group[0].location


### PR DESCRIPTION
## Problem
The customers may need more than two servers in the scs tier

## Solution
Add a "scs_server_count" property to the application section of the json file


## Tests
Change the value in the json file to "scs_server_count": 3 deploy and validate that 3 scs servers are created


## Notes
<Additional comments for the PR>