### PR TITLE
Kimforss add anchor v ms

### DIFF
--- a/deploy/terraform/run/sap_system/module.tf
+++ b/deploy/terraform/run/sap_system/module.tf
@@ -58,6 +58,7 @@ module "sap_namegenerator" {
   sap_sid       = local.sap_sid
   db_sid        = local.db_sid
   app_ostype    = local.app_ostype
+  anchor_ostype = local.anchor_ostype
   db_ostype     = local.db_ostype
   /////////////////////////////////////////////////////////////////////////////////////
   // The naming module creates a list of servers names that is app_server_count

--- a/deploy/terraform/run/sap_system/variables_local.tf
+++ b/deploy/terraform/run/sap_system/variables_local.tf
@@ -81,13 +81,19 @@ locals {
   sap_sid        = upper(try(var.application.sid, local.db_sid))
 
   app_ostype          = try(var.application.os.os_type, "LINUX")
+  anchor              = try(local.var_infra.anchor_vms, {})
+  anchor_ostype       = upper(try(local.anchor.os.os_type, "LINUX"))
   db_ostype           = try(var.databases[0].os.os_type, "LINUX")
   db_server_count     = try(length(var.databases[0].dbnodes), 1)
   app_server_count    = try(var.application.application_server_count, 0)
   webdispatcher_count = try(var.application.webdispatcher_count, 0)
   scs_server_count    = try(var.application.scs_high_availability, false) ? 2 : 1
 
-  zones = try (var.databases[0].zones, [])
-  
+
+  db_zones  = try(var.databases[0].zones, [])
+  app_zones = try(var.application.app_zones, [])
+  scs_zones = try(var.application.scs_zones, [])
+  web_zones = try(var.application.web_zones, [])
+  zones     = distinct(concat(local.db_zones, local.app_zones, local.scs_zones, local.web_zones))
 
 }

--- a/deploy/terraform/terraform-units/modules/sap_namegenerator/output.tf
+++ b/deploy/terraform/terraform-units/modules/sap_namegenerator/output.tf
@@ -23,6 +23,7 @@ output naming {
     }
     virtualmachine_names = {
       ANCHOR_COMPUTERNAME = local.anchor_server_names
+      ANCHOR_VMNAME       = local.anchor_server_vm_names
       ANYDB_COMPUTERNAME  = concat(local.anydb_computer_names, local.anydb_computer_names_ha)
       ANYDB_VMNAME        = concat(local.anydb_vm_names, local.anydb_vm_names_ha)
       APP_COMPUTERNAME    = local.app_server_names

--- a/deploy/terraform/terraform-units/modules/sap_namegenerator/output.tf
+++ b/deploy/terraform/terraform-units/modules/sap_namegenerator/output.tf
@@ -22,15 +22,16 @@ output naming {
       VNET     = local.vnet_keyvault_name
     }
     virtualmachine_names = {
-      ANYDB_COMPUTERNAME = concat(local.anydb_computer_names, local.anydb_computer_names_ha)
-      ANYDB_VMNAME       = concat(local.anydb_vm_names, local.anydb_vm_names_ha)
-      APP_COMPUTERNAME   = local.app_server_names
-      DEPLOYER           = local.deployer_vm_names
-      HANA_COMPUTERNAME  = concat(local.hana_computer_names, local.hana_computer_names_ha)
-      HANA_VMNAME        = concat(local.hana_server_vm_names, local.hana_server_vm_names_ha)
-      ISCSI_COMPUTERNAME = local.iscsi_server_names
-      SCS_COMPUTERNAME   = local.scs_server_names
-      WEB_COMPUTERNAME   = local.web_server_names
+      ANCHOR_COMPUTERNAME = local.anchor_server_names
+      ANYDB_COMPUTERNAME  = concat(local.anydb_computer_names, local.anydb_computer_names_ha)
+      ANYDB_VMNAME        = concat(local.anydb_vm_names, local.anydb_vm_names_ha)
+      APP_COMPUTERNAME    = local.app_server_names
+      DEPLOYER            = local.deployer_vm_names
+      HANA_COMPUTERNAME   = concat(local.hana_computer_names, local.hana_computer_names_ha)
+      HANA_VMNAME         = concat(local.hana_server_vm_names, local.hana_server_vm_names_ha)
+      ISCSI_COMPUTERNAME  = local.iscsi_server_names
+      SCS_COMPUTERNAME    = local.scs_server_names
+      WEB_COMPUTERNAME    = local.web_server_names
     }
     resource_suffixes = var.resource_suffixes
   }

--- a/deploy/terraform/terraform-units/modules/sap_namegenerator/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_namegenerator/variables_local.tf
@@ -52,6 +52,11 @@ variable db_platform {
   default     = "LINUX"
 }
 
+variable anchor_ostype {
+  description = "Anchor Server operating system"
+  default     = "LINUX"
+}
+
 variable app_server_count {
   type    = number
   default = 1

--- a/deploy/terraform/terraform-units/modules/sap_namegenerator/vm.tf
+++ b/deploy/terraform/terraform-units/modules/sap_namegenerator/vm.tf
@@ -2,11 +2,11 @@ locals {
 
   db_oscode       = upper(var.db_ostype) == "LINUX" ? "l" : "w"
   app_oscode      = upper(var.app_ostype) == "LINUX" ? "l" : "w"
-  anchor_oscode = upper(anchor_ostype) == "LINUX" ? "l" : "w"
+  anchor_oscode   = upper(var.anchor_ostype) == "LINUX" ? "l" : "w"
   db_platformcode = substr(var.db_platform, 0, 3)
 
   anchor_server_names = [for idx in range(length(var.zones)) :
-    format("%sanchor%02d%s%s", lower(var.sap_sid), idx, local.anchor_oscode, local.random_id_vm_verified)
+    format("%sanchor_z%s_%02d%s%s", lower(var.sap_sid), var.zones[idx % length(var.zones)], idx, local.anchor_oscode, local.random_id_vm_verified)
   ]
 
   deployer_vm_names = [for idx in range(var.deployer_vm_count) :

--- a/deploy/terraform/terraform-units/modules/sap_namegenerator/vm.tf
+++ b/deploy/terraform/terraform-units/modules/sap_namegenerator/vm.tf
@@ -2,10 +2,11 @@ locals {
 
   db_oscode       = upper(var.db_ostype) == "LINUX" ? "l" : "w"
   app_oscode      = upper(var.app_ostype) == "LINUX" ? "l" : "w"
+  anchor_oscode = upper(anchor_ostype) == "LINUX" ? "l" : "w"
   db_platformcode = substr(var.db_platform, 0, 3)
 
   anchor_server_names = [for idx in range(length(var.zones)) :
-    format("%sanchor%02d%s%s", lower(var.sap_sid), idx, local.app_oscode, local.random_id_vm_verified)
+    format("%sanchor%02d%s%s", lower(var.sap_sid), idx, local.anchor_oscode, local.random_id_vm_verified)
   ]
 
   deployer_vm_names = [for idx in range(var.deployer_vm_count) :

--- a/deploy/terraform/terraform-units/modules/sap_namegenerator/vm.tf
+++ b/deploy/terraform/terraform-units/modules/sap_namegenerator/vm.tf
@@ -6,6 +6,10 @@ locals {
   db_platformcode = substr(var.db_platform, 0, 3)
 
   anchor_server_names = [for idx in range(length(var.zones)) :
+    format("%sanchorz%s%02d%s%s", lower(var.sap_sid), var.zones[idx % length(var.zones)], idx, local.anchor_oscode, local.random_id_vm_verified)
+  ]
+
+  anchor_server_vm_names = [for idx in range(length(var.zones)) :
     format("%sanchor_z%s_%02d%s%s", lower(var.sap_sid), var.zones[idx % length(var.zones)], idx, local.anchor_oscode, local.random_id_vm_verified)
   ]
 

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/variables_local.tf
@@ -52,7 +52,8 @@ locals {
   storageaccount_name         = var.naming.storageaccount_names.SDU
   keyvault_names              = var.naming.keyvault_names.SDU
   virtualmachine_names        = var.naming.virtualmachine_names.ISCSI_COMPUTERNAME
-  anchor_virtualmachine_names = var.naming.virtualmachine_names.ANCHOR_COMPUTERNAME
+  anchor_virtualmachine_names = var.naming.virtualmachine_names.ANCHOR_VMNAME
+  anchor_computer_names       = var.naming.virtualmachine_names.ANCHOR_COMPUTERNAME
   resource_suffixes           = var.naming.resource_suffixes
 
   //Filter the list of databases to only HANA platform entries

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/variables_local.tf
@@ -48,11 +48,12 @@ locals {
   zones            = distinct(concat(local.db_zones, local.app_zones, local.scs_zones, local.web_zones))
   zonal_deployment = length(local.zones) > 0 ? true : false
 
-  vnet_prefix          = var.naming.prefix.VNET
-  storageaccount_name  = var.naming.storageaccount_names.SDU
-  keyvault_names       = var.naming.keyvault_names.SDU
-  virtualmachine_names = var.naming.virtualmachine_names.ISCSI_COMPUTERNAME
-  resource_suffixes    = var.naming.resource_suffixes
+  vnet_prefix                 = var.naming.prefix.VNET
+  storageaccount_name         = var.naming.storageaccount_names.SDU
+  keyvault_names              = var.naming.keyvault_names.SDU
+  virtualmachine_names        = var.naming.virtualmachine_names.ISCSI_COMPUTERNAME
+  anchor_virtualmachine_names = var.naming.virtualmachine_names.ANCHOR_COMPUTERNAME
+  resource_suffixes           = var.naming.resource_suffixes
 
   //Filter the list of databases to only HANA platform entries
   hana-databases = [
@@ -72,6 +73,27 @@ locals {
   }
 
   var_infra = try(var.infrastructure, {})
+
+  //Anchor VM
+  anchor      = try(local.var_infra.anchor_vms, {})
+  anchor_size = try(local.anchor.sku, "Standard_D8s_v3")
+  anchor_authentication = try(local.anchor.authentication,
+    {
+      "type"     = "key"
+      "username" = "azureadm"
+  })
+
+  anchor_custom_image = try(local.anchor.os.source_image_id, "") != "" ? true : false
+
+  anchor_os = {
+    "source_image_id" = local.anchor_custom_image ? local.anchor.os.source_image_id : ""
+    "publisher"       = try(local.anchor.os.publisher, local.anchor_custom_image ? "" : "suse")
+    "offer"           = try(local.anchor.os.offer, local.anchor_custom_image ? "" : "sles-sap-12-sp5")
+    "sku"             = try(local.anchor.os.sku, local.anchor_custom_image ? "" : "gen1")
+    "version"         = try(local.anchor.os.version, local.anchor_custom_image ? "" : "latest")
+  }
+  anchor_ostype           = upper(try(local.anchor.os.os_type, "LINUX"))
+  anchor_enable_ultradisk = try(local.anchor.support_ultra, [false, false, false])
 
   //Resource group
   var_rg    = try(local.var_infra.resource_group, {})

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/vm-anchor.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/vm-anchor.tf
@@ -39,7 +39,7 @@ resource "azurerm_linux_virtual_machine" "anchor" {
   disable_password_authentication = true
 
   os_disk {
-    name                 = format("%s_%s%s", local.prefix, local.anchor_virtualmachine_names[count.index], local.resource_suffixes.os_disk)
+    name                 = format("%s_%s%s", local.prefix, local.anchor_virtualmachine_names[count.index], local.resource_suffixes.osdisk)
     caching              = "ReadWrite"
     storage_account_type = "Standard_LRS"
   }
@@ -89,7 +89,7 @@ resource "azurerm_windows_virtual_machine" "anchor" {
   admin_password = local.anchor_authentication.password
 
   os_disk {
-    name                 = format("%s_%s%s", local.prefix, local.anchor_virtualmachine_names[count.index], local.resource_suffixes.os_disk)
+    name                 = format("%s_%s%s", local.prefix, local.anchor_virtualmachine_names[count.index], local.resource_suffixes.osdisk)
     caching              = "ReadWrite"
     storage_account_type = "Standard_LRS"
   }

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/vm-anchor.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/vm-anchor.tf
@@ -1,0 +1,117 @@
+data "azurerm_subnet" "anchor" {
+  count                = local.zonal_deployment ? (local.sub_db_exists ? 1 : 0) : 0
+  name                 = split("/", local.sub_db_arm_id)[10]
+  resource_group_name  = split("/", local.sub_db_arm_id)[4]
+  virtual_network_name = split("/", local.sub_db_arm_id)[8]
+}
+
+# Create Anchor VM
+resource "azurerm_network_interface" "anchor" {
+  count                         = local.zonal_deployment ? length(local.zones) : 0
+  name                          = format("%s_%s%s", local.prefix, local.anchor_virtualmachine_names[count.index], local.resource_suffixes.nic)
+  resource_group_name           = local.rg_exists ? data.azurerm_resource_group.resource-group[0].name : azurerm_resource_group.resource-group[0].name
+  location                      = local.rg_exists ? data.azurerm_resource_group.resource-group[0].location : azurerm_resource_group.resource-group[0].location
+  enable_accelerated_networking = false
+
+  ip_configuration {
+    name                          = "IPConfig1"
+    subnet_id                     = data.azurerm_subnet.anchor[0].id
+    private_ip_address            = try(local.anchor.nic_ips[count.index], cidrhost(data.azurerm_subnet.anchor[0].address_prefixes[0], (count.index + 5)))
+    private_ip_address_allocation = "static"
+  }
+}
+
+# Create the Linux Application VM(s)
+resource "azurerm_linux_virtual_machine" "anchor" {
+  count                        = local.zonal_deployment && (local.anchor_ostype == "LINUX") ? length(local.zones) : 0
+  name                         = format("%s_%s%s", local.prefix, local.anchor_virtualmachine_names[count.index], local.resource_suffixes.vm)
+  computer_name                = local.anchor_virtualmachine_names[count.index]
+  resource_group_name          = local.rg_exists ? data.azurerm_resource_group.resource-group[0].name : azurerm_resource_group.resource-group[0].name
+  location                     = local.rg_exists ? data.azurerm_resource_group.resource-group[0].location : azurerm_resource_group.resource-group[0].location
+  proximity_placement_group_id = azurerm_proximity_placement_group.ppg[count.index].id
+  zone                         = local.zones[count.index]
+
+  network_interface_ids = [
+    azurerm_network_interface.anchor[count.index].id
+  ]
+  size                            = local.anchor_size
+  admin_username                  = local.anchor_authentication.username
+  disable_password_authentication = true
+
+  os_disk {
+    name                 = format("%s_%s%s", local.prefix, local.anchor_virtualmachine_names[count.index], local.resource_suffixes.os_disk)
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  additional_capabilities {
+    ultra_ssd_enabled = local.anchor_enable_ultradisk[count.index]
+  }
+
+  source_image_id = local.anchor_custom_image ? local.anchor_os.source_image_id : null
+
+  dynamic "source_image_reference" {
+    for_each = range(local.anchor_custom_image ? 0 : 1)
+    content {
+      publisher = local.anchor_os.publisher
+      offer     = local.anchor_os.offer
+      sku       = local.anchor_os.sku
+      version   = local.anchor_os.version
+    }
+  }
+
+  admin_ssh_key {
+    username   = local.anchor_authentication.username
+    public_key = file(var.sshkey.path_to_public_key)
+  }
+
+  boot_diagnostics {
+    storage_account_uri = azurerm_storage_account.storage-bootdiag.primary_blob_endpoint
+  }
+}
+
+# Create the Windows Application VM(s)
+resource "azurerm_windows_virtual_machine" "anchor" {
+  count                        = local.zonal_deployment && (local.anchor_ostype == "WINDOWS") ? length(local.zones) : 0
+  name                         = format("%s_%s%s", local.prefix, local.anchor_virtualmachine_names[count.index], local.resource_suffixes.vm)
+  computer_name                = local.anchor_virtualmachine_names[count.index]
+  resource_group_name          = local.rg_exists ? data.azurerm_resource_group.resource-group[0].name : azurerm_resource_group.resource-group[0].name
+  location                     = local.rg_exists ? data.azurerm_resource_group.resource-group[0].location : azurerm_resource_group.resource-group[0].location
+  proximity_placement_group_id = azurerm_proximity_placement_group.ppg[count.index].id
+  zone                         = local.zones[count.index]
+
+  network_interface_ids = [
+    azurerm_network_interface.anchor[count.index].id
+  ]
+
+  size           = local.anchor_size
+  admin_username = local.anchor_authentication.username
+  admin_password = local.anchor_authentication.password
+
+  os_disk {
+    name                 = format("%s_%s%s", local.prefix, local.anchor_virtualmachine_names[count.index], local.resource_suffixes.os_disk)
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  additional_capabilities {
+    ultra_ssd_enabled = local.anchor_enable_ultradisk[count.index]
+  }
+
+  source_image_id = local.anchor_custom_image ? local.anchor_os.source_image_id : null
+
+  dynamic "source_image_reference" {
+    for_each = range(local.anchor_custom_image ? 0 : 1)
+    content {
+      publisher = local.anchor_os.publisher
+      offer     = local.anchor_os.offer
+      sku       = local.anchor_os.sku
+      version   = local.anchor_os.version
+    }
+  }
+
+  boot_diagnostics {
+    storage_account_uri = azurerm_storage_account.storage-bootdiag.primary_blob_endpoint
+  }
+}
+

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/vm-anchor.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/vm-anchor.tf
@@ -25,7 +25,7 @@ resource "azurerm_network_interface" "anchor" {
 resource "azurerm_linux_virtual_machine" "anchor" {
   count                        = local.zonal_deployment && (local.anchor_ostype == "LINUX") ? length(local.zones) : 0
   name                         = format("%s_%s%s", local.prefix, local.anchor_virtualmachine_names[count.index], local.resource_suffixes.vm)
-  computer_name                = local.anchor_virtualmachine_names[count.index]
+  computer_name                = local.anchor_computer_names[count.index]
   resource_group_name          = local.rg_exists ? data.azurerm_resource_group.resource-group[0].name : azurerm_resource_group.resource-group[0].name
   location                     = local.rg_exists ? data.azurerm_resource_group.resource-group[0].location : azurerm_resource_group.resource-group[0].location
   proximity_placement_group_id = azurerm_proximity_placement_group.ppg[count.index].id
@@ -74,7 +74,7 @@ resource "azurerm_linux_virtual_machine" "anchor" {
 resource "azurerm_windows_virtual_machine" "anchor" {
   count                        = local.zonal_deployment && (local.anchor_ostype == "WINDOWS") ? length(local.zones) : 0
   name                         = format("%s_%s%s", local.prefix, local.anchor_virtualmachine_names[count.index], local.resource_suffixes.vm)
-  computer_name                = local.anchor_virtualmachine_names[count.index]
+  computer_name                = local.anchor_computer_names[count.index]
   resource_group_name          = local.rg_exists ? data.azurerm_resource_group.resource-group[0].name : azurerm_resource_group.resource-group[0].name
   location                     = local.rg_exists ? data.azurerm_resource_group.resource-group[0].location : azurerm_resource_group.resource-group[0].location
   proximity_placement_group_id = azurerm_proximity_placement_group.ppg[count.index].id


### PR DESCRIPTION
## Problem
For HA zonal deployments all VMs may be in availability sets attached to proximity placement groups. For this scenario a zonal VM is needed to anchor the PPG to the right availability zone

## Solution
Add a section 
   "anchor_vms": {
      "sku": "Standard_D4s_v3",
      "authentication": {
        "type": "key",
        "username": "azureadm"
      },
      "support_ultra": [true, true, false],
      "os": {
        "publisher": "Oracle",
        "offer": "Oracle-Linux",
        "sku": "81",
        "version": "latest"
      }
    },
to the infrastructure node in the input json. This will instruct the automation code to deploy the anchor VMs
## Tests
Add the section mentioned above to the json file and deploy

## Notes
<Additional comments for the PR>