### PR TITLE
Separate computername and resource name in apptier naming module

### DIFF
--- a/deploy/terraform/run/sap_system/module.tf
+++ b/deploy/terraform/run/sap_system/module.tf
@@ -69,7 +69,10 @@ module "sap_namegenerator" {
   app_server_count = local.app_server_count
   web_server_count = local.webdispatcher_count
   scs_server_count = local.scs_server_count
-  zones            = local.zones
+  app_zones        = local.app_zones
+  scs_zones        = local.scs_zones
+  web_zones        = local.web_zones
+  db_zones         = local.db_zones
 }
 
 // Create Jumpboxes

--- a/deploy/terraform/run/sap_system/variables_local.tf
+++ b/deploy/terraform/run/sap_system/variables_local.tf
@@ -87,7 +87,9 @@ locals {
   webdispatcher_count = try(var.application.webdispatcher_count, 0)
   scs_server_count    = try(var.application.scs_high_availability, false) ? 2 : 1
 
-  zones = try (var.databases[0].zones, [])
-  
+  db_zones  = try(var.databases[0].zones, [])
+  app_zones = try(var.application.app_zones, [])
+  scs_zones = try(var.application.scs_zones, [])
+  web_zones = try(var.application.web_zones, [])
 
 }

--- a/deploy/terraform/terraform-units/modules/sap_namegenerator/output.tf
+++ b/deploy/terraform/terraform-units/modules/sap_namegenerator/output.tf
@@ -22,15 +22,17 @@ output naming {
       VNET     = local.vnet_keyvault_name
     }
     virtualmachine_names = {
-      ANYDB_COMPUTERNAME = concat(local.anydb_computer_names, local.anydb_computer_names_ha)
-      ANYDB_VMNAME       = concat(local.anydb_vm_names, local.anydb_vm_names_ha)
-      APP_COMPUTERNAME   = local.app_server_names
-      DEPLOYER           = local.deployer_vm_names
-      HANA_COMPUTERNAME  = concat(local.hana_computer_names, local.hana_computer_names_ha)
-      HANA_VMNAME        = concat(local.hana_server_vm_names, local.hana_server_vm_names_ha)
-      ISCSI_COMPUTERNAME = local.iscsi_server_names
-      SCS_COMPUTERNAME   = local.scs_server_names
-      WEB_COMPUTERNAME   = local.web_server_names
+      ANCHOR_COMPUTERNAME = local.anchor_server_names
+      ANYDB_COMPUTERNAME  = concat(local.anydb_computer_names, local.anydb_computer_names_ha)
+      ANYDB_VMNAME        = concat(local.anydb_vm_names, local.anydb_vm_names_ha)
+      APP_COMPUTERNAME    = local.app_server_names
+      APP_VMNAME          = local.app_server_vm_names
+      DEPLOYER            = local.deployer_vm_names
+      HANA_COMPUTERNAME   = concat(local.hana_computer_names, local.hana_computer_names_ha)
+      HANA_VMNAME         = concat(local.hana_server_vm_names, local.hana_server_vm_names_ha)
+      ISCSI_COMPUTERNAME  = local.iscsi_server_names
+      SCS_COMPUTERNAME    = local.scs_server_names
+      WEB_COMPUTERNAME    = local.web_server_names
     }
     resource_suffixes = var.resource_suffixes
   }

--- a/deploy/terraform/terraform-units/modules/sap_namegenerator/output.tf
+++ b/deploy/terraform/terraform-units/modules/sap_namegenerator/output.tf
@@ -32,7 +32,9 @@ output naming {
       HANA_VMNAME         = concat(local.hana_server_vm_names, local.hana_server_vm_names_ha)
       ISCSI_COMPUTERNAME  = local.iscsi_server_names
       SCS_COMPUTERNAME    = local.scs_server_names
+      SCS_VMNAME          = local.scs_server_vm_names
       WEB_COMPUTERNAME    = local.web_server_names
+      WEB_VMNAME          = local.web_server_vm_names
     }
     resource_suffixes = var.resource_suffixes
   }

--- a/deploy/terraform/terraform-units/modules/sap_namegenerator/output.tf
+++ b/deploy/terraform/terraform-units/modules/sap_namegenerator/output.tf
@@ -25,15 +25,15 @@ output naming {
       ANCHOR_COMPUTERNAME = local.anchor_server_names
       ANYDB_COMPUTERNAME  = concat(local.anydb_computer_names, local.anydb_computer_names_ha)
       ANYDB_VMNAME        = concat(local.anydb_vm_names, local.anydb_vm_names_ha)
-      APP_COMPUTERNAME    = local.app_server_names
+      APP_COMPUTERNAME    = local.app_computer_names
       APP_VMNAME          = local.app_server_vm_names
       DEPLOYER            = local.deployer_vm_names
       HANA_COMPUTERNAME   = concat(local.hana_computer_names, local.hana_computer_names_ha)
       HANA_VMNAME         = concat(local.hana_server_vm_names, local.hana_server_vm_names_ha)
       ISCSI_COMPUTERNAME  = local.iscsi_server_names
-      SCS_COMPUTERNAME    = local.scs_server_names
+      SCS_COMPUTERNAME    = local.scs_computer_names
       SCS_VMNAME          = local.scs_server_vm_names
-      WEB_COMPUTERNAME    = local.web_server_names
+      WEB_COMPUTERNAME    = local.web_computer_names
       WEB_VMNAME          = local.web_server_vm_names
     }
     resource_suffixes = var.resource_suffixes

--- a/deploy/terraform/terraform-units/modules/sap_namegenerator/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_namegenerator/variables_local.tf
@@ -241,6 +241,31 @@ variable zones {
   default = []
 }
 
+variable app_zones {
+  type        = list(string)
+  description = "List of availability zones for application tier"
+  default = []
+}
+
+variable scs_zones {
+  type        = list(string)
+  description = "List of availability zones for scs tier"
+  default = []
+}
+
+variable web_zones {
+  type        = list(string)
+  description = "List of availability zones for web tier"
+  default = []
+}
+
+variable db_zones {
+  type        = list(string)
+  description = "List of availability zones for db tier"
+  default = []
+}
+
+
 locals {
 
   location_short = upper(try(var.region_mapping[var.location], "unkn"))

--- a/deploy/terraform/terraform-units/modules/sap_namegenerator/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_namegenerator/variables_local.tf
@@ -235,12 +235,6 @@ variable resource_suffixes {
   }
 }
 
-variable zones {
-  type        = list(string)
-  description = "List of availability zones"
-  default = []
-}
-
 variable app_zones {
   type        = list(string)
   description = "List of availability zones for application tier"
@@ -277,6 +271,7 @@ locals {
   random_id_verified    = upper(substr(var.random_id, 0, var.sapautomation_name_limits.random_id_length))
   random_id_vm_verified = lower(substr(var.random_id, 0, var.sapautomation_name_limits.random_id_length))
 
-  zonal_deployment = try(length(var.zones),0) > 0 ? true : false
+  zones            = distinct(concat(var.db_zones, var.app_zones, var.scs_zones, var.web_zones))
+  zonal_deployment = try(length(local.zones),0) > 0 ? true : false
 }
 

--- a/deploy/terraform/terraform-units/modules/sap_namegenerator/vm.tf
+++ b/deploy/terraform/terraform-units/modules/sap_namegenerator/vm.tf
@@ -4,7 +4,7 @@ locals {
   app_oscode      = upper(var.app_ostype) == "LINUX" ? "l" : "w"
   db_platformcode = substr(var.db_platform, 0, 3)
 
-  anchor_server_names = [for idx in range(length(var.zones)) :
+  anchor_server_names = [for idx in range(length(local.zones)) :
     format("%sanchor%02d%s%s", lower(var.sap_sid), idx, local.app_oscode, local.random_id_vm_verified)
   ]
 
@@ -42,7 +42,6 @@ locals {
     local.zonal_deployment ? (
       format("%sapp_z%s_%02d%s%s", lower(var.sap_sid), var.app_zones[idx % length(var.app_zones)], idx, local.app_oscode, local.random_id_vm_verified)) : (
       format("%sapp%02d%s%s", lower(var.sap_sid), idx, local.app_oscode, local.random_id_vm_verified)
-
     )
   ]
 
@@ -76,8 +75,22 @@ locals {
     format("%sscs%02d%s%s", lower(var.sap_sid), idx, local.app_oscode, local.random_id_vm_verified)
   ]
 
+  scs_server_vm_names = [for idx in range(var.scs_server_count) :
+    local.zonal_deployment ? (
+      format("%sscs_z%s_%02d%s%s", lower(var.sap_sid), var.scs_zones[idx % length(var.scs_zones)], idx, local.app_oscode, local.random_id_vm_verified)) : (
+      format("%sscs%02d%s%s", lower(var.sap_sid), idx, local.app_oscode, local.random_id_vm_verified)
+    )
+  ]
+
   web_server_names = [for idx in range(var.web_server_count) :
     format("%sweb%02d%s%s", lower(var.sap_sid), idx, local.app_oscode, local.random_id_vm_verified)
+  ]
+
+  web_server_vm_names = [for idx in range(var.scs_server_count) :
+    local.zonal_deployment ? (
+      format("%sweb_z%s_%02d%s%s", lower(var.sap_sid), var.web_zones[idx % length(var.web_zones)], idx, local.app_oscode, local.random_id_vm_verified)) : (
+      format("%sweb%02d%s%s", lower(var.sap_sid), idx, local.app_oscode, local.random_id_vm_verified)
+    )
   ]
 
 }

--- a/deploy/terraform/terraform-units/modules/sap_namegenerator/vm.tf
+++ b/deploy/terraform/terraform-units/modules/sap_namegenerator/vm.tf
@@ -22,20 +22,28 @@ locals {
 
   anydb_vm_names = [for idx in range(var.db_server_count) :
     local.zonal_deployment ? (
-      format("%sd%s_z%s_%02dl%d%s", lower(var.sap_sid), lower(var.db_sid), var.zones[idx % length(var.zones)], idx, 0, local.random_id_vm_verified)) : (
+      format("%sd%s_z%s_%02dl%d%s", lower(var.sap_sid), lower(var.db_sid), var.db_zones[idx % length(var.db_zones)], idx, 0, local.random_id_vm_verified)) : (
       format("%sd%s%02dl%d%s", lower(var.sap_sid), lower(var.db_sid), idx, 0, local.random_id_vm_verified)
     )
   ]
 
   anydb_vm_names_ha = [for idx in range(var.db_server_count) :
     local.zonal_deployment ? (
-      format("%sd%s_z%s_%02dl%d%s", lower(var.sap_sid), lower(var.db_sid), var.zones[idx % length(var.zones)], idx, 1, local.random_id_vm_verified)) : (
+      format("%sd%s_z%s_%02dl%d%s", lower(var.sap_sid), lower(var.db_sid), var.db_zones[idx % length(var.db_zones)], idx, 1, local.random_id_vm_verified)) : (
       format("%sd%s%02dl%d%s", lower(var.sap_sid), lower(var.db_sid), idx, 1, local.random_id_vm_verified)
     )
   ]
 
   app_server_names = [for idx in range(var.app_server_count) :
     format("%sapp%02d%s%s", lower(var.sap_sid), idx, local.app_oscode, local.random_id_vm_verified)
+  ]
+
+  app_server_vm_names = [for idx in range(var.app_server_count) :
+    local.zonal_deployment ? (
+      format("%sapp_z%s_%02d%s%s", lower(var.sap_sid), var.app_zones[idx % length(var.app_zones)], idx, local.app_oscode, local.random_id_vm_verified)) : (
+      format("%sapp%02d%s%s", lower(var.sap_sid), idx, local.app_oscode, local.random_id_vm_verified)
+
+    )
   ]
 
   iscsi_server_names = [for idx in range(var.iscsi_server_count) :
@@ -52,14 +60,14 @@ locals {
 
   hana_server_vm_names = [for idx in range(var.db_server_count) :
     local.zonal_deployment ? (
-      format("%sd%s_z%s_%02dl%d%s", lower(var.sap_sid), lower(var.db_sid), var.zones[idx % length(var.zones)], idx, 0, local.random_id_vm_verified)) : (
+      format("%sd%s_z%s_%02dl%d%s", lower(var.sap_sid), lower(var.db_sid), var.db_zones[idx % length(var.db_zones)], idx, 0, local.random_id_vm_verified)) : (
       format("%sd%s%02dl%d%s", lower(var.sap_sid), lower(var.db_sid), idx, 0, local.random_id_vm_verified)
     )
   ]
 
   hana_server_vm_names_ha = [for idx in range(var.db_server_count) :
     local.zonal_deployment ? (
-      format("%sd%s_z%s_%02dl%d%s", lower(var.sap_sid), lower(var.db_sid), var.zones[idx % length(var.zones)], idx, 1, local.random_id_vm_verified)) : (
+      format("%sd%s_z%s_%02dl%d%s", lower(var.sap_sid), lower(var.db_sid), var.db_zones[idx % length(var.db_zones)], idx, 1, local.random_id_vm_verified)) : (
       format("%sd%s%02dl%d%s", lower(var.sap_sid), lower(var.db_sid), idx, 1, local.random_id_vm_verified)
     )
   ]

--- a/deploy/terraform/terraform-units/modules/sap_namegenerator/vm.tf
+++ b/deploy/terraform/terraform-units/modules/sap_namegenerator/vm.tf
@@ -34,7 +34,7 @@ locals {
     )
   ]
 
-  app_server_names = [for idx in range(var.app_server_count) :
+  app_computer_names = [for idx in range(var.app_server_count) :
     format("%sapp%02d%s%s", lower(var.sap_sid), idx, local.app_oscode, local.random_id_vm_verified)
   ]
 
@@ -71,7 +71,7 @@ locals {
     )
   ]
 
-  scs_server_names = [for idx in range(var.scs_server_count) :
+  scs_computer_names = [for idx in range(var.scs_server_count) :
     format("%sscs%02d%s%s", lower(var.sap_sid), idx, local.app_oscode, local.random_id_vm_verified)
   ]
 
@@ -82,7 +82,7 @@ locals {
     )
   ]
 
-  web_server_names = [for idx in range(var.web_server_count) :
+  web_computer_names = [for idx in range(var.web_server_count) :
     format("%sweb%02d%s%s", lower(var.sap_sid), idx, local.app_oscode, local.random_id_vm_verified)
   ]
 


### PR DESCRIPTION
## Problem
The current naming module does not cater for zonal information in the VM resource name

## Solution
Separate the computer name and the VM resource name to two different lists, this allows us to keep the 14 character computername length but provide additional information in the VM resource name

## Tests
<Please provide steps to test the PR>

## Notes
<Additional comments for the PR>