### PR TITLE
Add support for specifying different images for the components in the application tier

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/variables_local.tf
@@ -140,7 +140,7 @@ locals {
   // If custom image is used, we do not overwrite os reference with default value
   // If no publisher or no custom image is specified use the custom image from the app if specified
   scs_publisher_empty = try(var.application.scs_os.publisher, "") == "" ? true : false
-  scs_custom_image    = try(var.application.scs_os.source_image_id, "") && local.scs_publisher_empty && local.app_custom_image ? true : false
+  scs_custom_image    = try(var.application.scs_os.source_image_id, "") == "" && ! local.app_custom_image ? false : true
 
   scs_os = {
     "source_image_id" = local.scs_custom_image ? try(var.application.scs_os.source_image_id, var.application.os.source_image_id) : ""
@@ -154,7 +154,7 @@ locals {
   // If custom image is used, we do not overwrite os reference with default value
   // If no publisher or no custom image is specified use the custom image from the app if specified
   web_publisher_empty = try(var.application.web_os.publisher, "") == "" ? true : false
-  web_custom_image    = try(var.application.web_os.source_image_id, "") && local.web_publisher_empty && local.app_custom_image ? true : false
+  web_custom_image    = try(var.application.web_os.source_image_id, "") == "" && ! local.app_custom_image ? false : true
 
   web_os = {
     "source_image_id" = local.web_custom_image ? var.application.web_os.source_image_id : ""
@@ -163,10 +163,7 @@ locals {
     "sku"             = try(var.application.web_os.sku, local.web_custom_image ? "" : local.app_os.sku)
     "version"         = try(var.application.web_os.version, local.web_custom_image ? "" : local.app_os.version)
   }
-
-
 }
-
 
 locals {
   // Subnet IP Offsets

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/variables_local.tf
@@ -139,7 +139,6 @@ locals {
   // OS image for all SCS VMs
   // If custom image is used, we do not overwrite os reference with default value
   // If no publisher or no custom image is specified use the custom image from the app if specified
-  scs_publisher_empty = try(var.application.scs_os.publisher, "") == "" ? true : false
   scs_custom_image    = try(var.application.scs_os.source_image_id, "") == "" && ! local.app_custom_image ? false : true
 
   scs_os = {
@@ -153,7 +152,6 @@ locals {
   // OS image for all WebDispatcher VMs
   // If custom image is used, we do not overwrite os reference with default value
   // If no publisher or no custom image is specified use the custom image from the app if specified
-  web_publisher_empty = try(var.application.web_os.publisher, "") == "" ? true : false
   web_custom_image    = try(var.application.web_os.source_image_id, "") == "" && ! local.app_custom_image ? false : true
 
   web_os = {

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/variables_local.tf
@@ -136,6 +136,31 @@ locals {
     "version"         = try(var.application.os.version, local.app_custom_image ? "" : "latest")
   }
 
+  // OS image for all SCS VMs
+  // If custom image is used, we do not overwrite os reference with default value
+  scs_custom_image = try(var.application.scs_os.source_image_id, "") != "" ? true : false
+
+  scs_os = {
+    "source_image_id" = local.scs_custom_image ? var.application.scs_os.source_image_id : ""
+    "publisher"       = try(var.application.scs_os.publisher, local.scs_custom_image ? "" : local.app_os.publisher)
+    "offer"           = try(var.application.scs_os.offer, local.scs_custom_image ? "" : local.app_os.offer)
+    "sku"             = try(var.application.scs_os.sku, local.scs_custom_image ? "" : local.app_os.sku)
+    "version"         = try(var.application.scs_os.version, local.scs_custom_image ? "" : local.app_os.version)
+  }
+
+  // OS image for all WebDispatcher VMs
+  // If custom image is used, we do not overwrite os reference with default value
+  web_custom_image = try(var.application.web_os.source_image_id, "") != "" ? true : false
+
+  web_os = {
+    "source_image_id" = local.web_custom_image ? var.application.web_os.source_image_id : ""
+    "publisher"       = try(var.application.web_os.publisher, local.web_custom_image ? "" : local.app_os.publisher)
+    "offer"           = try(var.application.web_os.offer, local.web_custom_image ? "" : local.app_os.offer)
+    "sku"             = try(var.application.web_os.sku, local.web_custom_image ? "" : local.app_os.sku)
+    "version"         = try(var.application.web_os.version, local.web_custom_image ? "" : local.app_os.version)
+  }
+
+
 }
 
 

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-scs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-scs.tf
@@ -57,15 +57,15 @@ resource "azurerm_linux_virtual_machine" "scs" {
     storage_account_type = "Standard_LRS"
   }
 
-  source_image_id = local.app_custom_image ? local.app_os.source_image_id : null
+  source_image_id = local.scs_custom_image ? local.scs_os.source_image_id : null
 
   dynamic "source_image_reference" {
-    for_each = range(local.app_custom_image ? 0 : 1)
+    for_each = range(local.scs_custom_image ? 0 : 1)
     content {
-      publisher = local.app_os.publisher
-      offer     = local.app_os.offer
-      sku       = local.app_os.sku
-      version   = local.app_os.version
+      publisher = local.scs_os.publisher
+      offer     = local.scs_os.offer
+      sku       = local.scs_os.sku
+      version   = local.scs_os.version
     }
   }
 
@@ -114,15 +114,15 @@ resource "azurerm_windows_virtual_machine" "scs" {
     storage_account_type = "Standard_LRS"
   }
 
-  source_image_id = local.app_custom_image ? local.app_os.source_image_id : null
+  source_image_id = local.scs_custom_image ? local.scs_os.source_image_id : null
 
   dynamic "source_image_reference" {
-    for_each = range(local.app_custom_image ? 0 : 1)
+    for_each = range(local.scs_custom_image ? 0 : 1)
     content {
-      publisher = local.app_os.publisher
-      offer     = local.app_os.offer
-      sku       = local.app_os.sku
-      version   = local.app_os.version
+      publisher = local.scs_os.publisher
+      offer     = local.scs_os.offer
+      sku       = local.scs_os.sku
+      version   = local.scs_os.version
     }
   }
 

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-webdisp.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-webdisp.tf
@@ -51,15 +51,15 @@ resource "azurerm_linux_virtual_machine" "web" {
     storage_account_type = "Standard_LRS"
   }
 
-  source_image_id = local.app_custom_image ? local.app_os.source_image_id : null
+  source_image_id = local.web_custom_image ? local.web_os.source_image_id : null
 
   dynamic "source_image_reference" {
-    for_each = range(local.app_custom_image ? 0 : 1)
+    for_each = range(local.web_custom_image ? 0 : 1)
     content {
-      publisher = local.app_os.publisher
-      offer     = local.app_os.offer
-      sku       = local.app_os.sku
-      version   = local.app_os.version
+      publisher = local.web_os.publisher
+      offer     = local.web_os.offer
+      sku       = local.web_os.sku
+      version   = local.web_os.version
     }
   }
 
@@ -107,15 +107,15 @@ resource "azurerm_windows_virtual_machine" "web" {
     storage_account_type = "Standard_LRS"
   }
 
-  source_image_id = local.app_custom_image ? local.app_os.source_image_id : null
+  source_image_id = local.web_custom_image ? local.web_os.source_image_id : null
 
   dynamic "source_image_reference" {
-    for_each = range(local.app_custom_image ? 0 : 1)
+    for_each = range(local.web_custom_image ? 0 : 1)
     content {
-      publisher = local.app_os.publisher
-      offer     = local.app_os.offer
-      sku       = local.app_os.sku
-      version   = local.app_os.version
+      publisher = local.web_os.publisher
+      offer     = local.web_os.offer
+      sku       = local.web_os.sku
+      version   = local.web_os.version
     }
   }
 


### PR DESCRIPTION
## Problem
Customers want to deploy the application tier components (app, scs, web) using different operating systems, templates

## Solution
Add the option to specify different OS/template for scs and web VMs. If these are not specified deploy all the tier components using the same configuration as the application tier

## Tests
Add the following section to the json file 
```
 "os": {
      "publisher": "Oracle",
      "offer": "Oracle-Linux",
      "sku": "81",
      "version": "latest"
    },
    "scs_os": {
      "publisher": "suse",
      "offer": "sles-sap-15-sp1",
      "sku": "gen1",
      "version": "latest"
    },
    "web_os": {
      "publisher": "suse",
      "offer": "sles-sap-15-sp1",
      "sku": "gen1",
      "version": "latest"
    },
```

## Notes
Close #758