### PR TITLE
Fix IMDS call for deployer

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_deployer/IMDS.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/IMDS.tf
@@ -27,7 +27,7 @@ resource "null_resource" "IMDS" {
     type        = "ssh"
     host        = azurerm_public_ip.deployer[count.index].ip_address
     user        = local.deployers[count.index].authentication.username
-    private_key = local.deployers[count.index].authentication.type == "key" ? local.deployers[count.index].authentication.sshkey.private_key : null
+    private_key = local.deployers[count.index].authentication.type == "key" ? file(local.deployers[count.index].authentication.sshkey.path_to_private_key) : null
     password    = lookup(local.deployers[count.index].authentication, "password", null)
     timeout     = var.ssh-timeout
   }

--- a/deploy/terraform/terraform-units/modules/sap_deployer/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/variables_local.tf
@@ -69,7 +69,7 @@ locals {
         "type"     = "key",
         "username" = try(deployer.authentication.username, "azureadm"),
         "sshkey" = {
-          "path_to_private_key" = "~/.ssh/id_rsa"
+          "path_to_private_key" = var.sshkey.path_to_private_key
         }
       },
       "components" = [


### PR DESCRIPTION
## Problem
Cherry pick the change for IMDS into naming module does not work since in naming module, we do not generate SSH key pair.

## Solution
Use provided ssh key to call IMDS.

## Tests
Deploy a deployer locally and no longer observe below error:
`Error: Unsupported attribute: This object does not have an attribute named "private_key".
`
## Notes
Sample error: https://dev.azure.com/azuresaphana/Azure-SAP-HANA/_build/results?buildId=12673&view=logs&j=3e7c2453-b9e0-5f22-4314-eb3ec9329da1&t=789e6a3b-4b77-5dbf-5514-8767874c8eb8