### PR TITLE
support spn to deploy sapsystem

### DIFF
--- a/.pipeline/templates/sapsystem/create-sapsystem-steps.yml
+++ b/.pipeline/templates/sapsystem/create-sapsystem-steps.yml
@@ -84,6 +84,14 @@ steps:
       sapsystem_rg="${sapsystem_prefix}-EAUS-SAP-PRD"
       sapland_rg="UNIT-EAUS-SAP0-INFRASTRUCTURE"
 
+      # Store SPN in deployer KV
+      echo "=== Store SPN in deployer KV ==="
+      deployer_kv_name=$(az keyvault list --resource-group ${deployer_rg} | jq -r "'".[] | select(.name | contains(\\\"user\\\")).name"'")
+      az keyvault secret set --vault-name ${deployer_kv_name} --name ${sapsystem_prefix}-client-id --value $(hana-pipeline-spn-id) --output none
+      az keyvault secret set --vault-name ${deployer_kv_name} --name ${sapsystem_prefix}-client-secret --value $(hana-pipeline-spn-pw) --output none
+      az keyvault secret set --vault-name ${deployer_kv_name} --name ${sapsystem_prefix}-subscription-id --value $(landscape-subscription) --output none
+      az keyvault secret set --vault-name ${deployer_kv_name} --name ${sapsystem_prefix}-tenant-id --value $(landscape-tenant) --output none
+
       # If no osImage provided, deploy SLES12SP5
       [ -z "${{parameters.osImage_offer}}" ] && osImage_offer="sles-sap-12-sp5" || osImage_offer=${{parameters.osImage_offer}}
       [ -z "${{parameters.osImage_publisher}}" ] && osImage_publisher="SUSE" || osImage_publisher=${{parameters.osImage_publisher}}
@@ -117,6 +125,7 @@ steps:
       sap_system_key="${sapsystem_rg}.terraform.tfstate"
       deployer_tfstate_key=$(az storage blob list --account-name ${tfstate_sa_name} --container-name tfstate --only-show-errors | jq -r "'".[] | select(.name | contains(\\\"MGMT-INFRASTRUCTURE\\\")).name"'")
       saplib_tfstate_key=$(az storage blob list --account-name ${tfstate_sa_name} --container-name tfstate --only-show-errors | jq -r "'".[] | select(.name | contains(\\\"LIBRARY\\\")).name"'")
+      tfstate_resource_id=$(az storage account list --resource-group ${saplib_rg} | jq -r "'".[] | select(.name | contains(\\\"tfstate\\\")).id"'")
 
       db_type=${{parameters.db_type}}
       [ -z "$db_type" ] && db="HANA" || db=${db_type}
@@ -124,8 +133,7 @@ steps:
       cp ${repo_dir}/deploy/terraform/run/sap_system/sapsystem.json ${ws_dir}/sapsystem.json
       cat ${ws_dir}/sapsystem.json \
       | jq --arg environment "${sapsystem_prefix}" .infrastructure.environment\ =\ \$environment \
-      | jq --arg saplib_rg "${saplib_rg}" .infrastructure.vnets.management.saplib_resource_group_name\ =\ \$saplib_rg \
-      | jq --arg tfstate_sa_name "${tfstate_sa_name}" .infrastructure.vnets.management.tfstate_storage_account_name\ =\ \$tfstate_sa_name \
+      | jq --arg tfstate_resource_id "${tfstate_resource_id}" .infrastructure.vnets.management.tfstate_resource_id\ =\ \$tfstate_resource_id \
       | jq --arg deployer_tfstate_key "${deployer_tfstate_key}" .infrastructure.vnets.management.deployer_tfstate_key\ =\ \$deployer_tfstate_key \
       | jq .infrastructure.vnets.sap.is_existing\ =\ \"true\" \
       | jq --arg saplandscape_sap_vnet_arm_id "${saplandscape_sap_vnet_arm_id}" .infrastructure.vnets.sap.arm_id\ =\ \$saplandscape_sap_vnet_arm_id \
@@ -158,6 +166,7 @@ steps:
       echo "=== This may take quite a while, please be patient ==="
       terraform -version
       terraform init -upgrade=true -force-copy \
+        --backend-config "subscription_id=$(landscape-subscription)" \
         --backend-config "resource_group_name=${saplib_rg}" \
         --backend-config "storage_account_name=${tfstate_sa_name}" \
         --backend-config "container_name=tfstate" \

--- a/.pipeline/templates/sapsystem/delete-sapsystem-steps.yml
+++ b/.pipeline/templates/sapsystem/delete-sapsystem-steps.yml
@@ -73,6 +73,14 @@ steps:
       az group update --resource-group ${sapsystem_rg} --set tags.Delete=True
       az group delete -n ${sapsystem_rg} --no-wait -y
 
+      # Delete SPN secrets from deployer KV
+      echo "=== Delete SPN secrets from deployer KV ==="
+      deployer_kv_name=$(az keyvault list --resource-group ${deployer_rg} | jq -r '.[] | select(.name | contains("user")).name')
+      az keyvault secret delete --vault-name ${deployer_kv_name} --name ${sapsystem_prefix}-client-id --output none
+      az keyvault secret delete --vault-name ${deployer_kv_name} --name ${sapsystem_prefix}-client-secret --output none
+      az keyvault secret delete --vault-name ${deployer_kv_name} --name ${sapsystem_prefix}-subscription-id --output none
+      az keyvault secret delete --vault-name ${deployer_kv_name} --name ${sapsystem_prefix}-tenant-id --output none
+
       exit 0
     displayName: "Delete new sapsystem"
     env:

--- a/deploy/terraform/run/sap_system/imports.tf
+++ b/deploy/terraform/run/sap_system/imports.tf
@@ -1,0 +1,40 @@
+/*
+    Description:
+      Import deployer resources
+*/
+
+data "terraform_remote_state" "deployer" {
+  backend = "azurerm"
+  config = {
+    resource_group_name  = local.saplib_resource_group_name
+    storage_account_name = local.tfstate_storage_account_name
+    container_name       = local.tfstate_container_name
+    key                  = local.deployer_tfstate_key
+    subscription_id      = local.saplib_subscription_id
+    use_msi              = true
+  }
+}
+
+data "azurerm_key_vault_secret" "subscription_id" {
+  provider     = azurerm.deployer
+  name         = format("%s-subscription-id", local.environment)
+  key_vault_id = local.deployer_key_vault_arm_id
+}
+
+data "azurerm_key_vault_secret" "client_id" {
+  provider     = azurerm.deployer
+  name         = format("%s-client-id", local.environment)
+  key_vault_id = local.deployer_key_vault_arm_id
+}
+
+data "azurerm_key_vault_secret" "client_secret" {
+  provider     = azurerm.deployer
+  name         = format("%s-client-secret", local.environment)
+  key_vault_id = local.deployer_key_vault_arm_id
+}
+
+data "azurerm_key_vault_secret" "tenant_id" {
+  provider     = azurerm.deployer
+  name         = format("%s-tenant-id", local.environment)
+  key_vault_id = local.deployer_key_vault_arm_id
+}

--- a/deploy/terraform/run/sap_system/module.tf
+++ b/deploy/terraform/run/sap_system/module.tf
@@ -43,6 +43,7 @@ module "common_infrastructure" {
   subnet-mgmt         = module.deployer.subnet-mgmt
   nsg-mgmt            = module.deployer.nsg-mgmt
   deployer-uai        = module.deployer.deployer-uai
+  spn                 = local.spn
   // Comment out code with users.object_id for the time being.
   // deployer_user       = module.deployer.deployer_user
 }
@@ -87,7 +88,7 @@ module "hdb_node" {
   ppg              = module.common_infrastructure.ppg
   random-id        = module.common_infrastructure.random-id
   sid_kv_user      = module.common_infrastructure.sid_kv_user
-  sid_kv_user_msi  = module.common_infrastructure.sid_kv_user_msi
+  sid_kv_user_spn  = module.common_infrastructure.sid_kv_user_spn
   deployer-uai     = module.deployer.deployer-uai
   // Comment out code with users.object_id for the time being.
   // deployer_user    = module.deployer.deployer_user
@@ -111,7 +112,7 @@ module "app_tier" {
   ppg              = module.common_infrastructure.ppg
   random-id        = module.common_infrastructure.random-id
   sid_kv_user      = module.common_infrastructure.sid_kv_user
-  sid_kv_user_msi  = module.common_infrastructure.sid_kv_user_msi
+  sid_kv_user_spn  = module.common_infrastructure.sid_kv_user_spn
   deployer-uai     = module.deployer.deployer-uai
   // Comment out code with users.object_id for the time being.  
   // deployer_user    = module.deployer.deployer_user
@@ -134,7 +135,7 @@ module "anydb_node" {
   ppg              = module.common_infrastructure.ppg
   random-id        = module.common_infrastructure.random-id
   sid_kv_user      = module.common_infrastructure.sid_kv_user
-  sid_kv_user_msi  = module.common_infrastructure.sid_kv_user_msi
+  sid_kv_user_spn  = module.common_infrastructure.sid_kv_user_spn
 }
 
 // Generate output files

--- a/deploy/terraform/run/sap_system/providers.tf
+++ b/deploy/terraform/run/sap_system/providers.tf
@@ -13,8 +13,18 @@ Description:
 */
 
 provider "azurerm" {
-  version = "~> 2.25.0"
+  version = "~> 2.32.0"
   features {}
+  subscription_id = local.spn.subscription_id
+  client_id       = local.spn.client_id
+  client_secret   = local.spn.client_secret
+  tenant_id       = local.spn.tenant_id
+}
+
+provider "azurerm" {
+  version = "~> 2.32.0"
+  features {}
+  alias = "deployer"
 }
 
 terraform {

--- a/deploy/terraform/run/sap_system/sapsystem.json
+++ b/deploy/terraform/run/sap_system/sapsystem.json
@@ -12,8 +12,7 @@
     },
     "vnets": {
       "management": {
-        "saplib_resource_group_name": "",
-        "tfstate_storage_account_name": "",
+        "tfstate_resource_id": "",
         "deployer_tfstate_key": ""
       },
       "sap": {

--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/infrastructure.tf
@@ -5,7 +5,6 @@ Load balancer front IP address range: .4 - .9
 resource "azurerm_lb" "anydb" {
   count               = local.enable_deployment ? 1 : 0
   name                = format("%s_db-alb", local.prefix)
-  
   resource_group_name = var.resource-group[0].name
   location            = var.resource-group[0].location
 

--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/key_vault.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/key_vault.tf
@@ -19,18 +19,18 @@ resource "random_password" "password" {
  To force dependency between kv access policy and secrets. Expected behavior:
  https://github.com/terraform-providers/terraform-provider-azurerm/issues/4971
 */
-// store the xdb logon username in KV
+// Store the xdb logon username in KV when authentication type is password
 resource "azurerm_key_vault_secret" "auth_username" {
-  depends_on   = [var.sid_kv_user_msi]
+  depends_on   = [var.sid_kv_user_spn]
   count        = local.enable_auth_password ? 1 : 0
   name         = format("%s-%s-xdb-auth-username", local.prefix, local.sid)
   value        = local.sid_auth_username
   key_vault_id = local.sid_kv_user.id
 }
 
-// store the xdb logon password in KV
+// Store the xdb logon password in KV when authentication type is password
 resource "azurerm_key_vault_secret" "auth_password" {
-  depends_on   = [var.sid_kv_user_msi]
+  depends_on   = [var.sid_kv_user_spn]
   count        = local.enable_auth_password ? 1 : 0
   name         = format("%s-%s-xdb-auth-password", local.prefix, local.sid)
   value        = local.sid_auth_password

--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/variables_local.tf
@@ -22,7 +22,7 @@ variable "sid_kv_user" {
   description = "Details of the user keyvault for sap_system"
 }
 
-variable "sid_kv_user_msi" {
+variable "sid_kv_user_spn" {
   description = "Azurerm_key_vault_access_policy is required to save secrets in KV"
 }
 

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/key_vault.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/key_vault.tf
@@ -20,18 +20,18 @@ resource "random_password" "password" {
  https://github.com/terraform-providers/terraform-provider-azurerm/issues/4971
 */
 
-// store the app logon username in KV
+// Store the app logon username in KV when authentication type is password
 resource "azurerm_key_vault_secret" "app_auth_username" {
-  depends_on   = [var.sid_kv_user_msi]
+  depends_on   = [var.sid_kv_user_spn]
   count        = local.enable_auth_password ? 1 : 0
   name         = format("%s-%s-app-auth-username", local.prefix, local.sid)
   value        = local.sid_auth_username
   key_vault_id = local.sid_kv_user.id
 }
 
-// store the app logon password in KV
+// Store the app logon username in KV when authentication type is password
 resource "azurerm_key_vault_secret" "app_auth_password" {
-  depends_on   = [var.sid_kv_user_msi]
+  depends_on   = [var.sid_kv_user_spn]
   count        = local.enable_auth_password ? 1 : 0
   name         = format("%s-%s-app-auth-password", local.prefix, local.sid)
   value        = local.sid_auth_password

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/variables_local.tf
@@ -35,7 +35,7 @@ variable "sid_kv_user" {
   description = "Details of the user keyvault for sap_system"
 }
 
-variable "sid_kv_user_msi" {
+variable "sid_kv_user_spn" {
   description = "Azurerm_key_vault_access_policy is required to save secrets in KV"
 }
 

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/key_vault_sap_landscape.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/key_vault_sap_landscape.tf
@@ -3,28 +3,24 @@
   Set up key vault for sap landscape
 */
 
-data "azurerm_client_config" "deployer" {}
-
 // Create private KV with access policy
 resource "azurerm_key_vault" "kv_prvt" {
   count                      = local.enable_landscape_kv ? 1 : 0
   name                       = local.kv_private_name
   location                   = local.region
   resource_group_name        = local.rg_exists ? data.azurerm_resource_group.resource-group[0].name : azurerm_resource_group.resource-group[0].name
-  tenant_id                  = data.azurerm_client_config.deployer.tenant_id
+  tenant_id                  = local.spn.tenant_id
   soft_delete_enabled        = true
   soft_delete_retention_days = 7
   purge_protection_enabled   = true
   sku_name                   = "standard"
 }
 
-resource "azurerm_key_vault_access_policy" "kv_prvt_msi" {
+resource "azurerm_key_vault_access_policy" "kv_prvt_spn" {
   count        = local.enable_landscape_kv ? 1 : 0
   key_vault_id = azurerm_key_vault.kv_prvt[0].id
-
-  tenant_id = data.azurerm_client_config.deployer.tenant_id
-  object_id = var.deployer-uai.principal_id
-
+  tenant_id    = local.spn.tenant_id
+  object_id    = local.spn.client_id
   secret_permissions = [
     "get",
   ]
@@ -36,7 +32,7 @@ resource "azurerm_key_vault" "kv_user" {
   name                       = local.kv_user_name
   location                   = local.region
   resource_group_name        = local.rg_exists ? data.azurerm_resource_group.resource-group[0].name : azurerm_resource_group.resource-group[0].name
-  tenant_id                  = data.azurerm_client_config.deployer.tenant_id
+  tenant_id                  = local.spn.tenant_id
   soft_delete_enabled        = true
   soft_delete_retention_days = 7
   purge_protection_enabled   = true
@@ -44,12 +40,11 @@ resource "azurerm_key_vault" "kv_user" {
   sku_name = "standard"
 }
 
-resource "azurerm_key_vault_access_policy" "kv_user_msi" {
+resource "azurerm_key_vault_access_policy" "kv_user_spn" {
   count        = local.enable_landscape_kv ? 1 : 0
   key_vault_id = azurerm_key_vault.kv_user[0].id
-  tenant_id    = data.azurerm_client_config.deployer.tenant_id
-  object_id    = var.deployer-uai.principal_id
-
+  tenant_id    = local.spn.tenant_id
+  object_id    = local.spn.client_id
   secret_permissions = [
     "delete",
     "get",
@@ -83,7 +78,7 @@ resource "tls_private_key" "iscsi" {
 }
 
 resource "azurerm_key_vault_secret" "iscsi_ppk" {
-  depends_on   = [azurerm_key_vault_access_policy.kv_user_msi]
+  depends_on   = [azurerm_key_vault_access_policy.kv_user_spn]
   count        = (local.enable_landscape_kv && local.enable_iscsi_auth_key) ? 1 : 0
   name         = format("%s-iscsi-sshkey", local.prefix)
   value        = local.iscsi_private_key
@@ -91,7 +86,7 @@ resource "azurerm_key_vault_secret" "iscsi_ppk" {
 }
 
 resource "azurerm_key_vault_secret" "iscsi_pk" {
-  depends_on   = [azurerm_key_vault_access_policy.kv_user_msi]
+  depends_on   = [azurerm_key_vault_access_policy.kv_user_spn]
   count        = (local.enable_landscape_kv && local.enable_iscsi_auth_key) ? 1 : 0
   name         = format("%s-iscsi-sshkey-pub", local.prefix)
   value        = local.iscsi_public_key
@@ -103,7 +98,7 @@ resource "azurerm_key_vault_secret" "iscsi_pk" {
  https://github.com/terraform-providers/terraform-provider-azurerm/issues/4971
 */
 resource "azurerm_key_vault_secret" "iscsi_username" {
-  depends_on   = [azurerm_key_vault_access_policy.kv_user_msi]
+  depends_on   = [azurerm_key_vault_access_policy.kv_user_spn]
   count        = (local.enable_landscape_kv && local.enable_iscsi_auth_password) ? 1 : 0
   name         = format("%s-iscsi-username", local.prefix)
   value        = local.iscsi_auth_username
@@ -111,7 +106,7 @@ resource "azurerm_key_vault_secret" "iscsi_username" {
 }
 
 resource "azurerm_key_vault_secret" "iscsi_password" {
-  depends_on   = [azurerm_key_vault_access_policy.kv_user_msi]
+  depends_on   = [azurerm_key_vault_access_policy.kv_user_spn]
   count        = (local.enable_landscape_kv && local.enable_iscsi_auth_password) ? 1 : 0
   name         = format("%s-iscsi-password", local.prefix)
   value        = local.iscsi_auth_password
@@ -136,7 +131,7 @@ resource "tls_private_key" "sid" {
 }
 
 resource "azurerm_key_vault_secret" "sid_ppk" {
-  depends_on   = [azurerm_key_vault_access_policy.kv_user_msi]
+  depends_on   = [azurerm_key_vault_access_policy.kv_user_spn]
   count        = local.enable_landscape_kv ? 1 : 0
   name         = format("%s-sid-sshkey", local.prefix)
   value        = local.sid_private_key
@@ -144,7 +139,7 @@ resource "azurerm_key_vault_secret" "sid_ppk" {
 }
 
 resource "azurerm_key_vault_secret" "sid_pk" {
-  depends_on   = [azurerm_key_vault_access_policy.kv_user_msi]
+  depends_on   = [azurerm_key_vault_access_policy.kv_user_spn]
   count        = local.enable_landscape_kv ? 1 : 0
   name         = format("%s-sid-sshkey-pub", local.prefix)
   value        = local.sid_public_key

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/key_vault_sap_system.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/key_vault_sap_system.tf
@@ -10,20 +10,18 @@ resource "azurerm_key_vault" "sid_kv_prvt" {
   name                       = local.sid_kv_private_name
   location                   = local.region
   resource_group_name        = local.rg_exists ? data.azurerm_resource_group.resource-group[0].name : azurerm_resource_group.resource-group[0].name
-  tenant_id                  = data.azurerm_client_config.deployer.tenant_id
+  tenant_id                  = local.spn.tenant_id
   soft_delete_enabled        = true
   soft_delete_retention_days = 7
   purge_protection_enabled   = true
   sku_name                   = "standard"
 }
 
-resource "azurerm_key_vault_access_policy" "sid_kv_prvt_msi" {
+resource "azurerm_key_vault_access_policy" "sid_kv_prvt_spn" {
   count        = local.enable_sid_deployment ? 1 : 0
   key_vault_id = azurerm_key_vault.sid_kv_prvt[0].id
-
-  tenant_id = data.azurerm_client_config.deployer.tenant_id
-  object_id = var.deployer-uai.principal_id
-
+  tenant_id    = local.spn.tenant_id
+  object_id    = local.spn.client_id
   secret_permissions = [
     "get",
   ]
@@ -35,20 +33,18 @@ resource "azurerm_key_vault" "sid_kv_user" {
   name                       = local.sid_kv_user_name
   location                   = local.region
   resource_group_name        = local.rg_exists ? data.azurerm_resource_group.resource-group[0].name : azurerm_resource_group.resource-group[0].name
-  tenant_id                  = data.azurerm_client_config.deployer.tenant_id
+  tenant_id                  = local.spn.tenant_id
   soft_delete_enabled        = true
   soft_delete_retention_days = 7
   purge_protection_enabled   = true
-
-  sku_name = "standard"
+  sku_name                   = "standard"
 }
 
-resource "azurerm_key_vault_access_policy" "sid_kv_user_msi" {
+resource "azurerm_key_vault_access_policy" "sid_kv_user_spn" {
   count        = local.enable_sid_deployment ? 1 : 0
   key_vault_id = azurerm_key_vault.sid_kv_user[0].id
-  tenant_id    = data.azurerm_client_config.deployer.tenant_id
-  object_id    = var.deployer-uai.principal_id
-
+  tenant_id    = local.spn.tenant_id
+  object_id    = local.spn.client_id
   secret_permissions = [
     "delete",
     "get",

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/outputs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/outputs.tf
@@ -50,6 +50,6 @@ output "sid_kv_prvt" {
  To force dependency between kv access policy and secrets. Expected behavior:
  https://github.com/terraform-providers/terraform-provider-azurerm/issues/4971
 */
-output "sid_kv_user_msi" {
-  value = azurerm_key_vault_access_policy.sid_kv_user_msi
+output "sid_kv_user_spn" {
+  value = azurerm_key_vault_access_policy.sid_kv_user_spn
 }

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/variables_local.tf
@@ -25,6 +25,10 @@ variable "nsg-mgmt" {
   description = "Details about management nsg of deployer(s)"
 }
 
+variable "spn" {
+  description = "Current SPN used to authenticate to Azure"
+}
+
 variable "deployer-uai" {
   description = "Details of the UAI used by deployer(s)"
 }
@@ -140,7 +144,7 @@ locals {
   // Post fix for all deployed resources
   postfix = random_id.saplandscape.hex
 
-/* Comment out code with users.object_id for the time being
+  /* Comment out code with users.object_id for the time being
   // Additional users add to user KV
   kv_users = var.deployer_user
 */
@@ -397,5 +401,8 @@ locals {
   software = merge(var.software, {
     downloader = local.downloader
   })
+
+  // SPN
+  spn = try(var.spn, {})
 
 }

--- a/deploy/terraform/terraform-units/modules/sap_system/deployer/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/deployer/variables_local.tf
@@ -47,9 +47,11 @@ locals {
   region         = lower(try(var.infrastructure.region, ""))
   location_short = lower(try(var.region_mapping[local.region], "unkn"))
 
-  // Default value follows naming convention
-  saplib_resource_group_name   = try(local.deployer_config.saplib_resource_group_name, "${local.environment}-${local.location_short}-sap_library")
-  tfstate_storage_account_name = try(local.deployer_config.tfstate_storage_account_name, "")
+  // Locate the tfstate storage account
+  tfstate_resource_id          = try(local.deployer_config.tfstate_resource_id, "")
+  saplib_subscription_id       = split("/", local.tfstate_resource_id)[2]
+  saplib_resource_group_name   = split("/", local.tfstate_resource_id)[4]
+  tfstate_storage_account_name = split("/", local.tfstate_resource_id)[8]
   tfstate_container_name       = "tfstate"
   deployer_tfstate_key         = try(local.deployer_config.deployer_tfstate_key, "${local.environment}-${local.location_short}-deployer-infrastructure.terraform.tfstate")
 }

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/key_vault.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/key_vault.tf
@@ -19,18 +19,18 @@ resource "random_password" "password" {
  To force dependency between kv access policy and secrets. Expected behavior:
  https://github.com/terraform-providers/terraform-provider-azurerm/issues/4971
 */
-// store the hdb logon username in KV
+// Store the hdb logon username in KV when authentication type is password
 resource "azurerm_key_vault_secret" "auth_username" {
-  depends_on   = [var.sid_kv_user_msi]
+  depends_on   = [var.sid_kv_user_spn]
   count        = local.enable_auth_password ? 1 : 0
   name         = format("%s-%s-hdb-auth-username", local.prefix, local.sid)
   value        = local.sid_auth_username
   key_vault_id = local.sid_kv_user.id
 }
 
-// store the hdb logon password in KV
+// Store the hdb logon username in KV when authentication type is password
 resource "azurerm_key_vault_secret" "auth_password" {
-  depends_on   = [var.sid_kv_user_msi]
+  depends_on   = [var.sid_kv_user_spn]
   count        = local.enable_auth_password ? 1 : 0
   name         = format("%s-%s-hdb-auth-password", local.prefix, local.sid)
   value        = local.sid_auth_password

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/variables_local.tf
@@ -39,7 +39,7 @@ variable "sid_kv_user" {
   description = "Details of the user keyvault for sap_system"
 }
 
-variable "sid_kv_user_msi" {
+variable "sid_kv_user_spn" {
   description = "Azurerm_key_vault_access_policy is required to save secrets in KV"
 }
 


### PR DESCRIPTION
## Problem
<Please describe what problem this PR is trying to resolve>
This pr is to support deploying sap system/sap landscape by using SPN.
Only single subscription is supported.

## Solution
<Please elaborate the solution for the problem>

- Multi provider is used. Provider "deployer" is to retrieve SPN from deployer's KV.

- A default provider will be used to deploy resources.

- SPN will be authorized to access KV, instead of msi

-  tfstate_resource_id will be added into input json, remove saplib_rg, and storage account name from input json

- Test Pipeline is updated to test the new feature.

## Tests
<Please provide steps to test the PR>
See tests in test pipeline below.

## Notes
<Additional comments for the PR>