### PR TITLE
Clean software block and the related logic

### DIFF
--- a/.pipeline/templates/saplandscape/create-saplandscape-steps.yml
+++ b/.pipeline/templates/saplandscape/create-saplandscape-steps.yml
@@ -90,13 +90,21 @@ steps:
       sap_landscape_key="${saplandscape_rg}.terraform.tfstate"
       deployer_tfstate_key=$(az storage blob list --account-name ${tfstate_sa_name} --container-name tfstate --only-show-errors | jq -r "'".[] | select(.name | contains(\\\"MGMT-INFRASTRUCTURE\\\")).name"'")
       saplib_tfstate_key=$(az storage blob list --account-name ${tfstate_sa_name} --container-name tfstate --only-show-errors | jq -r "'".[] | select(.name | contains(\\\"LIBRARY\\\")).name"'")
+      tfstate_resource_id=$(az storage account list --resource-group ${saplib_rg} | jq -r "'".[] | select(.name | contains(\\\"tfstate\\\")).id"'")
+
+      # Store SPN in deployer KV
+      echo "=== Store SPN in deployer KV ==="
+      deployer_kv_name=$(az keyvault list --resource-group ${deployer_rg} | jq -r "'".[] | select(.name | contains(\\\"user\\\")).name"'")
+      az keyvault secret set --vault-name ${deployer_kv_name} --name ${saplandscape_prefix}-client-id --value $(hana-pipeline-spn-id) --output none
+      az keyvault secret set --vault-name ${deployer_kv_name} --name ${saplandscape_prefix}-client-secret --value $(hana-pipeline-spn-pw) --output none
+      az keyvault secret set --vault-name ${deployer_kv_name} --name ${saplandscape_prefix}-subscription-id --value $(landscape-subscription) --output none
+      az keyvault secret set --vault-name ${deployer_kv_name} --name ${saplandscape_prefix}-tenant-id --value $(landscape-tenant) --output none
 
       cp ${repo_dir}/deploy/terraform/run/sap_landscape/saplandscape.json ${ws_dir}/saplandscape.json
       cat ${ws_dir}/saplandscape.json \
       | jq --arg saplandscape_rg "${saplandscape_rg}" .infrastructure.resource_group.name\ =\ \$saplandscape_rg \
       | jq --arg environment "${saplandscape_prefix}" .infrastructure.environment\ =\ \$environment \
-      | jq --arg saplib_rg "${saplib_rg}" .infrastructure.vnets.management.saplib_resource_group_name\ =\ \$saplib_rg \
-      | jq --arg tfstate_sa_name "${tfstate_sa_name}" .infrastructure.vnets.management.tfstate_storage_account_name\ =\ \$tfstate_sa_name \
+      | jq --arg tfstate_resource_id "${tfstate_resource_id}" .infrastructure.vnets.management.tfstate_resource_id\ =\ \$tfstate_resource_id \
       | jq --arg deployer_tfstate_key "${deployer_tfstate_key}" .infrastructure.vnets.management.deployer_tfstate_key\ =\ \$deployer_tfstate_key \
       | jq --arg sap_vnet_address_space "${sap_vnet_address_space}" .infrastructure.vnets.sap.address_space\ =\ \$sap_vnet_address_space \
       | jq --arg subnet_iscsi_prefix "${subnet_iscsi_prefix}" .infrastructure.vnets.sap.subnet_iscsi.prefix\ =\ \$subnet_iscsi_prefix \

--- a/.pipeline/templates/saplandscape/delete-saplandscape-steps.yml
+++ b/.pipeline/templates/saplandscape/delete-saplandscape-steps.yml
@@ -20,12 +20,12 @@ steps:
 
       if [ -z "${isRelease}" ]
       then 
-        sapsystem_prefix="U$(echo $(Build.BuildId) | rev | cut -c1-4 | rev)"
+        saplandscape_prefix="U$(echo $(Build.BuildId) | rev | cut -c1-4 | rev)"
       else
-        sapsystem_prefix=${saplandscape_env}
+        saplandscape_prefix=${saplandscape_env}
       fi
 
-      saplandscape_rg="${sapsystem_prefix}-EAUS-SAP0-INFRASTRUCTURE"
+      saplandscape_rg="${saplandscape_prefix}-EAUS-SAP0-INFRASTRUCTURE"
 
       echo "=== Delete SAP system from deployer ==="
       ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no -o ConnectTimeout=$(ssh_timeout_s) "$(username)"@"$(publicIP)" '
@@ -38,12 +38,12 @@ steps:
 
       if [ -z "${isRelease}" ]
       then 
-        sapsystem_prefix="U$(echo $(Build.BuildId) | rev | cut -c1-4 | rev)"
+        saplandscape_prefix="U$(echo $(Build.BuildId) | rev | cut -c1-4 | rev)"
       else
-        sapsystem_prefix=${saplandscape_env}
+        saplandscape_prefix=${saplandscape_env}
       fi
 
-      saplandscape_rg="${sapsystem_prefix}-EAUS-SAP0-INFRASTRUCTURE"
+      saplandscape_rg="${saplandscape_prefix}-EAUS-SAP0-INFRASTRUCTURE"
 
       repo_dir=$HOME/$saplandscape_rg/sap-hana
       ws_dir=$HOME/Azure_SAP_Automated_Deployment/WORKSPACES/SAP_LANDSCAPE/${saplandscape_rg}
@@ -73,6 +73,14 @@ steps:
       az login --service-principal --user $(hana-pipeline-spn-id) --password $(hana-pipeline-spn-pw) --tenant $(landscape-tenant) --output none
       az group update --resource-group ${saplandscape_rg} --set tags.Delete=True
       az group delete -n ${saplandscape_rg} --no-wait -y
+
+      # Delete SPN secrets from deployer KV
+      echo "=== Delete SPN secrets from deployer KV ==="
+      deployer_kv_name=$(az keyvault list --resource-group ${deployer_rg} | jq -r '.[] | select(.name | contains("user")).name')
+      az keyvault secret delete --vault-name ${deployer_kv_name} --name ${saplandscape_prefix}-client-id --output none
+      az keyvault secret delete --vault-name ${deployer_kv_name} --name ${saplandscape_prefix}-client-secret --output none
+      az keyvault secret delete --vault-name ${deployer_kv_name} --name ${saplandscape_prefix}-subscription-id --output none
+      az keyvault secret delete --vault-name ${deployer_kv_name} --name ${saplandscape_prefix}-tenant-id --output none
 
       exit 0
     displayName: "Delete new sap landscape"

--- a/.pipeline/templates/sapsystem/create-sapsystem-steps.yml
+++ b/.pipeline/templates/sapsystem/create-sapsystem-steps.yml
@@ -51,7 +51,7 @@ steps:
 
       landscape_kv_arm_id=$(az keyvault list --resource-group ${saplandscape_rg} | jq -r "'".[] | select(.name | contains(\\\"user\\\")).id"'")
       landscape_kv_name=$(az keyvault list --resource-group ${saplandscape_rg} | jq -r "'".[] | select(.name | contains(\\\"user\\\")).name"'")
-      sid_public_key_secret_name=$(az keyvault secret list --vault-name ${landscape_kv_name} | jq -r "'".[] | select(.name | contains(\\\"iscsi\\\") | not) | select(.name | contains(\\\"pub\\\")).name"'")
+      sid_public_key_secret_name="${saplandscape_rg}-sid-sshkey-pub"
 
       # Modify environment value so it starts with u and with length of 5
       sapsystem_env=${{parameters.sapsystem_env}}

--- a/deploy/terraform/run/sap_landscape/saplandscape.json
+++ b/deploy/terraform/run/sap_landscape/saplandscape.json
@@ -9,8 +9,7 @@
         },
         "vnets": {
             "management": {
-                "saplib_resource_group_name": "",
-                "tfstate_storage_account_name": "",
+                "tfstate_resource_id": "",
                 "deployer_tfstate_key": ""
             },
             "sap": {
@@ -36,13 +35,6 @@
     ],
     "application": {
         "enable_deployment": false
-    },
-    "software": {
-        "storage_account_sapbits": {
-            "saplib_resource_group_name": "",
-            "tfstate_storage_account_name": "",
-            "saplib_tfstate_key": ""
-        }
     },
     "sshkey": {},
     "options": {}

--- a/deploy/terraform/run/sap_landscape/variables_global.tf
+++ b/deploy/terraform/run/sap_landscape/variables_global.tf
@@ -24,6 +24,7 @@ variable "options" {
 
 variable "software" {
   description = "Details of the infrastructure components required for SAP installation"
+  default     = {}
 }
 
 variable "ssh-timeout" {

--- a/deploy/terraform/run/sap_system/ansible.tf
+++ b/deploy/terraform/run/sap_system/ansible.tf
@@ -23,7 +23,7 @@ resource "null_resource" "ansible_playbook" {
       "curl -i -H \"Metadata: \"true\"\" -H \"user-agent: SAP AutoDeploy/${var.auto-deploy-version}; scenario=${var.scenario}; deploy-status=Terraform_finished\" http://169.254.169.254/metadata/instance?api-version=${var.api-version}",
       "export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES",
       "source ~/export-clustering-sp-details.sh",
-      "ansible-playbook -i ${local.ansible_path}/hosts.yml ~/sap-hana/deploy/ansible/sap_playbook.yml"
+      "ansible-playbook -i ${path.cwd}/ansible_config_files/hosts.yml ~/sap-hana/deploy/ansible/sap_playbook.yml"
     ]
   }
 }

--- a/deploy/terraform/run/sap_system/imports.tf
+++ b/deploy/terraform/run/sap_system/imports.tf
@@ -38,3 +38,8 @@ data "azurerm_key_vault_secret" "tenant_id" {
   name         = format("%s-tenant-id", local.environment)
   key_vault_id = local.deployer_key_vault_arm_id
 }
+
+// Import current service principal
+data "azuread_service_principal" "sp" {
+  application_id = local.spn.client_id
+}

--- a/deploy/terraform/run/sap_system/module.tf
+++ b/deploy/terraform/run/sap_system/module.tf
@@ -31,7 +31,7 @@ module "common_infrastructure" {
   subnet-mgmt         = module.deployer.subnet-mgmt
   nsg-mgmt            = module.deployer.nsg-mgmt
   deployer-uai        = module.deployer.deployer-uai
-  spn                 = local.spn
+  service_principal   = local.service_principal
   // Comment out code with users.object_id for the time being.
   // deployer_user       = module.deployer.deployer_user
 }
@@ -76,7 +76,6 @@ module "hdb_node" {
   ppg              = module.common_infrastructure.ppg
   random-id        = module.common_infrastructure.random-id
   sid_kv_user      = module.common_infrastructure.sid_kv_user
-  sid_kv_user_spn  = module.common_infrastructure.sid_kv_user_spn
   deployer-uai     = module.deployer.deployer-uai
   // Comment out code with users.object_id for the time being.
   // deployer_user    = module.deployer.deployer_user
@@ -100,7 +99,6 @@ module "app_tier" {
   ppg              = module.common_infrastructure.ppg
   random-id        = module.common_infrastructure.random-id
   sid_kv_user      = module.common_infrastructure.sid_kv_user
-  sid_kv_user_spn  = module.common_infrastructure.sid_kv_user_spn
   deployer-uai     = module.deployer.deployer-uai
   // Comment out code with users.object_id for the time being.  
   // deployer_user    = module.deployer.deployer_user
@@ -123,7 +121,6 @@ module "anydb_node" {
   ppg              = module.common_infrastructure.ppg
   random-id        = module.common_infrastructure.random-id
   sid_kv_user      = module.common_infrastructure.sid_kv_user
-  sid_kv_user_spn  = module.common_infrastructure.sid_kv_user_spn
 }
 
 // Generate output files

--- a/deploy/terraform/run/sap_system/module.tf
+++ b/deploy/terraform/run/sap_system/module.tf
@@ -15,18 +15,6 @@ module "deployer" {
   sshkey         = var.sshkey
 }
 
-module "saplibrary" {
-  source         = "../../terraform-units/modules/sap_system/saplibrary"
-  application    = var.application
-  databases      = var.databases
-  infrastructure = var.infrastructure
-  jumpboxes      = var.jumpboxes
-  options        = var.options
-  software       = var.software
-  ssh-timeout    = var.ssh-timeout
-  sshkey         = var.sshkey
-}
-
 module "common_infrastructure" {
   source              = "../../terraform-units/modules/sap_system/common_infrastructure"
   is_single_node_hana = "true"
@@ -149,9 +137,6 @@ module "output_files" {
   software                     = var.software
   ssh-timeout                  = var.ssh-timeout
   sshkey                       = var.sshkey
-  storage-sapbits              = module.saplibrary.saplibrary
-  file_share_name              = module.saplibrary.file_share_name
-  storagecontainer-sapbits     = module.saplibrary.storagecontainer-sapbits
   nics-iscsi                   = module.common_infrastructure.nics-iscsi
   infrastructure_w_defaults    = module.common_infrastructure.infrastructure_w_defaults
   software_w_defaults          = module.common_infrastructure.software_w_defaults

--- a/deploy/terraform/run/sap_system/providers.tf
+++ b/deploy/terraform/run/sap_system/providers.tf
@@ -28,12 +28,11 @@ provider "azurerm" {
 }
 
 provider "azuread" {
-  # Whilst version is optional, we /strongly recommend/ using it to pin the version of the Provider being used
-  version = "=0.10.0"
-  subscription_id = local.spn.subscription_id
-  client_id     = local.spn.client_id
-  client_secret = local.spn.client_secret
-  tenant_id     = local.spn.tenant_id
+  version         = ">= 0.10.0"
+
+  client_id       = local.spn.client_id
+  client_secret   = local.spn.client_secret
+  tenant_id       = local.spn.tenant_id
 }
 
 terraform {
@@ -46,4 +45,3 @@ terraform {
     tls      = { version = "~> 2.2" }
   }
 }
-

--- a/deploy/terraform/run/sap_system/providers.tf
+++ b/deploy/terraform/run/sap_system/providers.tf
@@ -27,6 +27,15 @@ provider "azurerm" {
   alias = "deployer"
 }
 
+provider "azuread" {
+  # Whilst version is optional, we /strongly recommend/ using it to pin the version of the Provider being used
+  version = "=0.10.0"
+  subscription_id = local.spn.subscription_id
+  client_id     = local.spn.client_id
+  client_secret = local.spn.client_secret
+  tenant_id     = local.spn.tenant_id
+}
+
 terraform {
   required_version = ">= 0.12"
   required_providers {
@@ -37,3 +46,4 @@ terraform {
     tls      = { version = "~> 2.2" }
   }
 }
+

--- a/deploy/terraform/run/sap_system/sapsystem.json
+++ b/deploy/terraform/run/sap_system/sapsystem.json
@@ -60,22 +60,6 @@
       "username": "azureadm"
     }
   },
-  "software": {
-    "storage_account_sapbits": {
-      "saplib_resource_group_name": "",
-      "tfstate_storage_account_name": "",
-      "saplib_tfstate_key": ""
-    },
-    "downloader": {
-      "scenarios": [
-        {
-          "scenario_type": "DB",
-          "product_name": "HANA",
-          "product_version": "2.0"
-        }
-      ]
-    }
-  },
   "options": {
     "enable_secure_transfer": true,
     "ansible_execution": false,

--- a/deploy/terraform/run/sap_system/variables_global.tf
+++ b/deploy/terraform/run/sap_system/variables_global.tf
@@ -28,7 +28,7 @@ variable "options" {
 
 variable "software" {
   description = "Details of the infrastructure components required for SAP installation"
-  default = {}
+  default     = {}
 }
 
 variable "ssh-timeout" {

--- a/deploy/terraform/run/sap_system/variables_global.tf
+++ b/deploy/terraform/run/sap_system/variables_global.tf
@@ -28,6 +28,7 @@ variable "options" {
 
 variable "software" {
   description = "Details of the infrastructure components required for SAP installation"
+  default = {}
 }
 
 variable "ssh-timeout" {

--- a/deploy/terraform/run/sap_system/variables_local.tf
+++ b/deploy/terraform/run/sap_system/variables_local.tf
@@ -64,4 +64,12 @@ locals {
     client_secret   = data.azurerm_key_vault_secret.client_secret.value,
     tenant_id       = data.azurerm_key_vault_secret.tenant_id.value,
   }
+
+  service_principal = {
+    subscription_id = local.spn.subscription_id,
+    client_id       = local.spn.client_id,
+    client_secret   = local.spn.client_secret,
+    tenant_id       = local.spn.tenant_id,
+    object_id       = data.azuread_service_principal.sp.id 
+  }
 }

--- a/deploy/terraform/run/sap_system/variables_local.tf
+++ b/deploy/terraform/run/sap_system/variables_local.tf
@@ -16,8 +16,6 @@ variable "scenario" {
 # Set defaults
 locals {
 
-  ansible_path = "${module.saplibrary.environment}_${module.saplibrary.sid}"
-
   # Options
   enable_secure_transfer = try(var.options.enable_secure_transfer, true)
   ansible_execution      = try(var.options.ansible_execution, false)

--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/key_vault.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/key_vault.tf
@@ -21,7 +21,6 @@ resource "random_password" "password" {
 */
 // Store the xdb logon username in KV when authentication type is password
 resource "azurerm_key_vault_secret" "auth_username" {
-  depends_on   = [var.sid_kv_user_spn]
   count        = local.enable_auth_password ? 1 : 0
   name         = format("%s-%s-xdb-auth-username", local.prefix, local.sid)
   value        = local.sid_auth_username
@@ -30,7 +29,6 @@ resource "azurerm_key_vault_secret" "auth_username" {
 
 // Store the xdb logon password in KV when authentication type is password
 resource "azurerm_key_vault_secret" "auth_password" {
-  depends_on   = [var.sid_kv_user_spn]
   count        = local.enable_auth_password ? 1 : 0
   name         = format("%s-%s-xdb-auth-password", local.prefix, local.sid)
   value        = local.sid_auth_password

--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/variables_local.tf
@@ -22,10 +22,6 @@ variable "sid_kv_user" {
   description = "Details of the user keyvault for sap_system"
 }
 
-variable "sid_kv_user_spn" {
-  description = "Azurerm_key_vault_access_policy is required to save secrets in KV"
-}
-
 variable "region_mapping" {
   type        = map(string)
   description = "Region Mapping: Full = Single CHAR, 4-CHAR"

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/key_vault.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/key_vault.tf
@@ -22,7 +22,6 @@ resource "random_password" "password" {
 
 // Store the app logon username in KV when authentication type is password
 resource "azurerm_key_vault_secret" "app_auth_username" {
-  depends_on   = [var.sid_kv_user_spn]
   count        = local.enable_auth_password ? 1 : 0
   name         = format("%s-%s-app-auth-username", local.prefix, local.sid)
   value        = local.sid_auth_username
@@ -31,7 +30,6 @@ resource "azurerm_key_vault_secret" "app_auth_username" {
 
 // Store the app logon username in KV when authentication type is password
 resource "azurerm_key_vault_secret" "app_auth_password" {
-  depends_on   = [var.sid_kv_user_spn]
   count        = local.enable_auth_password ? 1 : 0
   name         = format("%s-%s-app-auth-password", local.prefix, local.sid)
   value        = local.sid_auth_password

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/variables_local.tf
@@ -35,10 +35,6 @@ variable "sid_kv_user" {
   description = "Details of the user keyvault for sap_system"
 }
 
-variable "sid_kv_user_spn" {
-  description = "Azurerm_key_vault_access_policy is required to save secrets in KV"
-}
-
 variable "region_mapping" {
   type        = map(string)
   description = "Region Mapping: Full = Single CHAR, 4-CHAR"

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/key_vault_sap_landscape.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/key_vault_sap_landscape.tf
@@ -44,7 +44,7 @@ resource "azurerm_key_vault_access_policy" "kv_user_spn" {
   count        = local.enable_landscape_kv ? 1 : 0
   key_vault_id = azurerm_key_vault.kv_user[0].id
   tenant_id    = local.spn.tenant_id
-  object_id    = local.spn.client_id
+  object_id    = data.azuread_service_principal.sp.id
   secret_permissions = [
     "delete",
     "get",
@@ -156,4 +156,8 @@ data "azurerm_key_vault_secret" "sid_pk" {
   count        = local.enable_landscape_kv ? 0 : 1
   name         = local.secret_sid_pk_name
   key_vault_id = local.kv_landscape_id
+}
+
+data "azuread_service_principal" "sp" {
+  application_id = local.spn.client_id
 }

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/key_vault_sap_landscape.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/key_vault_sap_landscape.tf
@@ -78,7 +78,7 @@ resource "tls_private_key" "iscsi" {
 }
 
 resource "azurerm_key_vault_secret" "iscsi_ppk" {
-  depends_on   = [azurerm_key_vault_access_policy.kv_user_spn]
+  depends_on   = [azurerm_key_vault_access_policy.kv_user_spn[0]]
   count        = (local.enable_landscape_kv && local.enable_iscsi_auth_key) ? 1 : 0
   name         = format("%s-iscsi-sshkey", local.prefix)
   value        = local.iscsi_private_key
@@ -86,7 +86,7 @@ resource "azurerm_key_vault_secret" "iscsi_ppk" {
 }
 
 resource "azurerm_key_vault_secret" "iscsi_pk" {
-  depends_on   = [azurerm_key_vault_access_policy.kv_user_spn]
+  depends_on   = [azurerm_key_vault_access_policy.kv_user_spn[0]]
   count        = (local.enable_landscape_kv && local.enable_iscsi_auth_key) ? 1 : 0
   name         = format("%s-iscsi-sshkey-pub", local.prefix)
   value        = local.iscsi_public_key
@@ -98,7 +98,7 @@ resource "azurerm_key_vault_secret" "iscsi_pk" {
  https://github.com/terraform-providers/terraform-provider-azurerm/issues/4971
 */
 resource "azurerm_key_vault_secret" "iscsi_username" {
-  depends_on   = [azurerm_key_vault_access_policy.kv_user_spn]
+  depends_on   = [azurerm_key_vault_access_policy.kv_user_spn[0]]
   count        = (local.enable_landscape_kv && local.enable_iscsi_auth_password) ? 1 : 0
   name         = format("%s-iscsi-username", local.prefix)
   value        = local.iscsi_auth_username
@@ -106,7 +106,7 @@ resource "azurerm_key_vault_secret" "iscsi_username" {
 }
 
 resource "azurerm_key_vault_secret" "iscsi_password" {
-  depends_on   = [azurerm_key_vault_access_policy.kv_user_spn]
+  depends_on   = [azurerm_key_vault_access_policy.kv_user_spn[0]]
   count        = (local.enable_landscape_kv && local.enable_iscsi_auth_password) ? 1 : 0
   name         = format("%s-iscsi-password", local.prefix)
   value        = local.iscsi_auth_password
@@ -131,7 +131,7 @@ resource "tls_private_key" "sid" {
 }
 
 resource "azurerm_key_vault_secret" "sid_ppk" {
-  depends_on   = [azurerm_key_vault_access_policy.kv_user_spn]
+  depends_on   = [azurerm_key_vault_access_policy.kv_user_spn[0]]
   count        = local.enable_landscape_kv ? 1 : 0
   name         = format("%s-sid-sshkey", local.prefix)
   value        = local.sid_private_key
@@ -139,7 +139,7 @@ resource "azurerm_key_vault_secret" "sid_ppk" {
 }
 
 resource "azurerm_key_vault_secret" "sid_pk" {
-  depends_on   = [azurerm_key_vault_access_policy.kv_user_spn]
+  depends_on   = [azurerm_key_vault_access_policy.kv_user_spn[0]]
   count        = local.enable_landscape_kv ? 1 : 0
   name         = format("%s-sid-sshkey-pub", local.prefix)
   value        = local.sid_public_key

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/key_vault_sap_landscape.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/key_vault_sap_landscape.tf
@@ -143,10 +143,3 @@ resource "azurerm_key_vault_secret" "sid_pk" {
 resource "random_id" "saplandscape" {
   byte_length = 4
 }
-
-// retrieve public key from sap landscape's Key vault
-data "azurerm_key_vault_secret" "sid_pk" {
-  count        = local.enable_landscape_kv ? 0 : 1
-  name         = local.secret_sid_pk_name
-  key_vault_id = local.kv_landscape_id
-}

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/key_vault_sap_landscape.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/key_vault_sap_landscape.tf
@@ -9,21 +9,21 @@ resource "azurerm_key_vault" "kv_prvt" {
   name                       = local.kv_private_name
   location                   = local.region
   resource_group_name        = local.rg_exists ? data.azurerm_resource_group.resource-group[0].name : azurerm_resource_group.resource-group[0].name
-  tenant_id                  = local.spn.tenant_id
+  tenant_id                  = local.service_principal.tenant_id
   soft_delete_enabled        = true
   soft_delete_retention_days = 7
   purge_protection_enabled   = true
   sku_name                   = "standard"
-}
 
-resource "azurerm_key_vault_access_policy" "kv_prvt_spn" {
-  count        = local.enable_landscape_kv ? 1 : 0
-  key_vault_id = azurerm_key_vault.kv_prvt[0].id
-  tenant_id    = local.spn.tenant_id
-  object_id    = local.spn.client_id
-  secret_permissions = [
-    "get",
-  ]
+  access_policy {
+    tenant_id = local.service_principal.tenant_id
+    object_id = local.service_principal.object_id
+
+    secret_permissions = [
+      "get",
+    ]
+
+  }
 }
 
 // Create user KV with access policy
@@ -32,25 +32,24 @@ resource "azurerm_key_vault" "kv_user" {
   name                       = local.kv_user_name
   location                   = local.region
   resource_group_name        = local.rg_exists ? data.azurerm_resource_group.resource-group[0].name : azurerm_resource_group.resource-group[0].name
-  tenant_id                  = local.spn.tenant_id
+  tenant_id                  = local.service_principal.tenant_id
   soft_delete_enabled        = true
   soft_delete_retention_days = 7
   purge_protection_enabled   = true
+  sku_name                   = "standard"
 
-  sku_name = "standard"
-}
+  access_policy {
+    tenant_id = local.service_principal.tenant_id
+    object_id = local.service_principal.object_id
 
-resource "azurerm_key_vault_access_policy" "kv_user_spn" {
-  count        = local.enable_landscape_kv ? 1 : 0
-  key_vault_id = azurerm_key_vault.kv_user[0].id
-  tenant_id    = local.spn.tenant_id
-  object_id    = data.azuread_service_principal.sp.id
-  secret_permissions = [
-    "delete",
-    "get",
-    "list",
-    "set",
-  ]
+    secret_permissions = [
+      "delete",
+      "get",
+      "list",
+      "set",
+    ]
+
+  }
 }
 
 /* Comment out code with users.object_id for the time being
@@ -78,7 +77,6 @@ resource "tls_private_key" "iscsi" {
 }
 
 resource "azurerm_key_vault_secret" "iscsi_ppk" {
-  depends_on   = [azurerm_key_vault_access_policy.kv_user_spn[0]]
   count        = (local.enable_landscape_kv && local.enable_iscsi_auth_key) ? 1 : 0
   name         = format("%s-iscsi-sshkey", local.prefix)
   value        = local.iscsi_private_key
@@ -86,7 +84,6 @@ resource "azurerm_key_vault_secret" "iscsi_ppk" {
 }
 
 resource "azurerm_key_vault_secret" "iscsi_pk" {
-  depends_on   = [azurerm_key_vault_access_policy.kv_user_spn[0]]
   count        = (local.enable_landscape_kv && local.enable_iscsi_auth_key) ? 1 : 0
   name         = format("%s-iscsi-sshkey-pub", local.prefix)
   value        = local.iscsi_public_key
@@ -98,7 +95,6 @@ resource "azurerm_key_vault_secret" "iscsi_pk" {
  https://github.com/terraform-providers/terraform-provider-azurerm/issues/4971
 */
 resource "azurerm_key_vault_secret" "iscsi_username" {
-  depends_on   = [azurerm_key_vault_access_policy.kv_user_spn[0]]
   count        = (local.enable_landscape_kv && local.enable_iscsi_auth_password) ? 1 : 0
   name         = format("%s-iscsi-username", local.prefix)
   value        = local.iscsi_auth_username
@@ -106,7 +102,6 @@ resource "azurerm_key_vault_secret" "iscsi_username" {
 }
 
 resource "azurerm_key_vault_secret" "iscsi_password" {
-  depends_on   = [azurerm_key_vault_access_policy.kv_user_spn[0]]
   count        = (local.enable_landscape_kv && local.enable_iscsi_auth_password) ? 1 : 0
   name         = format("%s-iscsi-password", local.prefix)
   value        = local.iscsi_auth_password
@@ -131,7 +126,6 @@ resource "tls_private_key" "sid" {
 }
 
 resource "azurerm_key_vault_secret" "sid_ppk" {
-  depends_on   = [azurerm_key_vault_access_policy.kv_user_spn[0]]
   count        = local.enable_landscape_kv ? 1 : 0
   name         = format("%s-sid-sshkey", local.prefix)
   value        = local.sid_private_key
@@ -139,7 +133,6 @@ resource "azurerm_key_vault_secret" "sid_ppk" {
 }
 
 resource "azurerm_key_vault_secret" "sid_pk" {
-  depends_on   = [azurerm_key_vault_access_policy.kv_user_spn[0]]
   count        = local.enable_landscape_kv ? 1 : 0
   name         = format("%s-sid-sshkey-pub", local.prefix)
   value        = local.sid_public_key
@@ -156,8 +149,4 @@ data "azurerm_key_vault_secret" "sid_pk" {
   count        = local.enable_landscape_kv ? 0 : 1
   name         = local.secret_sid_pk_name
   key_vault_id = local.kv_landscape_id
-}
-
-data "azuread_service_principal" "sp" {
-  application_id = local.spn.client_id
 }

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/key_vault_sap_system.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/key_vault_sap_system.tf
@@ -10,21 +10,21 @@ resource "azurerm_key_vault" "sid_kv_prvt" {
   name                       = local.sid_kv_private_name
   location                   = local.region
   resource_group_name        = local.rg_exists ? data.azurerm_resource_group.resource-group[0].name : azurerm_resource_group.resource-group[0].name
-  tenant_id                  = local.spn.tenant_id
+  tenant_id                  = local.service_principal.tenant_id
   soft_delete_enabled        = true
   soft_delete_retention_days = 7
   purge_protection_enabled   = true
   sku_name                   = "standard"
-}
 
-resource "azurerm_key_vault_access_policy" "sid_kv_prvt_spn" {
-  count        = local.enable_sid_deployment ? 1 : 0
-  key_vault_id = azurerm_key_vault.sid_kv_prvt[0].id
-  tenant_id    = local.spn.tenant_id
-  object_id    = local.spn.client_id
-  secret_permissions = [
-    "get",
-  ]
+  access_policy {
+    tenant_id = local.service_principal.tenant_id
+    object_id = local.service_principal.object_id
+
+    secret_permissions = [
+      "get",
+    ]
+  }
+
 }
 
 // Create user KV with access policy
@@ -33,24 +33,24 @@ resource "azurerm_key_vault" "sid_kv_user" {
   name                       = local.sid_kv_user_name
   location                   = local.region
   resource_group_name        = local.rg_exists ? data.azurerm_resource_group.resource-group[0].name : azurerm_resource_group.resource-group[0].name
-  tenant_id                  = local.spn.tenant_id
+  tenant_id                  = local.service_principal.tenant_id
   soft_delete_enabled        = true
   soft_delete_retention_days = 7
   purge_protection_enabled   = true
   sku_name                   = "standard"
-}
 
-resource "azurerm_key_vault_access_policy" "sid_kv_user_spn" {
-  count        = local.enable_sid_deployment ? 1 : 0
-  key_vault_id = azurerm_key_vault.sid_kv_user[0].id
-  tenant_id    = local.spn.tenant_id
-  object_id    = local.spn.client_id
-  secret_permissions = [
-    "delete",
-    "get",
-    "list",
-    "set",
-  ]
+  access_policy {
+    tenant_id = local.service_principal.tenant_id
+    object_id = local.service_principal.object_id
+
+    secret_permissions = [
+      "delete",
+      "get",
+      "list",
+      "set",
+    ]
+
+  }
 }
 
 /* Comment out code with users.object_id for the time being

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/outputs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/outputs.tf
@@ -45,11 +45,3 @@ output "sid_kv_user" {
 output "sid_kv_prvt" {
   value = local.enable_sid_deployment ? azurerm_key_vault.sid_kv_prvt : null
 }
-
-/*
- To force dependency between kv access policy and secrets. Expected behavior:
- https://github.com/terraform-providers/terraform-provider-azurerm/issues/4971
-*/
-output "sid_kv_user_spn" {
-  value = azurerm_key_vault_access_policy.sid_kv_user_spn
-}

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/variables_local.tf
@@ -164,8 +164,7 @@ locals {
      At phase 2, the logic will be updated and the key vault information will be obtained from tfstate file of sap landscape.  
   */
   kv_landscape_id     = try(local.var_infra.landscape.key_vault_arm_id, "")
-  secret_sid_pk_name  = try(local.var_infra.landscape.sid_public_key_secret_name, "")
-  enable_landscape_kv = local.kv_landscape_id == "" ? true : false
+  enable_landscape_kv = local.kv_landscape_id == ""
 
   //iSCSI
   var_iscsi = try(local.var_infra.iscsi, {})

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/variables_local.tf
@@ -25,8 +25,8 @@ variable "nsg-mgmt" {
   description = "Details about management nsg of deployer(s)"
 }
 
-variable "spn" {
-  description = "Current SPN used to authenticate to Azure"
+variable "service_principal" {
+  description = "Current service principal used to authenticate to Azure"
 }
 
 variable "deployer-uai" {
@@ -402,7 +402,7 @@ locals {
     downloader = local.downloader
   })
 
-  // SPN
-  spn = try(var.spn, {})
+  // Current service principal
+  service_principal = try(var.service_principal, {})
 
 }

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/key_vault.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/key_vault.tf
@@ -21,7 +21,6 @@ resource "random_password" "password" {
 */
 // Store the hdb logon username in KV when authentication type is password
 resource "azurerm_key_vault_secret" "auth_username" {
-  depends_on   = [var.sid_kv_user_spn]
   count        = local.enable_auth_password ? 1 : 0
   name         = format("%s-%s-hdb-auth-username", local.prefix, local.sid)
   value        = local.sid_auth_username
@@ -30,7 +29,6 @@ resource "azurerm_key_vault_secret" "auth_username" {
 
 // Store the hdb logon username in KV when authentication type is password
 resource "azurerm_key_vault_secret" "auth_password" {
-  depends_on   = [var.sid_kv_user_spn]
   count        = local.enable_auth_password ? 1 : 0
   name         = format("%s-%s-hdb-auth-password", local.prefix, local.sid)
   value        = local.sid_auth_password

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/variables_local.tf
@@ -39,10 +39,6 @@ variable "sid_kv_user" {
   description = "Details of the user keyvault for sap_system"
 }
 
-variable "sid_kv_user_spn" {
-  description = "Azurerm_key_vault_access_policy is required to save secrets in KV"
-}
-
 variable "region_mapping" {
   type        = map(string)
   description = "Region Mapping: Full = Single CHAR, 4-CHAR"

--- a/deploy/terraform/terraform-units/modules/sap_system/output_files/inventory.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/output_files/inventory.tf
@@ -88,10 +88,10 @@ resource "local_file" "output-json" {
     ),
     "software" = merge(var.software_w_defaults, {
       storage_account_sapbits = {
-        name                = var.storage-sapbits.name,
-        storage_access_key  = var.storage-sapbits.primary_access_key,
-        file_share_name     = var.file_share_name
-        blob_container_name = try(var.storagecontainer-sapbits.name, null)
+        name                = ""
+        storage_access_key  = ""
+        file_share_name     = ""
+        blob_container_name = ""
       }
     })
     "options" = var.options

--- a/deploy/terraform/terraform-units/modules/sap_system/output_files/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/output_files/variables_local.tf
@@ -34,18 +34,6 @@ variable "nics-dbnodes-db" {
   description = "NICs of HANA database nodes"
 }
 
-variable "storage-sapbits" {
-  description = "Details of the storage account for SAP bits"
-}
-
-variable "file_share_name" {
-  description = "Name of the file share for SAP bits"
-}
-
-variable "storagecontainer-sapbits" {
-  description = "Details of the storage container for SAP bits"
-}
-
 variable "nics-iscsi" {
   description = "NICs of ISCSI target servers"
 }


### PR DESCRIPTION
## Problem
<Please describe what problem this PR is trying to resolve>
This pr is to address comments from previous discussion. Also fix a bug in previous pr. See Solution section down below, for which task items are included in this pr

## Solution
<Please elaborate the solution for the problem>

- Update test pipeline to support tfstate_resource_id in tf-saplandscape
- clean software block
- Get rid of importing saplibrary logic in sap system module 
- Merge KeyVault access policy into one Keyvault resource
- Clean the "depends on" keyvault access policy resource
- Fix the existing bug in the usage of Keyvault access policy.
See the erro here:https://dev.azure.com/azuresaphana/Azure-SAP-HANA/_build/results?buildId=12850&view=logs&j=26691db3-61d7-5524-8085-39e615892bb3&t=bd477c5e-eed1-5ccb-a423-ea4312ca6e75

See official doc from Terraform: https://www.terraform.io/docs/providers/azurerm/r/key_vault.html#object_id
The object id of keyvault access policy should be populated with the object id of service principal instead of the application id which is stored in Keyvault of deployer right now. To obtain the object id, a new provider azuread and the data resource azuread_service_principal are used.
sap library has similar bug, fixed here: https://github.com/Azure/sap-hana/pull/861

- Change the approach when retrieving value of "sid_public_key_secret_name" in create-sapsystem-steps.yml. Using command "az secret" doesn't work because it is run on deployer and the deployer-msi may not have permission to list all the secrets in the keyvault of saplandscape.




## Tests
<Please provide steps to test the PR>

See the results in the test pipeline down below.

## Notes
<Additional comments for the PR>