### PR TITLE
Enforce another NSG update before saplib post steps

### DIFF
--- a/.pipeline/tf-integration-test.yml
+++ b/.pipeline/tf-integration-test.yml
@@ -115,24 +115,20 @@ stages:
 
           az login --service-principal --user $(hana-pipeline-spn-id) --password $(hana-pipeline-spn-pw) --tenant $(landscape-tenant) --output none
           sapsystem_rg="${environment}-EAUS-SAP-PRD"
-          echo "=== Mark and try to delete rg ${sapsystem_rg} ==="
+          echo "=== Mark rg for deletion ${sapsystem_rg} ==="
           az group update --resource-group ${sapsystem_rg} --set tags.Delete=True
-          az group delete -n ${sapsystem_rg} --no-wait -y
 
           saplandscape_rg="${environment}-EAUS-SAP0-INFRASTRUCTURE"
-          echo "=== Mark and try to delete rg ${saplandscape_rg} ==="
+          echo "=== Mark rg for deletion ${saplandscape_rg} ==="
           az group update --resource-group ${saplandscape_rg} --set tags.Delete=True
-          az group delete -n ${saplandscape_rg} --no-wait -y
 
           saplib_rg="${environment}-EAUS-SAP_LIBRARY"
-          echo "=== Mark and try to delete rg ${saplib_rg} ==="
+          echo "=== Mark rg for deletion ${saplib_rg} ==="
           az group update --resource-group ${saplib_rg} --set tags.Delete=True
-          az group delete -n ${saplib_rg} --no-wait -y
 
           deployer_rg="${environment}-EAUS-MGMT-INFRASTRUCTURE"
-          echo "=== Mark and try to delete rg ${deployer_rg} ==="
+          echo "=== Mark rg for deletion ${deployer_rg} ==="
           az group update --resource-group ${deployer_rg} --set tags.Delete=True
-          az group delete -n ${deployer_rg} --no-wait -y
         displayName: "Clean up"
         env:
           ARM_CLIENT_ID: $(hana-pipeline-spn-id)

--- a/.pipeline/tf-integration-test.yml
+++ b/.pipeline/tf-integration-test.yml
@@ -56,6 +56,9 @@ stages:
           branch_name: $(sourceBranchName)
           deployer_env: "$(Build.BuildId)"
           saplib_env: "$(Build.BuildId)"
+      - template: templates/util/add-agent-to-deployer-nsg.yml
+        parameters:
+          deployer_env: "$(Build.BuildId)"
       - template: templates/saplib/post-saplib-steps.yml
         parameters:
           branch_name: $(sourceBranchName)

--- a/.pipeline/tf-integration-test.yml
+++ b/.pipeline/tf-integration-test.yml
@@ -106,7 +106,7 @@ stages:
       - template: templates/util/remove-agent-from-deployer-nsg.yml
         parameters:
           deployer_env: "$(Build.BuildId)"
-  - job: deleteAll
+  - job: markDeleteAll
     dependsOn: createSAPSystem
     condition: or(succeededOrFailed(), always())
     steps:
@@ -129,6 +129,35 @@ stages:
           deployer_rg="${environment}-EAUS-MGMT-INFRASTRUCTURE"
           echo "=== Mark rg for deletion ${deployer_rg} ==="
           az group update --resource-group ${deployer_rg} --set tags.Delete=True
+        displayName: "Tag resource with Delete: True"
+        env:
+          ARM_CLIENT_ID: $(hana-pipeline-spn-id)
+          ARM_CLIENT_SECRET: $(hana-pipeline-spn-pw)
+          ARM_TENANT_ID: $(landscape-tenant)
+          ARM_SUBSCRIPTION_ID: $(landscape-subscription)
+  - job: deleteAll
+    dependsOn: createSAPSystem
+    condition: and(succeeded(), always())
+    steps:
+      - script: |
+          environment="U$(echo $(Build.BuildId) | rev | cut -c1-4 | rev)"
+
+          az login --service-principal --user $(hana-pipeline-spn-id) --password $(hana-pipeline-spn-pw) --tenant $(landscape-tenant) --output none
+          sapsystem_rg="${environment}-EAUS-SAP-PRD"
+          echo "=== Try to delete rg ${sapsystem_rg} ==="
+          az group delete -n ${sapsystem_rg} --no-wait -y
+
+          saplandscape_rg="${environment}-EAUS-SAP0-INFRASTRUCTURE"
+          echo "=== Try to delete rg ${saplandscape_rg} ==="
+          az group delete -n ${saplandscape_rg} --no-wait -y
+
+          saplib_rg="${environment}-EAUS-SAP_LIBRARY"
+          echo "=== Try to delete rg ${saplib_rg} ==="
+          az group delete -n ${saplib_rg} --no-wait -y
+
+          deployer_rg="${environment}-EAUS-MGMT-INFRASTRUCTURE"
+          echo "=== Try to delete rg ${deployer_rg} ==="
+          az group delete -n ${deployer_rg} --no-wait -y
         displayName: "Clean up"
         env:
           ARM_CLIENT_ID: $(hana-pipeline-spn-id)

--- a/.pipeline/tf-release.yml
+++ b/.pipeline/tf-release.yml
@@ -88,6 +88,9 @@ stages:
           branch_name: $(sourceBranchName)
           deployer_env: "UNIT"
           saplib_env: "UNIT"
+      - template: templates/util/add-agent-to-deployer-nsg.yml
+        parameters:
+          deployer_env: "UNIT"
       - template: templates/saplib/post-saplib-steps.yml
         parameters:
           deployer_env: "UNIT"


### PR DESCRIPTION
## Problem
NSG often get replaced so quickly that the post saplib step will fail with error 255.

## Solution
1. Enforce adding agent ip and assign the correct NSG to the vnet before post saplib step.
1. Only mark RG's to delete but not deleting them - this will allow rerun failed jobs.

## Tests
https://dev.azure.com/azuresaphana/Azure-SAP-HANA/_build/results?buildId=12837&view=results
Here you see if the previous steps fails, it only mark rg as deletion with tag, without real deletion.

## Notes
The error in sap_landscape will be fixed with PR #858 