### PR TITLE
Split the keyvault namefrom a list to individual values

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_namegenerator/keyvault.tf
+++ b/deploy/terraform/terraform-units/modules/sap_namegenerator/keyvault.tf
@@ -1,15 +1,15 @@
 locals {
 
-  sdu_privileged_keyvault_name      = format("%s%s%s%sp%s", local.env_verified, local.location_short, local.vnet_verified, var.sap_sid, local.random_id_verified)
-  sdu_user_keyvault_name            = format("%s%s%s%su%s", local.env_verified, local.location_short, local.vnet_verified, var.sap_sid, local.random_id_verified)
+  sdu_private_keyvault_name = format("%s%s%s%sp%s", local.env_verified, local.location_short, local.vnet_verified, var.sap_sid, local.random_id_verified)
+  sdu_user_keyvault_name    = format("%s%s%s%su%s", local.env_verified, local.location_short, local.vnet_verified, var.sap_sid, local.random_id_verified)
 
-  deployer_privileged_keyvault_name = format("%s%s%sprvt%s", local.env_verified, local.location_short, local.dep_vnet_verified, local.random_id_verified)
-  deployer_user_keyvault_name       = format("%s%s%suser%s", local.env_verified, local.location_short, local.dep_vnet_verified, local.random_id_verified)
+  deployer_private_keyvault_name = format("%s%s%sprvt%s", local.env_verified, local.location_short, local.dep_vnet_verified, local.random_id_verified)
+  deployer_user_keyvault_name    = format("%s%s%suser%s", local.env_verified, local.location_short, local.dep_vnet_verified, local.random_id_verified)
 
-  vnet_privileged_keyvault_name     = format("%s%s%sprvt%s", local.env_verified, local.location_short, local.vnet_verified, local.random_id_verified)
-  vnet_user_keyvault_name           = format("%s%s%suser%s", local.env_verified, local.location_short, local.vnet_verified, local.random_id_verified)
+  vnet_private_keyvault_name = format("%s%s%sprvt%s", local.env_verified, local.location_short, local.vnet_verified, local.random_id_verified)
+  vnet_user_keyvault_name    = format("%s%s%suser%s", local.env_verified, local.location_short, local.vnet_verified, local.random_id_verified)
 
-  library_privileged_keyvault_name  = format("%s%sSAPLIBprvt%s", local.env_verified, local.location_short, local.random_id_verified)
-  library_user_keyvault_name        = format("%s%sSAPLIBuser%s", local.env_verified, local.location_short, local.random_id_verified)
+  library_private_keyvault_name = format("%s%sSAPLIBprvt%s", local.env_verified, local.location_short, local.random_id_verified)
+  library_user_keyvault_name    = format("%s%sSAPLIBuser%s", local.env_verified, local.location_short, local.random_id_verified)
 
 }

--- a/deploy/terraform/terraform-units/modules/sap_namegenerator/keyvault.tf
+++ b/deploy/terraform/terraform-units/modules/sap_namegenerator/keyvault.tf
@@ -1,12 +1,15 @@
 locals {
 
-  sdu_keyvault_name = [format("%s%s%s%sp%s", local.env_verified, local.location_short, local.vnet_verified, var.sap_sid, local.random_id_verified),
-  format("%s%s%s%su%s", local.env_verified, local.location_short, local.vnet_verified, var.sap_sid, local.random_id_verified)]
-  deployer_keyvault_name = [format("%s%s%sprvt%s", local.env_verified, local.location_short, local.dep_vnet_verified, local.random_id_verified),
-  format("%s%s%suser%s", local.env_verified, local.location_short, local.dep_vnet_verified, local.random_id_verified)]
-  vnet_keyvault_name = [format("%s%s%sprvt%s", local.env_verified, local.location_short, local.vnet_verified, local.random_id_verified),
-  format("%s%s%suser%s", local.env_verified, local.location_short, local.vnet_verified, local.random_id_verified)]
-  library_keyvault_name = [format("%s%sSAPLIBprvt%s", local.env_verified, local.location_short, local.random_id_verified),
-  format("%s%sSAPLIBuser%s", local.env_verified, local.location_short, local.random_id_verified)]
+  sdu_privileged_keyvault_name      = format("%s%s%s%sp%s", local.env_verified, local.location_short, local.vnet_verified, var.sap_sid, local.random_id_verified)
+  sdu_user_keyvault_name            = format("%s%s%s%su%s", local.env_verified, local.location_short, local.vnet_verified, var.sap_sid, local.random_id_verified)
+
+  deployer_privileged_keyvault_name = format("%s%s%sprvt%s", local.env_verified, local.location_short, local.dep_vnet_verified, local.random_id_verified)
+  deployer_user_keyvault_name       = format("%s%s%suser%s", local.env_verified, local.location_short, local.dep_vnet_verified, local.random_id_verified)
+
+  vnet_privileged_keyvault_name     = format("%s%s%sprvt%s", local.env_verified, local.location_short, local.vnet_verified, local.random_id_verified)
+  vnet_user_keyvault_name           = format("%s%s%suser%s", local.env_verified, local.location_short, local.vnet_verified, local.random_id_verified)
+
+  library_privileged_keyvault_name  = format("%s%sSAPLIBprvt%s", local.env_verified, local.location_short, local.random_id_verified)
+  library_user_keyvault_name        = format("%s%sSAPLIBuser%s", local.env_verified, local.location_short, local.random_id_verified)
 
 }

--- a/deploy/terraform/terraform-units/modules/sap_namegenerator/output.tf
+++ b/deploy/terraform/terraform-units/modules/sap_namegenerator/output.tf
@@ -16,10 +16,22 @@ output naming {
       }
     }
     keyvault_names = {
-      DEPLOYER = local.deployer_keyvault_name
-      LIBRARY  = local.library_keyvault_name
-      SDU      = local.sdu_keyvault_name
-      VNET     = local.vnet_keyvault_name
+      DEPLOYER = {
+        privileged_access = local.deployer_privileged_keyvault_name
+        user_access       = local.deployer_user_keyvault_name
+      }
+      LIBRARY = {
+        privileged_access = local.library_privileged_keyvault_name
+        user_access       = local.library_user_keyvault_name
+      }
+      SDU = {
+        privileged_access = local.sdu_privileged_keyvault_name
+        user_access       = local.sdu_user_keyvault_name
+      }
+      VNET = {
+        privileged_access = local.vnet_privileged_keyvault_name
+        user_access       = local.vnet_user_keyvault_name
+      }
     }
     virtualmachine_names = {
       ANCHOR_COMPUTERNAME = local.anchor_server_names

--- a/deploy/terraform/terraform-units/modules/sap_namegenerator/output.tf
+++ b/deploy/terraform/terraform-units/modules/sap_namegenerator/output.tf
@@ -17,20 +17,20 @@ output naming {
     }
     keyvault_names = {
       DEPLOYER = {
-        privileged_access = local.deployer_private_keyvault_name
-        user_access       = local.deployer_user_keyvault_name
+        private_access = local.deployer_private_keyvault_name
+        user_access    = local.deployer_user_keyvault_name
       }
       LIBRARY = {
-        privileged_access = local.library_private_keyvault_name
-        user_access       = local.library_user_keyvault_name
+        private_access = local.library_private_keyvault_name
+        user_access    = local.library_user_keyvault_name
       }
       SDU = {
-        privileged_access = local.sdu_private_keyvault_name
-        user_access       = local.sdu_user_keyvault_name
+        private_access = local.sdu_private_keyvault_name
+        user_access    = local.sdu_user_keyvault_name
       }
       VNET = {
-        privileged_access = local.vnet_private_keyvault_name
-        user_access       = local.vnet_user_keyvault_name
+        private_access = local.vnet_private_keyvault_name
+        user_access    = local.vnet_user_keyvault_name
       }
     }
     virtualmachine_names = {

--- a/deploy/terraform/terraform-units/modules/sap_namegenerator/output.tf
+++ b/deploy/terraform/terraform-units/modules/sap_namegenerator/output.tf
@@ -17,19 +17,19 @@ output naming {
     }
     keyvault_names = {
       DEPLOYER = {
-        privileged_access = local.deployer_privileged_keyvault_name
+        privileged_access = local.deployer_private_keyvault_name
         user_access       = local.deployer_user_keyvault_name
       }
       LIBRARY = {
-        privileged_access = local.library_privileged_keyvault_name
+        privileged_access = local.library_private_keyvault_name
         user_access       = local.library_user_keyvault_name
       }
       SDU = {
-        privileged_access = local.sdu_privileged_keyvault_name
+        privileged_access = local.sdu_private_keyvault_name
         user_access       = local.sdu_user_keyvault_name
       }
       VNET = {
-        privileged_access = local.vnet_privileged_keyvault_name
+        privileged_access = local.vnet_private_keyvault_name
         user_access       = local.vnet_user_keyvault_name
       }
     }


### PR DESCRIPTION
## Problem
The current design of passing a list of keyvault names makes the code harder to read

## Solution
Change the output of the naming module to separate the values to individual properties

```
keyvault_names = {
      DEPLOYER = {
        privileged_access = local.deployer_privileged_keyvault_name
        user_access       = local.deployer_user_keyvault_name
      }
      LIBRARY = {
        privileged_access = local.library_privileged_keyvault_name
        user_access       = local.library_user_keyvault_name
      }
      SDU = {
        privileged_access = local.sdu_privileged_keyvault_name
        user_access       = local.sdu_user_keyvault_name
      }
      VNET = {
        privileged_access = local.vnet_privileged_keyvault_name
        user_access       = local.vnet_user_keyvault_name
      }
    }
```

## Tests
<Please provide steps to test the PR>

## Notes
<Additional comments for the PR>