### PR TITLE
Keyvault access policy should use object id of service principal

### DIFF
--- a/deploy/terraform/bootstrap/sap_library/imports.tf
+++ b/deploy/terraform/bootstrap/sap_library/imports.tf
@@ -33,3 +33,8 @@ data "azurerm_key_vault_secret" "tenant_id" {
   name         = format("%s-tenant-id", local.environment)
   key_vault_id = local.deployer_key_vault_arm_id
 }
+
+// Import current service principal
+data "azuread_service_principal" "sp" {
+  application_id = local.spn.client_id
+}

--- a/deploy/terraform/bootstrap/sap_library/module.tf
+++ b/deploy/terraform/bootstrap/sap_library/module.tf
@@ -9,6 +9,6 @@ module "sap_library" {
   storage_account_tfstate = var.storage_account_tfstate
   software                = var.software
   deployer                = var.deployer
-  spn                     = local.spn
+  service_principal       = local.service_principal
   deployer_tfstate        = data.terraform_remote_state.deployer
 }

--- a/deploy/terraform/bootstrap/sap_library/providers.tf
+++ b/deploy/terraform/bootstrap/sap_library/providers.tf
@@ -28,6 +28,14 @@ provider "azurerm" {
   alias = "deployer"
 }
 
+provider "azuread" {
+  version         = ">= 0.10.0"
+
+  client_id       = local.spn.client_id
+  client_secret   = local.spn.client_secret
+  tenant_id       = local.spn.tenant_id
+}
+
 terraform {
   required_version = ">= 0.12"
   required_providers {

--- a/deploy/terraform/bootstrap/sap_library/variables_local.tf
+++ b/deploy/terraform/bootstrap/sap_library/variables_local.tf
@@ -60,4 +60,12 @@ locals {
     tenant_id       = data.azurerm_key_vault_secret.tenant_id.value,
   }
 
+  service_principal = {
+    subscription_id = local.spn.subscription_id,
+    client_id       = local.spn.client_id,
+    client_secret   = local.spn.client_secret,
+    tenant_id       = local.spn.tenant_id,
+    object_id       = data.azuread_service_principal.sp.id
+  }
+
 }

--- a/deploy/terraform/run/sap_library/imports.tf
+++ b/deploy/terraform/run/sap_library/imports.tf
@@ -38,3 +38,8 @@ data "azurerm_key_vault_secret" "tenant_id" {
   name         = format("%s-tenant-id", local.environment)
   key_vault_id = local.deployer_key_vault_arm_id
 }
+
+// Import current service principal
+data "azuread_service_principal" "sp" {
+  application_id = local.spn.client_id
+}

--- a/deploy/terraform/run/sap_library/module.tf
+++ b/deploy/terraform/run/sap_library/module.tf
@@ -9,6 +9,6 @@ module "sap_library" {
   storage_account_tfstate = var.storage_account_tfstate
   software                = var.software
   deployer                = var.deployer
-  spn                     = local.spn
+  service_principal       = local.service_principal
   deployer_tfstate        = data.terraform_remote_state.deployer
 }

--- a/deploy/terraform/run/sap_library/providers.tf
+++ b/deploy/terraform/run/sap_library/providers.tf
@@ -28,6 +28,14 @@ provider "azurerm" {
   alias = "deployer"
 }
 
+provider "azuread" {
+  version         = ">= 0.10.0"
+
+  client_id       = local.spn.client_id
+  client_secret   = local.spn.client_secret
+  tenant_id       = local.spn.tenant_id
+}
+
 terraform {
   required_version = ">= 0.12"
   required_providers {

--- a/deploy/terraform/run/sap_library/variables_local.tf
+++ b/deploy/terraform/run/sap_library/variables_local.tf
@@ -73,4 +73,12 @@ locals {
     tenant_id       = data.azurerm_key_vault_secret.tenant_id.value,
   }
 
+  service_principal = {
+    subscription_id = local.spn.subscription_id,
+    client_id       = local.spn.client_id,
+    client_secret   = local.spn.client_secret,
+    tenant_id       = local.spn.tenant_id,
+    object_id       = data.azuread_service_principal.sp.id
+  }
+
 }

--- a/deploy/terraform/terraform-units/modules/sap_library/key_vault.tf
+++ b/deploy/terraform/terraform-units/modules/sap_library/key_vault.tf
@@ -8,22 +8,20 @@ resource "azurerm_key_vault" "kv_prvt" {
   name                       = local.kv_private_name
   location                   = local.region
   resource_group_name        = local.rg_exists ? data.azurerm_resource_group.library[0].name : local.rg_name
-  tenant_id                  = local.spn.tenant_id
+  tenant_id                  = local.service_principal.tenant_id
   soft_delete_enabled        = true
   soft_delete_retention_days = 7
   purge_protection_enabled   = true
   sku_name                   = "standard"
-}
 
-resource "azurerm_key_vault_access_policy" "kv_prvt_spn" {
-  key_vault_id = azurerm_key_vault.kv_prvt.id
+  access_policy {
+    tenant_id = local.service_principal.tenant_id
+    object_id = local.service_principal.object_id
 
-  tenant_id = local.spn.tenant_id
-  object_id = local.spn.client_id
-
-  secret_permissions = [
-    "get",
-  ]
+    secret_permissions = [
+      "get",
+    ]
+  }
 }
 
 // Create user KV with access policy
@@ -31,25 +29,23 @@ resource "azurerm_key_vault" "kv_user" {
   name                       = local.kv_user_name
   location                   = local.region
   resource_group_name        = local.rg_exists ? data.azurerm_resource_group.library[0].name : local.rg_name
-  tenant_id                  = local.spn.tenant_id
+  tenant_id                  = local.service_principal.tenant_id
   soft_delete_enabled        = true
   soft_delete_retention_days = 7
   purge_protection_enabled   = true
+  sku_name                   = "standard"
 
-  sku_name = "standard"
-}
+  access_policy {
+    tenant_id = local.service_principal.tenant_id
+    object_id = local.service_principal.object_id
 
-resource "azurerm_key_vault_access_policy" "kv_user_spn" {
-  key_vault_id = azurerm_key_vault.kv_user.id
-  tenant_id    = local.spn.tenant_id
-  object_id    = local.spn.client_id
-
-  secret_permissions = [
-    "delete",
-    "get",
-    "list",
-    "set",
-  ]
+    secret_permissions = [
+      "delete",
+      "get",
+      "list",
+      "set",
+    ]
+  }
 }
 
 /* Comment out code with users.object_id for the time being

--- a/deploy/terraform/terraform-units/modules/sap_library/storage_accounts.tf
+++ b/deploy/terraform/terraform-units/modules/sap_library/storage_accounts.tf
@@ -93,9 +93,9 @@ TBD: two options
 */
 // Assign contributor role to deployer's msi to access tfstate storage account
 resource "azurerm_role_assignment" "deployer_msi_sa_tfstate" {
-  scope              = local.sa_sapbits_exists ? data.azurerm_storage_account.storage_tfstate[0].id : azurerm_storage_account.storage_tfstate[0].id
-  role_definition_name = "Storage Account Contributor" 
-  principal_id       = local.deployer_msi_principal_id
+  scope                = local.sa_sapbits_exists ? data.azurerm_storage_account.storage_tfstate[0].id : azurerm_storage_account.storage_tfstate[0].id
+  role_definition_name = "Storage Account Contributor"
+  principal_id         = local.deployer_msi_principal_id
 }
 
 // Generates random text for storage account name

--- a/deploy/terraform/terraform-units/modules/sap_library/variables_global.tf
+++ b/deploy/terraform/terraform-units/modules/sap_library/variables_global.tf
@@ -3,4 +3,3 @@ variable "storage_account_sapbits" {}
 variable "storage_account_tfstate" {}
 variable "software" {}
 variable "deployer" {}
-variable "spn" {}

--- a/deploy/terraform/terraform-units/modules/sap_library/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_library/variables_local.tf
@@ -47,6 +47,10 @@ variable "deployer_tfstate" {
   description = "terraform.tfstate of deployer"
 }
 
+variable "service_principal" {
+  description = "Current service principal used to authenticate to Azure"
+}
+
 locals {
 
   // Post fix for all deployed resources
@@ -116,8 +120,8 @@ locals {
   kv_private_name = format("%sSAPLIBprvt%s", local.kv_prefix, local.postfix)
   kv_user_name    = format("%sSAPLIBuser%s", local.kv_prefix, local.postfix)
 
-  // spn
-  spn = try(var.spn, {})
+  // Current service principal
+  service_principal = try(var.service_principal, {})
 
   // deployer terraform.tfstate
   deployer_tfstate          = var.deployer_tfstate


### PR DESCRIPTION
## Problem
<Please describe what problem this PR is trying to resolve>
Fix the existing bug in the usage of Keyvault access policy.

The object id of keyvault access policy should be populated with the object id of service principal instead of the application id which is stored in Keyvault of deployer right now. 

## Solution
<Please elaborate the solution for the problem>
To obtain the object id, a new provider azuread and the data resource azuread_service_principal are used.

## Tests
<Please provide steps to test the PR>
See the result in the test pipeline down below

![image](https://user-images.githubusercontent.com/62584551/96772294-ca4d8700-1397-11eb-890c-07ab5095a9e0.png)


## Notes
<Additional comments for the PR>
sap-hana-pipeline-app 
The object id used in configuring access policy is the object id of service principal instead of the object id of application.

