### PR TITLE
[NO DEPLOYER VM] Ability to deploy the deployer infrastructure without the deployer VM

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_deployer/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/variables_local.tf
@@ -52,6 +52,8 @@ locals {
 
   // Deployer(s) information with default override
   enable_deployers = length(local.deployer_input) > 0 ? true : false
+
+  // Provide the ability to deploy without the VM
   enable_vm        = try(local.deployer_input.deploy_vm, true)
 
   deployers = [

--- a/deploy/terraform/terraform-units/modules/sap_deployer/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/variables_local.tf
@@ -52,6 +52,8 @@ locals {
 
   // Deployer(s) information with default override
   enable_deployers = length(local.deployer_input) > 0 ? true : false
+  enable_vm        = try(local.deployer_input.deploy_vm, true)
+
   deployers = [
     for idx, deployer in local.deployer_input : {
       "name"                 = local.virtualmachine_names[idx],
@@ -76,7 +78,7 @@ locals {
         "terraform",
         "ansible"
       ],
-      "private_ip_address" = try(deployer.private_ip_address, cidrhost(local.sub_mgmt_deployed.address_prefixes[0], idx + 4))
+      "private_ip_address" = try(deployer.private_ip_address, cidrhost(local.sub_mgmt_deployed.address_prefixes[idx], 0 + 4))
     }
   ]
 

--- a/deploy/terraform/terraform-units/modules/sap_deployer/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/variables_local.tf
@@ -54,7 +54,7 @@ locals {
   enable_deployers = length(local.deployer_input) > 0 ? true : false
 
   // Provide the ability to deploy without the VM
-  enable_vm        = try(local.deployer_input.deploy_vm, true)
+  enable_vm = try(local.deployer_input[0].deploy_vm, true)
 
   deployers = [
     for idx, deployer in local.deployer_input : {
@@ -87,7 +87,7 @@ locals {
   // Deployer(s) information with updated pip
   deployers_updated = [
     for idx, deployer in local.deployers : merge({
-      "public_ip_address" = azurerm_public_ip.deployer[idx].ip_address
+      "public_ip_address" = local.enable_vm ? azurerm_public_ip.deployer[idx].ip_address : ""
     }, deployer)
   ]
 


### PR DESCRIPTION
## Problem
Customers who use Azure DevOps or other execution environments do not want a deployment with an VM that they will not use. This case applies for Terraform Enterprise as well

## Solution
Add an option in the deployers section that blocks the deployment of the VM. The default value for the setting is true, if the customer wants to deploy without the deployer VM they will need to explicitly add the section to the parameters.

 "deployers": [{
    "deploy_vm" : "false"
  }],

## Tests
Add the section to the json file and deploy the deployer (either bootstrap or run)

## Notes
<Additional comments for the PR>