### PR TITLE
Add the ability to specify the separator used between the resource prefix and the resource name

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_deployer/vm-deployer.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/vm-deployer.tf
@@ -12,7 +12,7 @@ data azurerm_client_config "current" {}
 // Public IP addresse and nic for Deployer
 resource "azurerm_public_ip" "deployer" {
   count               = length(local.deployers)
-  name                = format("%s_%s%s", local.prefix, local.deployers[count.index].name, local.resource_suffixes.pip)
+  name                = format("%s%s%s%s", local.prefix, var.naming.separator, local.deployers[count.index].name, local.resource_suffixes.pip)
   location            = azurerm_resource_group.deployer[0].location
   resource_group_name = azurerm_resource_group.deployer[0].name
   allocation_method   = "Static"
@@ -20,7 +20,7 @@ resource "azurerm_public_ip" "deployer" {
 
 resource "azurerm_network_interface" "deployer" {
   count               = length(local.deployers)
-  name                = format("%s_%s%s", local.prefix, local.deployers[count.index].name, local.resource_suffixes.nic)
+  name                = format("%s%s%s%s", local.prefix, var.naming.separator, local.deployers[count.index].name, local.resource_suffixes.nic)
   location            = azurerm_resource_group.deployer[0].location
   resource_group_name = azurerm_resource_group.deployer[0].name
 
@@ -57,7 +57,7 @@ resource "azurerm_role_assignment" "sub_user_admin" {
 // Linux Virtual Machine for Deployer
 resource "azurerm_linux_virtual_machine" "deployer" {
   count                           = length(local.deployers)
-  name                            = format("%s_%s%s", local.prefix, local.deployers[count.index].name, local.resource_suffixes.vm)
+  name                            = format("%s%s%s%s", local.prefix, var.naming.separator, local.deployers[count.index].name, local.resource_suffixes.vm)
   computer_name                   = local.deployers[count.index].name
   location                        = azurerm_resource_group.deployer[0].location
   resource_group_name             = azurerm_resource_group.deployer[0].name
@@ -68,7 +68,7 @@ resource "azurerm_linux_virtual_machine" "deployer" {
   disable_password_authentication = local.deployers[count.index].authentication.type != "password" ? true : false
 
   os_disk {
-    name                 = format("%s_%s%s", local.prefix, local.deployers[count.index].name, local.resource_suffixes.osdisk)
+    name                 = format("%s%s%s%s", local.prefix, var.naming.separator, local.deployers[count.index].name, local.resource_suffixes.osdisk)
     caching              = "ReadWrite"
     storage_account_type = local.deployers[count.index].disk_type
   }

--- a/deploy/terraform/terraform-units/modules/sap_namegenerator/output.tf
+++ b/deploy/terraform/terraform-units/modules/sap_namegenerator/output.tf
@@ -49,5 +49,7 @@ output naming {
       WEB_VMNAME          = local.web_server_vm_names
     }
     resource_suffixes = var.resource_suffixes
+
+    separator = local.separator
   }
 }

--- a/deploy/terraform/terraform-units/modules/sap_namegenerator/resourcegroup.tf
+++ b/deploy/terraform/terraform-units/modules/sap_namegenerator/resourcegroup.tf
@@ -1,6 +1,9 @@
 locals {
 
-  sdu_name      = length(var.codename) > 0 ? upper(format("%s-%s-%s_%s-%s", local.env_verified, local.location_short, local.vnet_verified, var.codename, var.sap_sid)) : upper(format("%s-%s-%s-%s", local.env_verified, local.location_short, local.vnet_verified, var.sap_sid))
+  sdu_name = length(var.codename) > 0 ? (
+    upper(format("%s-%s-%s_%s-%s", local.env_verified, local.location_short, local.vnet_verified, var.codename, var.sap_sid))) : (
+    upper(format("%s-%s-%s-%s", local.env_verified, local.location_short, local.vnet_verified, var.sap_sid))
+  )
   deployer_name = upper(format("%s-%s-%s", local.env_verified, local.location_short, local.dep_vnet_verified))
   vnet_name     = upper(format("%s-%s-%s", local.env_verified, local.location_short, local.vnet_verified))
   library_name  = upper(format("%s-%s", local.env_verified, local.location_short))

--- a/deploy/terraform/terraform-units/modules/sap_namegenerator/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_namegenerator/variables_local.tf
@@ -238,25 +238,25 @@ variable resource_suffixes {
 variable app_zones {
   type        = list(string)
   description = "List of availability zones for application tier"
-  default = []
+  default     = []
 }
 
 variable scs_zones {
   type        = list(string)
   description = "List of availability zones for scs tier"
-  default = []
+  default     = []
 }
 
 variable web_zones {
   type        = list(string)
   description = "List of availability zones for web tier"
-  default = []
+  default     = []
 }
 
 variable db_zones {
   type        = list(string)
   description = "List of availability zones for db tier"
-  default = []
+  default     = []
 }
 
 
@@ -272,6 +272,10 @@ locals {
   random_id_vm_verified = lower(substr(var.random_id, 0, var.sapautomation_name_limits.random_id_length))
 
   zones            = distinct(concat(var.db_zones, var.app_zones, var.scs_zones, var.web_zones))
-  zonal_deployment = try(length(local.zones),0) > 0 ? true : false
+  zonal_deployment = try(length(local.zones), 0) > 0 ? true : false
+
+  //The separator to use between the prefix and resource name
+  separator = "_"
+
 }
 

--- a/deploy/terraform/terraform-units/modules/sap_namegenerator/vm.tf
+++ b/deploy/terraform/terraform-units/modules/sap_namegenerator/vm.tf
@@ -22,14 +22,14 @@ locals {
 
   anydb_vm_names = [for idx in range(var.db_server_count) :
     local.zonal_deployment ? (
-      format("%sd%s_z%s_%02dl%d%s", lower(var.sap_sid), lower(var.db_sid), var.db_zones[idx % length(var.db_zones)], idx, 0, local.random_id_vm_verified)) : (
+      format("%sd%s%sz%s%s%02dl%d%s", lower(var.sap_sid), lower(var.db_sid), local.separator, var.db_zones[idx % length(var.db_zones)], local.separator, idx, 0, local.random_id_vm_verified)) : (
       format("%sd%s%02dl%d%s", lower(var.sap_sid), lower(var.db_sid), idx, 0, local.random_id_vm_verified)
     )
   ]
 
   anydb_vm_names_ha = [for idx in range(var.db_server_count) :
     local.zonal_deployment ? (
-      format("%sd%s_z%s_%02dl%d%s", lower(var.sap_sid), lower(var.db_sid), var.db_zones[idx % length(var.db_zones)], idx, 1, local.random_id_vm_verified)) : (
+      format("%sd%s%sz%s%s%02dl%d%s", lower(var.sap_sid), lower(var.db_sid), local.separator, var.db_zones[idx % length(var.db_zones)], local.separator, idx, 1, local.random_id_vm_verified)) : (
       format("%sd%s%02dl%d%s", lower(var.sap_sid), lower(var.db_sid), idx, 1, local.random_id_vm_verified)
     )
   ]
@@ -40,7 +40,7 @@ locals {
 
   app_server_vm_names = [for idx in range(var.app_server_count) :
     local.zonal_deployment ? (
-      format("%sapp_z%s_%02d%s%s", lower(var.sap_sid), var.app_zones[idx % length(var.app_zones)], idx, local.app_oscode, local.random_id_vm_verified)) : (
+      format("%sapp%sz%s%s%02d%s%s", lower(var.sap_sid), local.separator, var.app_zones[idx % length(var.app_zones)], local.separator, idx, local.app_oscode, local.random_id_vm_verified)) : (
       format("%sapp%02d%s%s", lower(var.sap_sid), idx, local.app_oscode, local.random_id_vm_verified)
     )
   ]
@@ -59,14 +59,14 @@ locals {
 
   hana_server_vm_names = [for idx in range(var.db_server_count) :
     local.zonal_deployment ? (
-      format("%sd%s_z%s_%02dl%d%s", lower(var.sap_sid), lower(var.db_sid), var.db_zones[idx % length(var.db_zones)], idx, 0, local.random_id_vm_verified)) : (
+      format("%sd%s%sz%s%s%02dl%d%s", lower(var.sap_sid), lower(var.db_sid), local.separator, var.db_zones[idx % length(var.db_zones)], local.separator, idx, 0, local.random_id_vm_verified)) : (
       format("%sd%s%02dl%d%s", lower(var.sap_sid), lower(var.db_sid), idx, 0, local.random_id_vm_verified)
     )
   ]
 
   hana_server_vm_names_ha = [for idx in range(var.db_server_count) :
     local.zonal_deployment ? (
-      format("%sd%s_z%s_%02dl%d%s", lower(var.sap_sid), lower(var.db_sid), var.db_zones[idx % length(var.db_zones)], idx, 1, local.random_id_vm_verified)) : (
+      format("%sd%s%sz%s%s%02dl%d%s", lower(var.sap_sid), lower(var.db_sid), local.separator, var.db_zones[idx % length(var.db_zones)], local.separator, idx, 1, local.random_id_vm_verified)) : (
       format("%sd%s%02dl%d%s", lower(var.sap_sid), lower(var.db_sid), idx, 1, local.random_id_vm_verified)
     )
   ]
@@ -77,7 +77,7 @@ locals {
 
   scs_server_vm_names = [for idx in range(var.scs_server_count) :
     local.zonal_deployment ? (
-      format("%sscs_z%s_%02d%s%s", lower(var.sap_sid), var.scs_zones[idx % length(var.scs_zones)], idx, local.app_oscode, local.random_id_vm_verified)) : (
+      format("%sscs%sz%s%s%02d%s%s", lower(var.sap_sid), local.separator, var.scs_zones[idx % length(var.scs_zones)], local.separator, idx, local.app_oscode, local.random_id_vm_verified)) : (
       format("%sscs%02d%s%s", lower(var.sap_sid), idx, local.app_oscode, local.random_id_vm_verified)
     )
   ]
@@ -88,7 +88,7 @@ locals {
 
   web_server_vm_names = [for idx in range(var.scs_server_count) :
     local.zonal_deployment ? (
-      format("%sweb_z%s_%02d%s%s", lower(var.sap_sid), var.web_zones[idx % length(var.web_zones)], idx, local.app_oscode, local.random_id_vm_verified)) : (
+      format("%sweb%sz%s%s%02d%s%s", lower(var.sap_sid), local.separator, var.web_zones[idx % length(var.web_zones)], local.separator, idx, local.app_oscode, local.random_id_vm_verified)) : (
       format("%sweb%02d%s%s", lower(var.sap_sid), idx, local.app_oscode, local.random_id_vm_verified)
     )
   ]

--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/infrastructure.tf
@@ -46,8 +46,8 @@ resource "azurerm_network_interface_backend_address_pool_association" "anydb" {
 # AVAILABILITY SET ================================================================================================
 
 resource "azurerm_availability_set" "anydb" {
-  count                        = local.enable_deployment ?  max(length(local.zones),1) : 0
-  name                         = local.zonal_deployment ? format("%s_z%s%s", local.prefix, local.zones[count.index], local.resource_suffixes.db-avset) : format("%s%s", local.prefix, local.resource_suffixes.db-avset)
+  count                        = local.enable_deployment ? max(length(local.zones), 1) : 0
+  name                         = local.zonal_deployment ? format("%s%sz%s%s", local.prefix, var.naming.separator, local.zones[count.index], local.resource_suffixes.db-avset) : format("%s%s", local.prefix, local.resource_suffixes.db-avset)
   location                     = var.resource-group[0].location
   resource_group_name          = var.resource-group[0].name
   platform_update_domain_count = 20

--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/variables_local.tf
@@ -169,14 +169,14 @@ locals {
   )
 
   dbnodes = flatten([[for idx, dbnode in try(local.anydb.dbnodes, [{}]) : {
-    name         = try("${dbnode.name}-0", format("%s_%s%s", local.prefix, local.virtualmachine_names[idx], local.resource_suffixes.vm))
+    name         = try("${dbnode.name}-0", format("%s%s%s%s", local.prefix, local.prefix, var.naming.separator,local.virtualmachine_names[idx], local.resource_suffixes.vm))
     computername = try("${dbnode.name}-0", local.computer_names[idx], local.resource_suffixes.vm)
     role         = try(dbnode.role, "worker"),
     db_nic_ip    = lookup(dbnode, "db_nic_ips", [false, false])[0]
     }
     ],
     [for idx, dbnode in try(local.anydb.dbnodes, [{}]) : {
-      name         = try("${dbnode.name}-1", format("%s_%s%s", local.prefix, local.virtualmachine_names[idx + local.node_count], local.resource_suffixes.vm))
+      name         = try("${dbnode.name}-1", format("%s%s%s%s", local.prefix, var.naming.separator, local.virtualmachine_names[idx + local.node_count], local.resource_suffixes.vm))
       computername = try("${dbnode.name}-1", local.computer_names[idx + local.node_count], local.resource_suffixes.vm)
       role         = try(dbnode.role, "worker"),
       db_nic_ip    = lookup(dbnode, "db_nic_ips", [false, false])[1],

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/infrastructure.tf
@@ -112,7 +112,7 @@ resource "azurerm_lb_rule" "ers" {
 # Create the SCS Availability Set
 resource "azurerm_availability_set" "scs" {
   count                        = local.enable_deployment ? local.scs_server_count == local.scs_zone_count ? 0 : max(length(local.scs_zones), 1) : 0
-  name                         = local.scs_zonal_deployment ? format("%s_z%s%s", local.prefix, local.scs_zones[count.index], local.resource_suffixes.scs-avset) : format("%s%s", local.prefix, local.resource_suffixes.scs-avset)
+  name                         = local.scs_zonal_deployment ? format("%s%sz%s%s", local.prefix, var.naming.separator, local.scs_zones[count.index], local.resource_suffixes.scs-avset) : format("%s%s", local.prefix, local.resource_suffixes.scs-avset)
   location                     = var.resource-group[0].location
   resource_group_name          = var.resource-group[0].name
   platform_update_domain_count = 20
@@ -128,7 +128,7 @@ resource "azurerm_availability_set" "scs" {
 # Create the Application Availability Set
 resource "azurerm_availability_set" "app" {
   count                        = local.enable_deployment ? local.application_server_count == local.app_zone_count ? 0 : max(local.app_zone_count, 1) : 0
-  name                         = local.app_zonal_deployment ? format("%s_z%s%s", local.prefix, local.app_zones[count.index], local.resource_suffixes.app-avset) : format("%s%s", local.prefix, local.resource_suffixes.app-avset)
+  name                         = local.app_zonal_deployment ? format("%s%sz%s%s", local.prefix, var.naming.separator, local.app_zones[count.index], local.resource_suffixes.app-avset) : format("%s%s", local.prefix, local.resource_suffixes.app-avset)
   location                     = var.resource-group[0].location
   resource_group_name          = var.resource-group[0].name
   platform_update_domain_count = 20
@@ -192,7 +192,7 @@ resource "azurerm_network_interface_backend_address_pool_association" "web" {
 # Create the Web dispatcher Availability Set
 resource "azurerm_availability_set" "web" {
   count                        = local.enable_deployment ? local.webdispatcher_count == local.web_zone_count ? 0 : max(length(local.web_zones), 1) : 0
-  name                         = local.web_zonal_deployment ? format("%s_z%s%s", local.prefix, local.web_zones[count.index], local.resource_suffixes.web-avset) : format("%s%s", local.prefix, local.resource_suffixes.web-avset)
+  name                         = local.web_zonal_deployment ? format("%s%sz%s%s", local.prefix, var.naming.separator, local.web_zones[count.index], local.resource_suffixes.web-avset) : format("%s%s", local.prefix, local.resource_suffixes.web-avset)
   location                     = var.resource-group[0].location
   resource_group_name          = var.resource-group[0].name
   platform_update_domain_count = 20

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-app.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-app.tf
@@ -74,7 +74,7 @@ resource "azurerm_linux_virtual_machine" "app" {
 # Create the Windows Application VM(s)
 resource "azurerm_windows_virtual_machine" "app" {
   count               = local.enable_deployment ? (upper(local.app_ostype) == "WINDOWS" ? local.application_server_count : 0) : 0
-  name                = format("%s%s%s", local.prefix, var.naming.separator, local.app_virtualmachine_names[count.index], local.resource_suffixes.vm)
+  name                = format("%s%s%s%s", local.prefix, var.naming.separator, local.app_virtualmachine_names[count.index], local.resource_suffixes.vm)
   computer_name       = local.app_computer_names[count.index]
   location            = var.resource-group[0].location
   resource_group_name = var.resource-group[0].name
@@ -126,7 +126,7 @@ resource "azurerm_windows_virtual_machine" "app" {
 # Creates managed data disk
 resource "azurerm_managed_disk" "app" {
   count                = local.enable_deployment ? length(local.app-data-disks) : 0
-  name                 = format("%s%s%s", local.prefix, var.naming.separator, local.app_virtualmachine_names[count.index], local.app-data-disks[count.index].suffix)
+  name                 = format("%s%s%s%s", local.prefix, var.naming.separator, local.app_virtualmachine_names[count.index], local.app-data-disks[count.index].suffix)
   location             = var.resource-group[0].location
   resource_group_name  = var.resource-group[0].name
   create_option        = "Empty"

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-app.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-app.tf
@@ -1,7 +1,7 @@
 # Create Application NICs
 resource "azurerm_network_interface" "app" {
   count                         = local.enable_deployment ? local.application_server_count : 0
-  name                          = format("%s_%s%s", local.prefix, local.app_virtualmachine_names[count.index], local.resource_suffixes.nic)
+  name                          = format("%s%s%s%s", local.prefix, var.naming.separator, local.app_virtualmachine_names[count.index], local.resource_suffixes.nic)
   location                      = var.resource-group[0].location
   resource_group_name           = var.resource-group[0].name
   enable_accelerated_networking = local.app_sizing.compute.accelerated_networking
@@ -17,7 +17,7 @@ resource "azurerm_network_interface" "app" {
 # Create the Linux Application VM(s)
 resource "azurerm_linux_virtual_machine" "app" {
   count               = local.enable_deployment ? (upper(local.app_ostype) == "LINUX" ? local.application_server_count : 0) : 0
-  name                = format("%s_%s%s", local.prefix, local.app_virtualmachine_names[count.index], local.resource_suffixes.vm)
+  name                = format("%s%s%s%s", local.prefix, var.naming.separator, local.app_virtualmachine_names[count.index], local.resource_suffixes.vm)
   computer_name       = local.app_computer_names[count.index]
   location            = var.resource-group[0].location
   resource_group_name = var.resource-group[0].name
@@ -44,7 +44,7 @@ resource "azurerm_linux_virtual_machine" "app" {
   disable_password_authentication = true
 
   os_disk {
-    name                 = format("%s_%s%s", local.prefix, local.app_virtualmachine_names[count.index], local.resource_suffixes.osdisk)
+    name                 = format("%s%s%s%s", local.prefix, var.naming.separator, local.app_virtualmachine_names[count.index], local.resource_suffixes.osdisk)
     caching              = "ReadWrite"
     storage_account_type = "Standard_LRS"
   }
@@ -74,7 +74,7 @@ resource "azurerm_linux_virtual_machine" "app" {
 # Create the Windows Application VM(s)
 resource "azurerm_windows_virtual_machine" "app" {
   count               = local.enable_deployment ? (upper(local.app_ostype) == "WINDOWS" ? local.application_server_count : 0) : 0
-  name                = format("%s_%s%s", local.prefix, local.app_virtualmachine_names[count.index], local.resource_suffixes.vm)
+  name                = format("%s%s%s", local.prefix, var.naming.separator, local.app_virtualmachine_names[count.index], local.resource_suffixes.vm)
   computer_name       = local.app_computer_names[count.index]
   location            = var.resource-group[0].location
   resource_group_name = var.resource-group[0].name
@@ -101,7 +101,7 @@ resource "azurerm_windows_virtual_machine" "app" {
   admin_password = local.authentication.password
 
   os_disk {
-    name                 = format("%s_%s%s", local.prefix, local.app_virtualmachine_names[count.index], local.resource_suffixes.osdisk)
+    name                 = format("%s%s%s%s", local.prefix, var.naming.separator, local.app_virtualmachine_names[count.index], local.resource_suffixes.osdisk)
     caching              = "ReadWrite"
     storage_account_type = "Standard_LRS"
   }
@@ -126,7 +126,7 @@ resource "azurerm_windows_virtual_machine" "app" {
 # Creates managed data disk
 resource "azurerm_managed_disk" "app" {
   count                = local.enable_deployment ? length(local.app-data-disks) : 0
-  name                 = format("%s_%s%s", local.prefix, local.app_virtualmachine_names[count.index], local.app-data-disks[count.index].suffix)
+  name                 = format("%s%s%s", local.prefix, var.naming.separator, local.app_virtualmachine_names[count.index], local.app-data-disks[count.index].suffix)
   location             = var.resource-group[0].location
   resource_group_name  = var.resource-group[0].name
   create_option        = "Empty"

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-scs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-scs.tf
@@ -1,7 +1,7 @@
 # Create SCS NICs
 resource "azurerm_network_interface" "scs" {
   count                         = local.enable_deployment ? local.scs_server_count : 0
-  name                          = format("%s_%s%s", local.prefix, local.scs_virtualmachine_names[count.index], local.resource_suffixes.nic)
+  name                          = format("%s%s%s%s", local.prefix, var.naming.separator, local.scs_virtualmachine_names[count.index], local.resource_suffixes.nic)
   location                      = var.resource-group[0].location
   resource_group_name           = var.resource-group[0].name
   enable_accelerated_networking = local.scs_sizing.compute.accelerated_networking
@@ -25,7 +25,7 @@ resource "azurerm_network_interface_backend_address_pool_association" "scs" {
 # Create the SCS Linux VM(s)
 resource "azurerm_linux_virtual_machine" "scs" {
   count               = local.enable_deployment && (upper(local.app_ostype) == "LINUX") ? local.scs_server_count : 0
-  name                = format("%s_%s%s", local.prefix, local.scs_virtualmachine_names[count.index], local.resource_suffixes.vm)
+  name                = format("%s%s%s%s", local.prefix, var.naming.separator, local.scs_virtualmachine_names[count.index], local.resource_suffixes.vm)
   computer_name       = local.scs_computer_names[count.index]
   location            = var.resource-group[0].location
   resource_group_name = var.resource-group[0].name
@@ -52,7 +52,7 @@ resource "azurerm_linux_virtual_machine" "scs" {
   disable_password_authentication = true
 
   os_disk {
-    name                 = format("%s_%s%s", local.prefix, local.scs_virtualmachine_names[count.index], local.resource_suffixes.osdisk)
+    name                 = format("%s%s%s%s", local.prefix, var.naming.separator, local.scs_virtualmachine_names[count.index], local.resource_suffixes.osdisk)
     caching              = "ReadWrite"
     storage_account_type = "Standard_LRS"
   }
@@ -82,7 +82,7 @@ resource "azurerm_linux_virtual_machine" "scs" {
 # Create the SCS Windows VM(s)
 resource "azurerm_windows_virtual_machine" "scs" {
   count               = local.enable_deployment && (upper(local.app_ostype) == "WINDOWS") ? local.scs_server_count : 0
-  name                = format("%s_%s%s", local.prefix, local.scs_virtualmachine_names[count.index], local.resource_suffixes.vm)
+  name                = format("%s%s%s%s", local.prefix, var.naming.separator, local.scs_virtualmachine_names[count.index], local.resource_suffixes.vm)
   computer_name       = local.scs_computer_names[count.index]
   location            = var.resource-group[0].location
   resource_group_name = var.resource-group[0].name
@@ -109,7 +109,7 @@ resource "azurerm_windows_virtual_machine" "scs" {
   admin_password = local.authentication.password
 
   os_disk {
-    name                 = format("%s_%s%s", local.prefix, local.scs_virtualmachine_names[count.index], local.resource_suffixes.osdisk)
+    name                 = format("%s%s%s%s", local.prefix, var.naming.separator, local.scs_virtualmachine_names[count.index], local.resource_suffixes.osdisk)
     caching              = "ReadWrite"
     storage_account_type = "Standard_LRS"
   }
@@ -134,7 +134,7 @@ resource "azurerm_windows_virtual_machine" "scs" {
 # Creates managed data disk
 resource "azurerm_managed_disk" "scs" {
   count                = local.enable_deployment ? length(local.scs-data-disks) : 0
-  name                 = format("%s_%s%s", local.prefix, local.scs_virtualmachine_names[count.index], local.scs-data-disks[count.index].suffix)
+  name                 = format("%s%s%s%s", local.prefix, var.naming.separator, local.scs_virtualmachine_names[count.index], local.scs-data-disks[count.index].suffix)
   location             = var.resource-group[0].location
   resource_group_name  = var.resource-group[0].name
   create_option        = "Empty"

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-webdisp.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-webdisp.tf
@@ -1,7 +1,7 @@
 # Create Web dispatcher NICs
 resource "azurerm_network_interface" "web" {
   count                         = local.enable_deployment ? local.webdispatcher_count : 0
-  name                          = format("%s_%s%s", local.prefix, local.web_virtualmachine_names[count.index], local.resource_suffixes.nic)
+  name                          = format("%s%s%s%s", local.prefix, var.naming.separator, local.web_virtualmachine_names[count.index], local.resource_suffixes.nic)
   location                      = var.resource-group[0].location
   resource_group_name           = var.resource-group[0].name
   enable_accelerated_networking = local.web_sizing.compute.accelerated_networking
@@ -20,7 +20,7 @@ resource "azurerm_network_interface" "web" {
 # Create the Linux Web dispatcher VM(s)
 resource "azurerm_linux_virtual_machine" "web" {
   count               = local.enable_deployment ? (upper(local.app_ostype) == "LINUX" ? local.webdispatcher_count : 0) : 0
-  name                = format("%s_%s%s", local.prefix, local.web_virtualmachine_names[count.index], local.resource_suffixes.vm)
+  name                = format("%s%s%s%s", local.prefix, var.naming.separator, local.web_virtualmachine_names[count.index], local.resource_suffixes.vm)
   computer_name       = local.web_computer_names[count.index]
   location            = var.resource-group[0].location
   resource_group_name = var.resource-group[0].name
@@ -46,7 +46,7 @@ resource "azurerm_linux_virtual_machine" "web" {
   disable_password_authentication = true
 
   os_disk {
-    name                 = format("%s_%s%s", local.prefix, local.web_virtualmachine_names[count.index], local.resource_suffixes.osdisk)
+    name                 = format("%s%s%s%s", local.prefix, var.naming.separator, local.web_virtualmachine_names[count.index], local.resource_suffixes.osdisk)
     caching              = "ReadWrite"
     storage_account_type = "Standard_LRS"
   }
@@ -76,7 +76,7 @@ resource "azurerm_linux_virtual_machine" "web" {
 # Create the Windows Web dispatcher VM(s)
 resource "azurerm_windows_virtual_machine" "web" {
   count               = local.enable_deployment ? (upper(local.app_ostype) == "WINDOWS" ? local.webdispatcher_count : 0) : 0
-  name                = format("%s_%s%s", local.prefix, local.web_virtualmachine_names[count.index], local.resource_suffixes.vm)
+  name                = format("%s%s%s%s", local.prefix, var.naming.separator, local.web_virtualmachine_names[count.index], local.resource_suffixes.vm)
   computer_name       = local.web_computer_names[count.index]
   location            = var.resource-group[0].location
   resource_group_name = var.resource-group[0].name
@@ -102,7 +102,7 @@ resource "azurerm_windows_virtual_machine" "web" {
   admin_password = local.authentication.password
 
   os_disk {
-    name                 = format("%s_%s%s", local.prefix, local.web_virtualmachine_names[count.index], local.resource_suffixes.osdisk)
+    name                 = format("%s%s%s%s", local.prefix, var.naming.separator, local.web_virtualmachine_names[count.index], local.resource_suffixes.osdisk)
     caching              = "ReadWrite"
     storage_account_type = "Standard_LRS"
   }
@@ -127,7 +127,7 @@ resource "azurerm_windows_virtual_machine" "web" {
 # Creates managed data disk
 resource "azurerm_managed_disk" "web" {
   count                = local.enable_deployment ? length(local.web-data-disks) : 0
-  name                 = format("%s_%s%s", local.prefix, local.web_virtualmachine_names[count.index], local.web-data-disks[count.index].suffix)
+  name                 = format("%s%s%s%s", local.prefix, var.naming.separator, local.web_virtualmachine_names[count.index], local.web-data-disks[count.index].suffix)
   location             = var.resource-group[0].location
   resource_group_name  = var.resource-group[0].name
   create_option        = "Empty"

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/infrastructure.tf
@@ -75,7 +75,7 @@ resource "azurerm_storage_account" "storage-bootdiag" {
 
 resource "azurerm_proximity_placement_group" "ppg" {
   count               = local.ppg_exists ? 0 : (local.zonal_deployment ? max(length(local.zones), 1) : 1)
-  name                = local.zonal_deployment ? format("%s_z%s%s", local.prefix, local.zones[count.index], local.resource_suffixes.ppg) : local.ppg_name
+  name                = local.zonal_deployment ? format("%s%sz%s%s", local.prefix, var.naming.separator, local.zones[count.index], local.resource_suffixes.ppg) : local.ppg_name
   resource_group_name = local.rg_exists ? data.azurerm_resource_group.resource-group[0].name : azurerm_resource_group.resource-group[0].name
   location            = local.rg_exists ? data.azurerm_resource_group.resource-group[0].location : azurerm_resource_group.resource-group[0].location
 }

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/iscsi.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/iscsi.tf
@@ -65,7 +65,7 @@ iSCSI device IP address range: .4 -
 # Creates the NIC and IP address for iSCSI device
 resource "azurerm_network_interface" "iscsi" {
   count               = local.iscsi_count
-  name                = format("%s_%s%s", local.prefix, local.virtualmachine_names[count.index], local.resource_suffixes.nic)
+  name                = format("%s%s%s%s", local.prefix, var.naming.separator, local.virtualmachine_names[count.index], local.resource_suffixes.nic)
   location            = local.rg_exists ? data.azurerm_resource_group.resource-group[0].location : azurerm_resource_group.resource-group[0].location
   resource_group_name = local.rg_exists ? data.azurerm_resource_group.resource-group[0].name : azurerm_resource_group.resource-group[0].name
 
@@ -87,7 +87,7 @@ resource "azurerm_network_interface_security_group_association" "iscsi" {
 # Manages Linux Virtual Machine for iSCSI
 resource "azurerm_linux_virtual_machine" "iscsi" {
   count                           = local.iscsi_count
-  name                            = format("%s_%s%s", local.prefix, local.virtualmachine_names[count.index], local.resource_suffixes.vm)
+  name                            = format("%s%s%s%s", local.prefix, var.naming.separator, local.virtualmachine_names[count.index], local.resource_suffixes.vm)
   computer_name                   = local.virtualmachine_names[count.index]
   location                        = local.rg_exists ? data.azurerm_resource_group.resource-group[0].location : azurerm_resource_group.resource-group[0].location
   resource_group_name             = local.rg_exists ? data.azurerm_resource_group.resource-group[0].name : azurerm_resource_group.resource-group[0].name
@@ -98,7 +98,7 @@ resource "azurerm_linux_virtual_machine" "iscsi" {
   disable_password_authentication = local.iscsi.authentication.type != "password" ? true : false
 
   os_disk {
-    name                 = format("%s_%s%s", local.prefix, local.virtualmachine_names[count.index], local.resource_suffixes.osdisk)
+    name                 = format("%s%s%s%s", local.prefix, var.naming.separator, local.virtualmachine_names[count.index], local.resource_suffixes.osdisk)
     caching              = "ReadWrite"
     storage_account_type = "Premium_LRS"
   }

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/infrastructure.tf
@@ -81,7 +81,7 @@ resource "azurerm_subnet_network_security_group_association" "Associate-db" {
 
 resource "azurerm_availability_set" "hdb" {
   count                        = local.enable_deployment ? max(length(local.zones), 1) : 0
-  name                         = local.zonal_deployment ? format("%s_z%s%s", local.prefix, local.zones[count.index], local.resource_suffixes.db-avset) : format("%s%s", local.prefix, local.resource_suffixes.db-avset)
+  name                         = local.zonal_deployment ? format("%s%sz%s%s", local.prefix, var.naming.separator, local.zones[count.index], local.resource_suffixes.db-avset) : format("%s%s", local.prefix, local.resource_suffixes.db-avset)
   location                     = var.resource-group[0].location
   resource_group_name          = var.resource-group[0].name
   platform_update_domain_count = 20

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/variables_local.tf
@@ -137,7 +137,7 @@ locals {
   shine                  = try(local.hdb.shine, { email = "shinedemo@microsoft.com" })
 
   dbnodes = flatten([[for idx, dbnode in try(local.hdb.dbnodes, [{}]) : {
-    name         = try("${dbnode.name}-0", format("%s_%s%s", local.prefix, local.virtualmachine_names[idx], local.resource_suffixes.vm))
+    name         = try("${dbnode.name}-0", format("%s%s%s%s", local.prefix, var.naming.separator, local.virtualmachine_names[idx], local.resource_suffixes.vm))
     computername = try("${dbnode.name}-0", local.computer_names[idx], local.resource_suffixes.vm)
     role         = try(dbnode.role, "worker")
     admin_nic_ip = lookup(dbnode, "admin_nic_ips", [false, false])[0]
@@ -145,7 +145,7 @@ locals {
     }
     ],
     [for idx, dbnode in try(local.hdb.dbnodes, [{}]) : {
-      name         = try("${dbnode.name}-1", format("%s_%s%s", local.prefix, local.virtualmachine_names[idx + local.node_count], local.resource_suffixes.vm))
+      name         = try("${dbnode.name}-1", format("%s%s%s%s", local.prefix, var.naming.separator, local.virtualmachine_names[idx + local.node_count], local.resource_suffixes.vm))
       computername = try("${dbnode.name}-1", local.computer_names[idx + local.node_count])
       role         = try(dbnode.role, "worker")
       admin_nic_ip = lookup(dbnode, "admin_nic_ips", [false, false])[1]


### PR DESCRIPTION
## Problem
The current solution has a hardcoded separator "_" that separates the resource prefix and the resource name. For customers who implement their naming convention there is no way of overriding the separator

## Solution
Make the separator to be part of the naming module with the default value "_", if customers want to override the naming module they can specify the separator to another string or keep it empty

 //The separator to use between the prefix and resource name
  separator = "_"

and return it from the naming module
output.tf
....
 separator = local.separator

the naming logic becomes
name                = format("%s%s%s%s", local.prefix, **var.naming.separator**, local.app_virtualmachine_names[count.index], local.resource_suffixes.vm)

## Tests
<Please provide steps to test the PR>

## Notes
<Additional comments for the PR>