### PR TITLE
move tfstate_source_id to the root level and simplify importing deployer logic

### DIFF
--- a/.pipeline/templates/saplandscape/create-saplandscape-steps.yml
+++ b/.pipeline/templates/saplandscape/create-saplandscape-steps.yml
@@ -104,8 +104,8 @@ steps:
       cat ${ws_dir}/saplandscape.json \
       | jq --arg saplandscape_rg "${saplandscape_rg}" .infrastructure.resource_group.name\ =\ \$saplandscape_rg \
       | jq --arg environment "${saplandscape_prefix}" .infrastructure.environment\ =\ \$environment \
-      | jq --arg tfstate_resource_id "${tfstate_resource_id}" .infrastructure.vnets.management.tfstate_resource_id\ =\ \$tfstate_resource_id \
-      | jq --arg deployer_tfstate_key "${deployer_tfstate_key}" .infrastructure.vnets.management.deployer_tfstate_key\ =\ \$deployer_tfstate_key \
+      | jq --arg tfstate_resource_id "${tfstate_resource_id}" .tfstate_resource_id\ =\ \$tfstate_resource_id \
+      | jq --arg deployer_tfstate_key "${deployer_tfstate_key}" .deployer_tfstate_key\ =\ \$deployer_tfstate_key \
       | jq --arg sap_vnet_address_space "${sap_vnet_address_space}" .infrastructure.vnets.sap.address_space\ =\ \$sap_vnet_address_space \
       | jq --arg subnet_iscsi_prefix "${subnet_iscsi_prefix}" .infrastructure.vnets.sap.subnet_iscsi.prefix\ =\ \$subnet_iscsi_prefix \
       | jq --arg saplib_rg "${saplib_rg}" .software.storage_account_sapbits.saplib_resource_group_name\ =\ \$saplib_rg \

--- a/.pipeline/templates/sapsystem/create-sapsystem-steps.yml
+++ b/.pipeline/templates/sapsystem/create-sapsystem-steps.yml
@@ -133,8 +133,8 @@ steps:
       cp ${repo_dir}/deploy/terraform/run/sap_system/sapsystem.json ${ws_dir}/sapsystem.json
       cat ${ws_dir}/sapsystem.json \
       | jq --arg environment "${sapsystem_prefix}" .infrastructure.environment\ =\ \$environment \
-      | jq --arg tfstate_resource_id "${tfstate_resource_id}" .infrastructure.vnets.management.tfstate_resource_id\ =\ \$tfstate_resource_id \
-      | jq --arg deployer_tfstate_key "${deployer_tfstate_key}" .infrastructure.vnets.management.deployer_tfstate_key\ =\ \$deployer_tfstate_key \
+      | jq --arg tfstate_resource_id "${tfstate_resource_id}" .tfstate_resource_id\ =\ \$tfstate_resource_id \
+      | jq --arg deployer_tfstate_key "${deployer_tfstate_key}" .deployer_tfstate_key\ =\ \$deployer_tfstate_key \
       | jq .infrastructure.vnets.sap.is_existing\ =\ \"true\" \
       | jq --arg saplandscape_sap_vnet_arm_id "${saplandscape_sap_vnet_arm_id}" .infrastructure.vnets.sap.arm_id\ =\ \$saplandscape_sap_vnet_arm_id \
       | jq --arg sap_vnet_address_space "${sap_vnet_address_space}" .infrastructure.vnets.sap.address_space\ =\ \$sap_vnet_address_space \

--- a/deploy/terraform/run/sap_landscape/saplandscape.json
+++ b/deploy/terraform/run/sap_landscape/saplandscape.json
@@ -1,4 +1,6 @@
 {
+    "tfstate_resource_id": "",
+    "deployer_tfstate_key": "",
     "infrastructure": {
         "region": "eastus",
         "environment": "global",
@@ -8,10 +10,6 @@
             "name": "azure-test-saplandscape-rg"
         },
         "vnets": {
-            "management": {
-                "tfstate_resource_id": "",
-                "deployer_tfstate_key": ""
-            },
             "sap": {
                 "address_space": "10.1.0.0/16",
                 "subnet_iscsi": {

--- a/deploy/terraform/run/sap_system/imports.tf
+++ b/deploy/terraform/run/sap_system/imports.tf
@@ -1,6 +1,6 @@
 /*
     Description:
-      Import deployer resources
+      Retrieve remote tfstate file of Deployer and current environment's SPN
 */
 
 data "terraform_remote_state" "deployer" {

--- a/deploy/terraform/run/sap_system/module.tf
+++ b/deploy/terraform/run/sap_system/module.tf
@@ -3,17 +3,6 @@
   Setup common infrastructure
 */
 
-module "deployer" {
-  source         = "../../terraform-units/modules/sap_system/deployer"
-  application    = var.application
-  databases      = var.databases
-  infrastructure = var.infrastructure
-  jumpboxes      = var.jumpboxes
-  options        = var.options
-  software       = var.software
-  ssh-timeout    = var.ssh-timeout
-  sshkey         = var.sshkey
-}
 
 module "common_infrastructure" {
   source              = "../../terraform-units/modules/sap_system/common_infrastructure"
@@ -27,11 +16,8 @@ module "common_infrastructure" {
   ssh-timeout         = var.ssh-timeout
   sshkey              = var.sshkey
   subnet-sap-admin    = module.hdb_node.subnet-sap-admin
-  vnet-mgmt           = module.deployer.vnet-mgmt
-  subnet-mgmt         = module.deployer.subnet-mgmt
-  nsg-mgmt            = module.deployer.nsg-mgmt
-  deployer-uai        = module.deployer.deployer-uai
   service_principal   = local.service_principal
+  deployer_tfstate    = data.terraform_remote_state.deployer.outputs
   // Comment out code with users.object_id for the time being.
   // deployer_user       = module.deployer.deployer_user
 }
@@ -54,7 +40,7 @@ module "jumpbox" {
   output-json       = module.output_files.output-json
   ansible-inventory = module.output_files.ansible-inventory
   random-id         = module.common_infrastructure.random-id
-  deployer-uai      = module.deployer.deployer-uai
+  deployer_tfstate  = data.terraform_remote_state.deployer.outputs
 }
 
 // Create HANA database nodes
@@ -76,7 +62,6 @@ module "hdb_node" {
   ppg              = module.common_infrastructure.ppg
   random-id        = module.common_infrastructure.random-id
   sid_kv_user      = module.common_infrastructure.sid_kv_user
-  deployer-uai     = module.deployer.deployer-uai
   // Comment out code with users.object_id for the time being.
   // deployer_user    = module.deployer.deployer_user
 }
@@ -99,7 +84,6 @@ module "app_tier" {
   ppg              = module.common_infrastructure.ppg
   random-id        = module.common_infrastructure.random-id
   sid_kv_user      = module.common_infrastructure.sid_kv_user
-  deployer-uai     = module.deployer.deployer-uai
   // Comment out code with users.object_id for the time being.  
   // deployer_user    = module.deployer.deployer_user
 }
@@ -153,6 +137,6 @@ module "output_files" {
   nics-anydb                   = module.anydb_node.nics-anydb
   any-database-info            = module.anydb_node.any-database-info
   anydb-loadbalancers          = module.anydb_node.anydb-loadbalancers
-  deployers                    = module.deployer.import_deployer
+  deployer_tfstate             = data.terraform_remote_state.deployer.outputs
   random-id                    = module.common_infrastructure.random-id
 }

--- a/deploy/terraform/run/sap_system/providers.tf
+++ b/deploy/terraform/run/sap_system/providers.tf
@@ -28,11 +28,11 @@ provider "azurerm" {
 }
 
 provider "azuread" {
-  version         = ">= 0.10.0"
+  version = ">= 0.10.0"
 
-  client_id       = local.spn.client_id
-  client_secret   = local.spn.client_secret
-  tenant_id       = local.spn.tenant_id
+  client_id     = local.spn.client_id
+  client_secret = local.spn.client_secret
+  tenant_id     = local.spn.tenant_id
 }
 
 terraform {

--- a/deploy/terraform/run/sap_system/sapsystem.json
+++ b/deploy/terraform/run/sap_system/sapsystem.json
@@ -1,4 +1,6 @@
 {
+  "tfstate_resource_id": "",
+  "deployer_tfstate_key": "",
   "infrastructure": {
     "region": "eastus",
     "environment": "np",
@@ -11,10 +13,6 @@
       "sid_public_key_secret_name": ""
     },
     "vnets": {
-      "management": {
-        "tfstate_resource_id": "",
-        "deployer_tfstate_key": ""
-      },
       "sap": {
         "is_existing": "false",
         "arm_id": "",

--- a/deploy/terraform/run/sap_system/variables_local.tf
+++ b/deploy/terraform/run/sap_system/variables_local.tf
@@ -45,7 +45,7 @@ locals {
 
 // Import deployer information for ansible.tf
 locals {
-  import_deployer = module.deployer.import_deployer
+  import_deployer = data.terraform_remote_state.deployer.outputs.deployer
 }
 
 locals {

--- a/deploy/terraform/run/sap_system/variables_local.tf
+++ b/deploy/terraform/run/sap_system/variables_local.tf
@@ -13,6 +13,14 @@ variable "scenario" {
   default     = "HANA Database"
 }
 
+variable "tfstate_resource_id" {
+  description = "Resource id of tfstate storage account"
+}
+
+variable "deployer_tfstate_key" {
+  description = "The key of deployer's remote tfstate file"
+}
+
 # Set defaults
 locals {
 
@@ -44,16 +52,13 @@ locals {
   // The environment of sap landscape and sap system
   environment = upper(try(var.infrastructure.environment, ""))
 
-  // Get deployer remote tfstate info
-  deployer_config = try(var.infrastructure.vnets.management, {})
-
   // Locate the tfstate storage account
-  tfstate_resource_id          = try(local.deployer_config.tfstate_resource_id, "")
+  tfstate_resource_id          = try(var.tfstate_resource_id, "")
   saplib_subscription_id       = split("/", local.tfstate_resource_id)[2]
   saplib_resource_group_name   = split("/", local.tfstate_resource_id)[4]
   tfstate_storage_account_name = split("/", local.tfstate_resource_id)[8]
   tfstate_container_name       = "tfstate"
-  deployer_tfstate_key         = try(local.deployer_config.deployer_tfstate_key, "")
+  deployer_tfstate_key         = try(var.deployer_tfstate_key, "")
 
   // Retrieve the arm_id of deployer's Key Vault from deployer's terraform.tfstate
   deployer_key_vault_arm_id = try(data.terraform_remote_state.deployer.outputs.deployer_kv_user_arm_id, "")
@@ -70,6 +75,6 @@ locals {
     client_id       = local.spn.client_id,
     client_secret   = local.spn.client_secret,
     tenant_id       = local.spn.tenant_id,
-    object_id       = data.azuread_service_principal.sp.id 
+    object_id       = data.azuread_service_principal.sp.id
   }
 }

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/variables_local.tf
@@ -22,10 +22,6 @@ variable "random-id" {
   description = "Random hex string"
 }
 
-variable "deployer-uai" {
-  description = "Details of the UAI used by deployer(s)"
-}
-
 variable "deployer_user" {
   description = "Details of the users"
   default     = []

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/infrastructure.tf
@@ -40,9 +40,9 @@ data "azurerm_virtual_network" "vnet-sap" {
 # Peers management VNET to SAP VNET
 resource "azurerm_virtual_network_peering" "peering-management-sap" {
   count                        = local.vnet_sap_exists ? 0 : 1
-  name                         = substr(format("%s_to_%s", var.vnet-mgmt.name, local.vnet_sap_exists ? data.azurerm_virtual_network.vnet-sap[0].name : azurerm_virtual_network.vnet-sap[0].name), 0, 80)
-  resource_group_name          = var.vnet-mgmt.resource_group_name
-  virtual_network_name         = var.vnet-mgmt.name
+  name                         = substr(format("%s_to_%s", local.vnet-mgmt.name, local.vnet_sap_exists ? data.azurerm_virtual_network.vnet-sap[0].name : azurerm_virtual_network.vnet-sap[0].name), 0, 80)
+  resource_group_name          = local.vnet-mgmt.resource_group_name
+  virtual_network_name         = local.vnet-mgmt.name
   remote_virtual_network_id    = local.vnet_sap_exists ? data.azurerm_virtual_network.vnet-sap[0].id : azurerm_virtual_network.vnet-sap[0].id
   allow_virtual_network_access = true
 }
@@ -50,10 +50,10 @@ resource "azurerm_virtual_network_peering" "peering-management-sap" {
 # Peers SAP VNET to management VNET
 resource "azurerm_virtual_network_peering" "peering-sap-management" {
   count                        = local.vnet_sap_exists ? 0 : 1
-  name                         = substr(format("%s_to_%s", local.vnet_sap_exists ? data.azurerm_virtual_network.vnet-sap[0].name : azurerm_virtual_network.vnet-sap[0].name, var.vnet-mgmt.name), 0, 80)
+  name                         = substr(format("%s_to_%s", local.vnet_sap_exists ? data.azurerm_virtual_network.vnet-sap[0].name : azurerm_virtual_network.vnet-sap[0].name, local.vnet-mgmt.name), 0, 80)
   resource_group_name          = local.vnet_sap_exists ? data.azurerm_virtual_network.vnet-sap[0].resource_group_name : azurerm_virtual_network.vnet-sap[0].resource_group_name
   virtual_network_name         = local.vnet_sap_exists ? data.azurerm_virtual_network.vnet-sap[0].name : azurerm_virtual_network.vnet-sap[0].name
-  remote_virtual_network_id    = var.vnet-mgmt.id
+  remote_virtual_network_id    = local.vnet-mgmt.id
   allow_virtual_network_access = true
   allow_forwarded_traffic      = true
 }

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/outputs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/outputs.tf
@@ -7,11 +7,11 @@ output "vnet-sap" {
 }
 
 output "subnet-mgmt" {
-  value = var.subnet-mgmt
+  value = local.subnet-mgmt
 }
 
 output "nsg-mgmt" {
-  value = var.nsg-mgmt
+  value = local.nsg-mgmt
 }
 
 output "storage-bootdiag" {

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/variables_local.tf
@@ -13,25 +13,14 @@ variable "subnet-sap-admin" {
   description = "Information about SAP admin subnet"
 }
 
-variable "vnet-mgmt" {
-  description = "Details about management vnet of deployer(s)"
-}
-
-variable "subnet-mgmt" {
-  description = "Details about management subnet of deployer(s)"
-}
-
-variable "nsg-mgmt" {
-  description = "Details about management nsg of deployer(s)"
+variable "deployer_tfstate" {
+  description = "Deployer remote tfstate file"
 }
 
 variable "service_principal" {
   description = "Current service principal used to authenticate to Azure"
 }
 
-variable "deployer-uai" {
-  description = "Details of the UAI used by deployer(s)"
-}
 /* Comment out code with users.object_id for the time being
 variable "deployer_user" {
   description = "Details of the users"
@@ -78,6 +67,12 @@ variable "region_mapping" {
 
 //Set defaults
 locals {
+
+  // Retrieve information about Deployer from tfstate file
+  deployer_tfstate = var.deployer_tfstate
+  vnet-mgmt        = local.deployer_tfstate.vnet_mgmt
+  subnet-mgmt      = local.deployer_tfstate.subnet_mgmt
+  nsg-mgmt         = local.deployer_tfstate.nsg_mgmt
 
   //Filter the list of databases to only HANA platform entries
   hana-databases = [

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/variables_local.tf
@@ -26,15 +26,6 @@ variable "random-id" {
   description = "Random hex string"
 }
 
-variable "deployer-uai" {
-  description = "Details of the UAI used by deployer(s)"
-}
-
-variable "deployer_user" {
-  description = "Details of the users"
-  default     = []
-}
-
 variable "sid_kv_user" {
   description = "Details of the user keyvault for sap_system"
 }

--- a/deploy/terraform/terraform-units/modules/sap_system/jumpbox/certificates.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/jumpbox/certificates.tf
@@ -20,7 +20,7 @@ resource "azurerm_key_vault" "key-vault" {
 
   access_policy {
     tenant_id = data.azurerm_client_config.current.tenant_id
-    object_id = var.deployer-uai.principal_id
+    object_id = local.deployer-uai.principal_id
 
     certificate_permissions = [
       "create",

--- a/deploy/terraform/terraform-units/modules/sap_system/jumpbox/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/jumpbox/variables_local.tf
@@ -26,11 +26,15 @@ variable "random-id" {
   description = "Random hex for creating unique Azure key vault name"
 }
 
-variable "deployer-uai" {
-  description = "Details of the UAI used by deployer(s)"
+variable "deployer_tfstate" {
+  description = "Deployer tfstate file"
 }
 
 locals {
+
+  // Retrieve deployer information from tfstate file
+  deployer-uai = var.deployer_tfstate.deployer-uai
+
   output-tf = jsondecode(var.output-json.content)
 
   # Linux jumpbox information

--- a/deploy/terraform/terraform-units/modules/sap_system/jumpbox/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/jumpbox/variables_local.tf
@@ -33,7 +33,7 @@ variable "deployer_tfstate" {
 locals {
 
   // Retrieve deployer information from tfstate file
-  deployer-uai = var.deployer_tfstate.deployer-uai
+  deployer-uai = var.deployer_tfstate.deployer_uai
 
   output-tf = jsondecode(var.output-json.content)
 

--- a/deploy/terraform/terraform-units/modules/sap_system/output_files/inventory.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/output_files/inventory.tf
@@ -120,7 +120,7 @@ resource "local_file" "ansible-inventory" {
     ips-web               = local.ips-web
     anydbnodes            = local.anydb_vms,
     ips-anydbnodes        = local.ips-anydbnodes,
-    deployers             = var.deployers
+    deployers             = local.deployers
     }
   )
   filename             = "${path.cwd}/ansible_config_files/hosts"

--- a/deploy/terraform/terraform-units/modules/sap_system/output_files/inventory.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/output_files/inventory.tf
@@ -146,7 +146,7 @@ resource "local_file" "ansible-inventory-yml" {
     ips-web               = local.ips-web
     anydbnodes            = local.anydb_vms,
     ips-anydbnodes        = local.ips-anydbnodes,
-    deployers             = var.deployers
+    deployers             = local.deployers
     }
   )
   filename             = "${path.cwd}/ansible_config_files/hosts.yml"

--- a/deploy/terraform/terraform-units/modules/sap_system/output_files/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/output_files/variables_local.tf
@@ -78,11 +78,14 @@ variable "any-database-info" {
   description = "Updated anydb database json"
 }
 
-variable "deployers" {
-  description = "Details of the deployer(s)"
+variable "deployer_tfstate" {
+  description = "Deployer tfstate file"
 }
 
 locals {
+  // Retrieve deployer information from tfstate file
+  deployers = var.deployer_tfstate.deployer
+
   ips-iscsi                    = var.nics-iscsi[*].private_ip_address
   ips-jumpboxes-windows        = var.nics-jumpboxes-windows[*].private_ip_address
   ips-jumpboxes-linux          = var.nics-jumpboxes-linux[*].private_ip_address
@@ -146,5 +149,5 @@ locals {
       ]
     ])
     if adatabase != {}
-  ])
+  ]) 
 }


### PR DESCRIPTION
## Problem
<Please describe what problem this PR is trying to resolve>
1. Based on the feedbacks,  "tfstate_source_id" and "deployer_tfstate_key" need to be moved the root level of input json.

2. Currently, importing deployer is implemented in a child module of sapsystem. Everytime, the input json about importing deployer has a change, both run/sap_system and terraform-units/sap_system need to be changed.

## Solution
<Please elaborate the solution for the problem>
1. move tfstate_source_id and "deployer_tfstate_key" to the root level. 

2. split "importing deployer's terraform tfstate file" logic from sapsystem.
To simplify the structure and make our system better support multi-subscription in the future, importing deployer will be split form sapsystem child module, and will be implemented  in the root module run/sapsystem/imports.tf, and the remote tfstate file retrieved will be passed to the child modules.

3. Clean some not in use arguments. 


## Tests
<Please provide steps to test the PR>

## Notes
<Additional comments for the PR>