### PR TITLE
comment out nsg of web and clean output of common_infrastructure

### DIFF
--- a/deploy/terraform/run/sap_system/module.tf
+++ b/deploy/terraform/run/sap_system/module.tf
@@ -3,7 +3,6 @@
   Setup common infrastructure
 */
 
-
 module "common_infrastructure" {
   source              = "../../terraform-units/modules/sap_system/common_infrastructure"
   is_single_node_hana = "true"
@@ -34,8 +33,6 @@ module "jumpbox" {
   ssh-timeout       = var.ssh-timeout
   sshkey            = var.sshkey
   resource-group    = module.common_infrastructure.resource-group
-  subnet-mgmt       = module.common_infrastructure.subnet-mgmt
-  nsg-mgmt          = module.common_infrastructure.nsg-mgmt
   storage-bootdiag  = module.common_infrastructure.storage-bootdiag
   output-json       = module.output_files.output-json
   ansible-inventory = module.output_files.ansible-inventory
@@ -55,8 +52,6 @@ module "hdb_node" {
   ssh-timeout      = var.ssh-timeout
   sshkey           = var.sshkey
   resource-group   = module.common_infrastructure.resource-group
-  subnet-mgmt      = module.common_infrastructure.subnet-mgmt
-  nsg-mgmt         = module.common_infrastructure.nsg-mgmt
   vnet-sap         = module.common_infrastructure.vnet-sap
   storage-bootdiag = module.common_infrastructure.storage-bootdiag
   ppg              = module.common_infrastructure.ppg
@@ -78,7 +73,6 @@ module "app_tier" {
   ssh-timeout      = var.ssh-timeout
   sshkey           = var.sshkey
   resource-group   = module.common_infrastructure.resource-group
-  subnet-mgmt      = module.common_infrastructure.subnet-mgmt
   vnet-sap         = module.common_infrastructure.vnet-sap
   storage-bootdiag = module.common_infrastructure.storage-bootdiag
   ppg              = module.common_infrastructure.ppg

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/nsg-webdisp.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/nsg-webdisp.tf
@@ -36,6 +36,8 @@ resource "azurerm_network_security_rule" "webRule_internet" {
   network_security_group_name  = local.sub_web_nsg_deployed.name
 }
 
+/*
+   Comment out this nsg rule temporarily, because of peering between vnet-mgmt and vnet-sap, mgmt-subnet can access subnet-web by default.
 # NSG rule to open ports for Web dispatcher
 resource "azurerm_network_security_rule" "web" {
   count                        = local.enable_deployment ? (local.sub_web_nsg_exists ? 0 : length(local.nsg-ports.web)) : 0
@@ -51,3 +53,4 @@ resource "azurerm_network_security_rule" "web" {
   resource_group_name          = var.resource-group[0].name
   network_security_group_name  = local.sub_web_nsg_deployed.name
 }
+*/

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/variables_local.tf
@@ -2,10 +2,6 @@ variable "resource-group" {
   description = "Details of the resource group"
 }
 
-variable "subnet-mgmt" {
-  description = "Details of the management subnet"
-}
-
 variable "vnet-sap" {
   description = "Details of the SAP VNet"
 }

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/outputs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/outputs.tf
@@ -6,14 +6,6 @@ output "vnet-sap" {
   value = local.vnet_sap_exists ? data.azurerm_virtual_network.vnet-sap : azurerm_virtual_network.vnet-sap
 }
 
-output "subnet-mgmt" {
-  value = local.subnet-mgmt
-}
-
-output "nsg-mgmt" {
-  value = local.nsg-mgmt
-}
-
 output "storage-bootdiag" {
   value = azurerm_storage_account.storage-bootdiag
 }

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/variables_local.tf
@@ -2,14 +2,6 @@ variable "resource-group" {
   description = "Details of the resource group"
 }
 
-variable "subnet-mgmt" {
-  description = "Details of the management subnet"
-}
-
-variable "nsg-mgmt" {
-  description = "Details of the NSG for management subnet"
-}
-
 variable "vnet-sap" {
   description = "Details of the SAP VNet"
 }

--- a/deploy/terraform/terraform-units/modules/sap_system/jumpbox/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/jumpbox/variables_local.tf
@@ -2,14 +2,6 @@ variable "resource-group" {
   description = "Details of the resource group"
 }
 
-variable "subnet-mgmt" {
-  description = "Details of the management subnet"
-}
-
-variable "nsg-mgmt" {
-  description = "Details of the management NSG"
-}
-
 variable "storage-bootdiag" {
   description = "Details of the boot diagnostics storage account"
 }
@@ -34,6 +26,8 @@ locals {
 
   // Retrieve deployer information from tfstate file
   deployer-uai = var.deployer_tfstate.deployer_uai
+  subnet-mgmt  = var.deployer_tfstate.subnet_mgmt
+  nsg-mgmt     = var.deployer_tfstate.nsg_mgmt
 
   output-tf = jsondecode(var.output-json.content)
 

--- a/deploy/terraform/terraform-units/modules/sap_system/jumpbox/vm-jump-linux.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/jumpbox/vm-jump-linux.tf
@@ -30,7 +30,7 @@ resource "azurerm_network_interface" "jump-linux" {
 
   ip_configuration {
     name                          = "ipconfig1"
-    subnet_id                     = var.subnet-mgmt.id
+    subnet_id                     = local.subnet-mgmt.id
     private_ip_address            = local.vm-jump-linux[count.index].private_ip_address
     private_ip_address_allocation = "static"
     public_ip_address_id          = azurerm_public_ip.jump-linux[count.index].id
@@ -41,7 +41,7 @@ resource "azurerm_network_interface" "jump-linux" {
 resource "azurerm_network_interface_security_group_association" "jump-linux" {
   count                     = length(local.vm-jump-linux)
   network_interface_id      = azurerm_network_interface.jump-linux[count.index].id
-  network_security_group_id = var.nsg-mgmt.id
+  network_security_group_id = local.nsg-mgmt.id
 }
 
 # Manages Linux Virtual Machine for Linux jumpboxes

--- a/deploy/terraform/terraform-units/modules/sap_system/jumpbox/vm-jump-win.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/jumpbox/vm-jump-win.tf
@@ -30,7 +30,7 @@ resource "azurerm_network_interface" "jump-win" {
 
   ip_configuration {
     name                          = "ipconfig1"
-    subnet_id                     = var.subnet-mgmt.id
+    subnet_id                     = local.subnet-mgmt.id
     private_ip_address            = local.vm-jump-win[count.index].private_ip_address
     private_ip_address_allocation = "static"
     public_ip_address_id          = azurerm_public_ip.jump-win[count.index].id
@@ -41,7 +41,7 @@ resource "azurerm_network_interface" "jump-win" {
 resource "azurerm_network_interface_security_group_association" "jump-win" {
   count                     = length(local.vm-jump-win)
   network_interface_id      = azurerm_network_interface.jump-win[count.index].id
-  network_security_group_id = var.nsg-mgmt.id
+  network_security_group_id = local.nsg-mgmt.id
 }
 
 # Manages Windows Virtual Machine for Windows jumpboxes


### PR DESCRIPTION
## Problem
<Please describe what problem this PR is trying to resolve>
1. one NSG rule of webdispatcher may be redundant. Peering between vnet-mgmt and vnet-sap can allow mgmt-subnet to access subnet-web by default

2. Currently common_infrastructure output vnet-mgmt, subnet-mgmt, and nsg-mgmt. These information can be fetched from deployer's tfstate directly, there's no need to let common_infrastructure pass these information to other child modules.

## Solution
<Please elaborate the solution for the problem>
1. Comment out NSG rule of webdispatcher temporarily. After thorough test, the comment can be removed.

2. Get rid of output vnet-mgmt, subnet-mgmt, and nsg-mgmt in common_infrastructure. Simplify module.tf


## Tests
<Please provide steps to test the PR>

see test result in test pipeline down below.

## Notes
<Additional comments for the PR>