### PR TITLE
remove deployer from output_files module

### DIFF
--- a/deploy/terraform/run/sap_system/module.tf
+++ b/deploy/terraform/run/sap_system/module.tf
@@ -131,6 +131,5 @@ module "output_files" {
   nics-anydb                   = module.anydb_node.nics-anydb
   any-database-info            = module.anydb_node.any-database-info
   anydb-loadbalancers          = module.anydb_node.anydb-loadbalancers
-  deployer_tfstate             = data.terraform_remote_state.deployer.outputs
   random-id                    = module.common_infrastructure.random-id
 }

--- a/deploy/terraform/terraform-units/modules/sap_system/output_files/ansible_inventory.tmpl
+++ b/deploy/terraform/terraform-units/modules/sap_system/output_files/ansible_inventory.tmpl
@@ -45,14 +45,6 @@ ${ips-jumpboxes-linux[index(jumpboxes-linux, jumpbox-linux)]}  ansible_connectio
 ${ips-jumpboxes-linux[index(jumpboxes-linux, jumpbox-linux)]}  ansible_connection=ssh  ansible_user=${jumpbox-linux.authentication.username}  ansible_ssh_pass=${jumpbox-linux.authentication.password}  ansible_become_pass=${jumpbox-linux.authentication.password}
 %{~ endif }
 %{~ endfor }
-%{~ for deployer in deployers }
-%{~ if deployer.authentication.type == "key" }
-localhost  ansible_connection=local  ansible_user=${deployer.authentication.username}
-%{~ endif }
-%{~ if deployer.authentication.type == "password" }
-localhost  ansible_connection=local  ansible_user=${deployer.authentication.username}  ansible_ssh_pass=${deployer.authentication.password}  ansible_become_pass=${deployer.authentication.password}
-%{~ endif }
-%{~ endfor }
 %{~ for ip-dbnode-admin in ips-dbnodes-admin }
 %{~ if dbnodes[index(ips-dbnodes-admin, ip-dbnode-admin)].authentication.type == "key" }
 ${ip-dbnode-admin}  ansible_connection=ssh  ansible_user=${dbnodes[index(ips-dbnodes-admin, ip-dbnode-admin)].authentication.username}

--- a/deploy/terraform/terraform-units/modules/sap_system/output_files/inventory.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/output_files/inventory.tf
@@ -120,7 +120,6 @@ resource "local_file" "ansible-inventory" {
     ips-web               = local.ips-web
     anydbnodes            = local.anydb_vms,
     ips-anydbnodes        = local.ips-anydbnodes,
-    deployers             = local.deployers
     }
   )
   filename             = "${path.cwd}/ansible_config_files/hosts"
@@ -146,7 +145,6 @@ resource "local_file" "ansible-inventory-yml" {
     ips-web               = local.ips-web
     anydbnodes            = local.anydb_vms,
     ips-anydbnodes        = local.ips-anydbnodes,
-    deployers             = local.deployers
     }
   )
   filename             = "${path.cwd}/ansible_config_files/hosts.yml"

--- a/deploy/terraform/terraform-units/modules/sap_system/output_files/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/output_files/variables_local.tf
@@ -70,6 +70,7 @@ variable "nics-anydb" {
 variable "random-id" {
   description = "Random hex string"
 }
+
 variable "anydb-loadbalancers" {
   description = "List of LoadBalancers created for HANA Databases"
 }
@@ -78,13 +79,7 @@ variable "any-database-info" {
   description = "Updated anydb database json"
 }
 
-variable "deployer_tfstate" {
-  description = "Deployer tfstate file"
-}
-
 locals {
-  // Retrieve deployer information from tfstate file
-  deployers = var.deployer_tfstate.deployer
 
   ips-iscsi                    = var.nics-iscsi[*].private_ip_address
   ips-jumpboxes-windows        = var.nics-jumpboxes-windows[*].private_ip_address


### PR DESCRIPTION
## Problem
<Please describe what problem this PR is trying to resolve>
Ansible stage doesn't need deployer's information.

## Solution
<Please elaborate the solution for the problem>
Get rid of importing deployer's tfstate logic in sapsystem module.

## Tests
<Please provide steps to test the PR>

## Notes
<Additional comments for the PR>