### PR TITLE
Add spn logon to ansible steps

### DIFF
--- a/.pipeline/templates/ansible/ansible-playbook-steps.yml
+++ b/.pipeline/templates/ansible/ansible-playbook-steps.yml
@@ -6,6 +6,9 @@ steps:
       ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no -o ConnectTimeout=$(ssh_timeout_s) "$(username)"@"$(publicIP)" '
       source /etc/profile.d/deploy_server.sh
 
+      echo "=== Login using pipeline spn ==="
+      az login --service-principal -u $(hana-pipeline-spn-id) -p $(hana-pipeline-spn-pw) --tenant $(landscape-tenant) --output none
+
       saplandscape_rg=${{parameters.saplandscape_rg_name}}
       sapsystem_rg_name=${{parameters.sapsystem_rg_name}}
       repo_dir=$HOME/Azure_SAP_Automated_Deployment/sap-hana


### PR DESCRIPTION
## Problem
msi no longer has access to sap_landscape KV.

## Solution
On deployer, logon with SPN before retrieving SSH key.

## Tests
https://dev.azure.com/azuresaphana/Azure-SAP-HANA/_build/results?buildId=13554&view=logs&j=9f023c7a-31b1-56e6-342c-b6c6c5b3b1c2

## Notes
<Additional comments for the PR>