### PR TITLE
Change deployer vnet from MGMT to DEP00 in cleanup job

### DIFF
--- a/azure-pipelines-cleanup.yaml
+++ b/azure-pipelines-cleanup.yaml
@@ -34,7 +34,7 @@ jobs:
   steps:
   - script: |
       az login --service-principal --user $(hana-pipeline-spn-id) --password  $(hana-pipeline-spn-pw) --tenant $(landscape-tenant) --output none
-      deployer_rg="UNIT-EAUS-MGMT-INFRASTRUCTURE"
+      deployer_rg="UNIT-EAUS-DEP00-INFRASTRUCTURE"
       mgmt_vnet=$(az network vnet list --resource-group ${deployer_rg} | jq -r '.[].name')
       peering_list=$(az network vnet peering list --resource-group ${deployer_rg} --vnet-name ${mgmt_vnet} | jq -c '.[] | select(.peeringState=="Disconnected")' | jq -r .name)
       for peering in ${peering_list}
@@ -50,7 +50,7 @@ jobs:
   - script: |
       az login --service-principal --user $(hana-pipeline-spn-id) --password  $(hana-pipeline-spn-pw) --tenant $(landscape-tenant) --output none
       
-      rg_name="UNIT-EAUS-MGMT-INFRASTRUCTURE"
+      rg_name="UNIT-EAUS-DEP00-INFRASTRUCTURE"
 
       vnet_name=$(az network vnet list --resource-group ${rg_name} | jq -r .[].name)
       subnet_name=$(az network vnet list --resource-group ${rg_name} | jq -r .[].subnets[].name)


### PR DESCRIPTION
## Problem
The RG name still uses MGMT instead of DEP00 in cleanup job.

## Solution
Change deployer RG from *MGMT* to *DEP00*

## Tests
https://dev.azure.com/azuresaphana/Azure-SAP-HANA/_build/results?buildId=13735&view=results

## Notes
Have to cherry pick this to other branches as well.