### PR TITLE
Use offset table for vm nic offsets

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/infrastructure.tf
@@ -14,7 +14,12 @@ resource "azurerm_lb" "anydb" {
     name                          = format("%s%s", local.prefix, local.resource_suffixes.db_alb_feip)
     subnet_id                     = local.sub_db_exists ? data.azurerm_subnet.anydb[0].id : azurerm_subnet.anydb[0].id
     private_ip_address_allocation = "Static"
-    private_ip_address            = local.sub_db_exists ? try(local.anydb.loadbalancer.frontend_ip, cidrhost(local.sub_db_exists ? data.azurerm_subnet.anydb[0].address_prefixes[0] : azurerm_subnet.anydb[0].address_prefixes[0], tonumber(count.index) + 4)) : cidrhost(local.sub_db_exists ? data.azurerm_subnet.anydb[0].address_prefixes[0] : azurerm_subnet.anydb[0].address_prefixes[0], tonumber(count.index) + 4)
+    private_ip_address = try(local.anydb.loadbalancer.frontend_ip,
+      cidrhost(local.sub_db_exists ?
+        data.azurerm_subnet.anydb[0].address_prefixes[0] :
+        azurerm_subnet.anydb[0].address_prefixes[0],
+      tonumber(count.index) + local.anydb_ip_offsets.anydb_lb)
+    )
   }
 }
 

--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/variables_local.tf
@@ -243,6 +243,14 @@ locals {
     }
   ]
 
+  // Subnet IP Offsets
+  // Note: First 4 IP addresses in a subnet are reserved by Azure
+  anydb_ip_offsets = {
+    anydb_lb       = 4
+    anydb_admin_vm = 10
+    anydb_db_vm    = 10
+  }
+
   // Ports used for specific DB Versions
   lb_ports = {
     "ASE" = [

--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/vm-anydb.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/vm-anydb.tf
@@ -18,7 +18,7 @@ resource "azurerm_network_interface" "anydb_db" {
       cidrhost(local.sub_db_exists ? (
         data.azurerm_subnet.anydb[0].address_prefixes[0]) : (
         azurerm_subnet.anydb[0].address_prefixes[0]
-      ), tonumber(count.index) + 10)
+      ), tonumber(count.index) + local.anydb_ip_offsets.anydb_db_vm)
     )
 
     private_ip_address_allocation = "static"
@@ -40,7 +40,7 @@ resource "azurerm_network_interface" "anydb_admin" {
 
     private_ip_address = try(local.anydb_vms[count.index].admin_nic_ip, false) != false ? (
       local.anydb_vms[count.index].admin_nic_ip) : (
-      cidrhost(var.admin_subnet[0].address_prefixes[0], tonumber(count.index) + 10)
+      cidrhost(var.admin_subnet[0].address_prefixes[0], tonumber(count.index) + local.anydb_ip_offsets.anydb_admin_vm)
     )
     private_ip_address_allocation = "static"
   }

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/variables_local.tf
@@ -231,6 +231,11 @@ locals {
     app_vm = 4 + 10
     web_vm = local.sub_web_defined ? (4 + 2) : -3
   }
+  admin_ip_offsets = {
+    scs_vm = 4 + 16
+    app_vm = 4 + 11
+    web_vm = 4 + 21
+  }
 
   // Default VM config should be merged with any the user passes in
   app_sizing = lookup(local.sizes.app, local.vm_sizing, lookup(local.sizes.app, "Default"))

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-app.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-app.tf
@@ -33,7 +33,7 @@ resource "azurerm_network_interface" "app_admin" {
     subnet_id = var.admin_subnet.id
     private_ip_address = try(local.app_admin_nic_ips[count.index],
       cidrhost(var.admin_subnet.address_prefixes[0],
-        tonumber(count.index) + 15
+        tonumber(count.index) + local.admin_ip_offsets.app_vm
       )
     )
     private_ip_address_allocation = "static"

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-scs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-scs.tf
@@ -33,7 +33,7 @@ resource "azurerm_network_interface" "scs_admin" {
     subnet_id = var.admin_subnet.id
     private_ip_address = try(local.scs_admin_nic_ips[count.index],
       cidrhost(var.admin_subnet.id.address_prefixes[0],
-        tonumber(count.index) + 20
+        tonumber(count.index) + local.admin_ip_offsets.scs_vm
       )
     )
     private_ip_address_allocation = "static"

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-webdisp.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-webdisp.tf
@@ -29,7 +29,7 @@ resource "azurerm_network_interface" "web_admin" {
     name      = "IPConfig1"
     subnet_id = var.admin_subnet.id
     private_ip_address = try(local.web_admin_nic_ips[count.index],
-      cidrhost(var.admin_subnet.address_prefixes[0], tonumber(count.index) + 25
+      cidrhost(var.admin_subnet.address_prefixes[0], tonumber(count.index) + local.admin_ip_offsets.web_vm
       )
     )
     private_ip_address_allocation = "static"

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/variables_local.tf
@@ -217,6 +217,14 @@ locals {
     }
   ]
 
+  // Subnet IP Offsets
+  // Note: First 4 IP addresses in a subnet are reserved by Azure
+  hdb_ip_offsets = {
+    hdb_lb       = 4
+    hdb_admin_vm = 10
+    hdb_db_vm    = 10
+  }
+
   // Ports used for specific HANA Versions
   lb_ports = {
     "1" = [

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/vm-hdb.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/vm-hdb.tf
@@ -24,7 +24,7 @@ resource "azurerm_network_interface" "nics_dbnodes_admin" {
     subnet_id = var.admin_subnet.id
     private_ip_address = lookup(local.hdb_vms[count.index], "admin_nic_ip", false) != false ? (
       local.hdb_vms[count.index].admin_nic_ip) : (
-      cidrhost(var.admin_subnet.address_prefixes[0], tonumber(count.index) + 10)
+      cidrhost(var.admin_subnet.address_prefixes[0], tonumber(count.index) + local.hdb_ip_offsets.hdb_admin_vm)
     )
 
     private_ip_address_allocation = "static"
@@ -50,7 +50,7 @@ resource "azurerm_network_interface" "nics_dbnodes_db" {
       cidrhost((local.sub_db_exists ? (
         data.azurerm_subnet.sap_db[0].address_prefixes[0]) : (
         azurerm_subnet.sap_db[0].address_prefixes[0])
-      ), tonumber(count.index) + 10)
+      ), tonumber(count.index) + local.hdb_ip_offsets.hdb_db_vm)
     )
     private_ip_address_allocation = "static"
   }
@@ -74,8 +74,8 @@ resource "azurerm_lb" "hdb" {
     subnet_id                     = local.sub_db_exists ? data.azurerm_subnet.sap_db[0].id : azurerm_subnet.sap_db[0].id
     private_ip_address_allocation = "Static"
     private_ip_address = try(local.hana_database.loadbalancer.frontend_ip, (local.sub_db_exists ? (
-      cidrhost(data.azurerm_subnet.sap_db[0].address_prefixes[0], tonumber(count.index) + 4)) : (
-      cidrhost(azurerm_subnet.sap_db[0].address_prefixes[0], tonumber(count.index) + 4)))
+      cidrhost(data.azurerm_subnet.sap_db[0].address_prefixes[0], tonumber(count.index) + local.hdb_ip_offsets.hdb_lb)) : (
+      cidrhost(azurerm_subnet.sap_db[0].address_prefixes[0], tonumber(count.index) + local.hdb_ip_offsets.hdb_lb)))
     )
   }
 }


### PR DESCRIPTION
## Problem
Now the offset is hardcoded in the vm configuration.
Especially with the admin nics.

## Solution
Make it a list of offsets and this way easier to modify if we decide to re-arrange the IPs.

## Tests
<Please provide steps to test the PR>

## Notes
<Additional comments for the PR>