### PR TITLE
Fix README.MD link

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -49,7 +49,7 @@ Step 2) [**Select Terraform Deployment Unit**](#terraform-deployment-units)
 
 ## Contributions
 
-If you want to contribute to our project, be sure to review the [contributing guidelines](/documentation/contributing.md).
+If you want to contribute to our project, be sure to review the [contributing guidelines](/CONTRIBUTING.md).
 
 We use [GitHub issues](https://github.com/Azure/sap-hana/issues/) for feature requests and bugs.
 


### PR DESCRIPTION
## Problem
There is an broken link in the README.MD that suppose to redirect the user to CONTRIBUTING.md when click

see #884

## Solution
The link is fix by providing the correct address

closes #884 

## Tests
Click the link to see if it redirect to the correct page

