### PR TITLE
Improve post deployer step so less failure due to NSG

### DIFF
--- a/.pipeline/templates/util/add-agent-to-deployer-nsg.yml
+++ b/.pipeline/templates/util/add-agent-to-deployer-nsg.yml
@@ -25,10 +25,14 @@ steps:
      
       echo "=== Update deployer NSG source address with agent IP ==="
       prefix_list=$(az network nsg rule show  -g ${rg_name} --nsg-name ${nsg_name} -n ssh | jq -r '.sourceAddressPrefix, (.sourceAddressPrefixes | join(" ")) | select(.!=null)')
-      az network nsg rule update -g ${rg_name} --nsg-name ${nsg_name} -n ssh --source-address-prefixes $(agent_ip) ${prefix_list} --output none
+      # this command always return success in case the pip is already assigned in the NSG.
+      az network nsg rule update -g ${rg_name} --nsg-name ${nsg_name} -n ssh --source-address-prefixes $(agent_ip) ${prefix_list} --output none || true
  
       echo "=== Assgin ${nsg_name} to deployer ${subnet_name} to avoid NRMS ==="
       az network vnet subnet update -g ${rg_name} -n ${subnet_name} --vnet-name ${vnet_name} --network-security-group ${nsg_name} --output none
+
+      echo "=== Wait 1 minute for the new NSG to take effective ==="
+      sleep 1m
     displayName: "Add agent IP to deployer NSG"
     env:
       ARM_CLIENT_ID: $(hana-pipeline-spn-id)

--- a/.pipeline/tf-integration-test.yml
+++ b/.pipeline/tf-integration-test.yml
@@ -36,6 +36,9 @@ stages:
       - template: templates/util/collect-deployer-info.yml
         parameters:
           deployer_env: "$(Build.BuildId)"
+      - template: templates/util/add-agent-to-deployer-nsg.yml
+        parameters:
+          deployer_env: "$(Build.BuildId)"
       - template: templates/deployer/post-deployer-steps.yml
         parameters:
           deployer_env: "$(Build.BuildId)"


### PR DESCRIPTION
## Problem
NSG blocks the post deployer step which will upload the tfstate to deployer.

## Solution
1. Reassign NSG and attempt to add agent IP to deployer NSG.
1. Set a wait time for 1 minute before trying to logon deployer from agent.

## Tests
https://dev.azure.com/azuresaphana/Azure-SAP-HANA/_build/results?buildId=14359&view=results

## Notes
Will cherry pick this change to all feature and beta branch, so the integration test will more likely to pass.