### PR TITLE
Remove workaround for deployer creation in pipeline

### DIFF
--- a/.pipeline/templates/deployer/create-deployer-steps.yml
+++ b/.pipeline/templates/deployer/create-deployer-steps.yml
@@ -49,9 +49,6 @@ steps:
       terraform -version
       terraform init -upgrade=true ${repo_path}/deploy/terraform/bootstrap/sap_deployer/
       terraform apply -auto-approve -var-file=${input} ${repo_path}/deploy/terraform/bootstrap/sap_deployer/
-      # Terraform apply twice to mitigate the issue: https://github.com/terraform-providers/terraform-provider-azurerm/issues/9107
-      sleep 5m
-      terraform apply -auto-approve -var-file=${input} ${repo_path}/deploy/terraform/bootstrap/sap_deployer/
     displayName: "Deploy deployer bootstrap: Branch ${{parameters.branch_name}}"
     condition: or(succeededOrFailed(), always())
     env:


### PR DESCRIPTION
## Problem
Issue: https://github.com/terraform-providers/terraform-provider-azurerm/issues/9114
A workaround had to be placed so that the deployer creation will succeed.

## Solution
The above issue has been fixed in azurerm 2.35.0, therefore we no longer need the workaround.

## Tests
https://dev.azure.com/azuresaphana/Azure-SAP-HANA/_build/results?buildId=14361&view=results

## Notes
Will cherry-pick this to all beta and feature branch.