### PR TITLE
Improve cleanup after deployment in pipeline

### DIFF
--- a/.pipeline/templates/saplandscape/delete-saplandscape-steps.yml
+++ b/.pipeline/templates/saplandscape/delete-saplandscape-steps.yml
@@ -61,6 +61,9 @@ steps:
       
       echo "=== Delete git clone for the build from deployer ==="
       rm -rf ~/${saplandscape_rg}
+
+      echo "=== Cleanup local .terraform ==="
+      rm -r ${ws_dir}/.terraform
       '
 
       vnet_name="${deployer_prefix}-EAUS-DEP00-vnet"
@@ -75,6 +78,9 @@ steps:
       az group delete -n ${saplandscape_rg} --no-wait -y
 
       # Delete SPN secrets from deployer KV
+      echo "=== Login using pipeline spn ==="
+      az login --service-principal -u $(hana-pipeline-spn-id) -p $(hana-pipeline-spn-pw) --tenant $(landscape-tenant) --output none
+
       echo "=== Delete SPN secrets from deployer KV ==="
       deployer_kv_name=$(az keyvault list --resource-group ${deployer_rg} | jq -r '.[] | select(.name | contains("user")).name')
       az keyvault secret delete --vault-name ${deployer_kv_name} --name ${saplandscape_prefix}-client-id --output none

--- a/.pipeline/templates/sapsystem/delete-sapsystem-steps.yml
+++ b/.pipeline/templates/sapsystem/delete-sapsystem-steps.yml
@@ -61,6 +61,9 @@ steps:
 
       echo "=== Delete git clone for the build from deployer ==="
       rm -rf ~/${sapsystem_rg}
+
+      echo "=== Cleanup local .terraform ==="
+      rm -r ${ws_dir}/.terraform
       '
 
       echo "=== Remove vnet peering with vnet-mgmt in case deployment/destroy fails ==="
@@ -74,6 +77,9 @@ steps:
       az group delete -n ${sapsystem_rg} --no-wait -y
 
       # Delete SPN secrets from deployer KV
+      echo "=== Login using pipeline spn ==="
+      az login --service-principal -u $(hana-pipeline-spn-id) -p $(hana-pipeline-spn-pw) --tenant $(landscape-tenant) --output none
+
       echo "=== Delete SPN secrets from deployer KV ==="
       deployer_kv_name=$(az keyvault list --resource-group ${deployer_rg} | jq -r '.[] | select(.name | contains("user")).name')
       az keyvault secret delete --vault-name ${deployer_kv_name} --name ${sapsystem_prefix}-client-id --output none


### PR DESCRIPTION
## Problem
1. With the new KV access policy, need to logon as pipeline SPN to cleanup SPN information stored in UNIT deployer KV.
1. `.terraform` folder has 253M which soon filled up the disk space on UNIT deployer.

## Solution
1. Add az login with pipeline SPN.
1. Keep the json in the workspace for trouble shooting but cleanup `.terraform` folder.

## Tests
https://dev.azure.com/azuresaphana/Azure-SAP-HANA/_build/results?buildId=14387&view=logs&j=d74fbdb8-21ab-504f-dfdd-a2f588aea454&t=df52d566-6f97-5759-01ad-b1b41d0c5555
https://dev.azure.com/azuresaphana/Azure-SAP-HANA/_build/results?buildId=14388&view=logs&j=4d5ce374-d25e-52bb-fc45-d97b802157cf&t=1469e00d-edcd-50af-9e72-1784eaff7d99

## Notes
This change will be cherry picked to all feature and beta branches.