### PR TITLE
fix a bug about storage_list when deploying saplandscape

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/variables_local.tf
@@ -106,7 +106,7 @@ locals {
 
   default_filepath = local.enable_hdb_deployment ? "${path.module}/../../../../../configs/hdb_sizes.json" : "${path.module}/../../../../../configs/anydb_sizes.json"
   sizes            = jsondecode(file(length(var.custom_disk_sizes_filename) > 0 ? var.custom_disk_sizes_filename : local.default_filepath))
-  storage_list     = lookup(local.sizes, var.databases[0].size).storage
+  storage_list     = length(var.databases) > 0 ? lookup(local.sizes, var.databases[0].size).storage : []
   enable_ultradisk = try(compact([
     for storage in local.storage_list :
     storage.disk_type == "UltraSSD_LRS" ? true : ""


### PR DESCRIPTION
## Problem
<Please describe what problem this PR is trying to resolve>
A bug when deploying saplandscape, var.database is empty, which leads to an error when referecing.

## Solution
<Please elaborate the solution for the problem>
Add a condition. If var.database is empty list, return []

## Tests
<Please provide steps to test the PR>

See test pipeline:

https://dev.azure.com/azuresaphana/Azure-SAP-HANA/_build/results?buildId=14445&view=results


## Notes
<Additional comments for the PR>