### PR TITLE
reference azure resource group implicitly to add dependency

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_library/key_vault.tf
+++ b/deploy/terraform/terraform-units/modules/sap_library/key_vault.tf
@@ -7,7 +7,7 @@
 resource "azurerm_key_vault" "kv_prvt" {
   name                       = local.keyvault_names.private_access
   location                   = local.region
-  resource_group_name        = local.rg_exists ? data.azurerm_resource_group.library[0].name : local.rg_name
+  resource_group_name        = local.rg_exists ? data.azurerm_resource_group.library[0].name : azurerm_resource_group.library[0].name
   tenant_id                  = local.service_principal.tenant_id
   soft_delete_enabled        = true
   soft_delete_retention_days = 7
@@ -28,7 +28,7 @@ resource "azurerm_key_vault" "kv_prvt" {
 resource "azurerm_key_vault" "kv_user" {
   name                       = local.keyvault_names.user_access
   location                   = local.region
-  resource_group_name        = local.rg_exists ? data.azurerm_resource_group.library[0].name : local.rg_name
+  resource_group_name        = local.rg_exists ? data.azurerm_resource_group.library[0].name : azurerm_resource_group.library[0].name
   tenant_id                  = local.service_principal.tenant_id
   soft_delete_enabled        = true
   soft_delete_retention_days = 7


### PR DESCRIPTION
## Problem
<Please describe what problem this PR is trying to resolve>
When provisioning kv of saplandscape, the following error exists:

![image](https://user-images.githubusercontent.com/62584551/98423946-14e02c00-2045-11eb-82f7-396870a1a998.png)

## Solution
<Please elaborate the solution for the problem>
reference azure resource group implicitly to add dependency between RG and KV, so that RG will be provisioned before KVs.

## Tests
<Please provide steps to test the PR>

https://dev.azure.com/azuresaphana/Azure-SAP-HANA/_build/results?buildId=14577&view=results

## Notes
<Additional comments for the PR>