### PR TITLE
Fixes for deployments without zone information

### DIFF
--- a/deploy/terraform/run/sap_system/imports.tf
+++ b/deploy/terraform/run/sap_system/imports.tf
@@ -11,7 +11,7 @@ data "terraform_remote_state" "deployer" {
     container_name       = local.tfstate_container_name
     key                  = local.deployer_tfstate_key
     subscription_id      = local.saplib_subscription_id
-    use_msi              = true
+   // use_msi              = true
   }
 }
 

--- a/deploy/terraform/run/sap_system/imports.tf
+++ b/deploy/terraform/run/sap_system/imports.tf
@@ -11,7 +11,7 @@ data "terraform_remote_state" "deployer" {
     container_name       = local.tfstate_container_name
     key                  = local.deployer_tfstate_key
     subscription_id      = local.saplib_subscription_id
-   // use_msi              = true
+    use_msi              = true
   }
 }
 

--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/variables_local.tf
@@ -56,7 +56,7 @@ locals {
   // Zones
   zones            = try(local.anydb.zones, [])
   zonal_deployment = length(local.zones) > 0 ? true : false
-  db_zone_count    = try(length(local.zones), 1)
+  db_zone_count    = length(local.zones)
 
   // SAP vnet
   var_infra       = try(var.infrastructure, {})

--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/vm-anydb.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/vm-anydb.tf
@@ -55,14 +55,14 @@ resource "azurerm_linux_virtual_machine" "dbserver" {
   resource_group_name = var.resource_group[0].name
   location            = var.resource_group[0].location
 
-  proximity_placement_group_id = local.zonal_deployment ? var.ppg[count.index % local.db_zone_count].id : var.ppg[0].id
+  proximity_placement_group_id = local.zonal_deployment ? var.ppg[count.index % max(local.db_zone_count,1)].id : var.ppg[0].id
   //Ultra disk requires zonal deployment
   availability_set_id = local.enable_ultradisk ? null : (
-    local.zonal_deployment && local.db_server_count == local.db_zone_count ? null : azurerm_availability_set.anydb[count.index % local.db_zone_count].id
+    local.zonal_deployment && local.db_server_count == local.db_zone_count ? null : azurerm_availability_set.anydb[count.index % max(local.db_zone_count,1)].id
   )
 
   zone = local.zonal_deployment ? (
-    local.db_server_count == local.db_zone_count ? local.zones[count.index % local.db_zone_count] : null) : (
+    local.db_server_count == local.db_zone_count ? local.zones[count.index % max(local.db_zone_count,1)] : null) : (
     null
   )
 
@@ -129,15 +129,15 @@ resource "azurerm_windows_virtual_machine" "dbserver" {
   resource_group_name = var.resource_group[0].name
   location            = var.resource_group[0].location
 
-  proximity_placement_group_id = local.zonal_deployment ? var.ppg[count.index % local.db_zone_count].id : var.ppg[0].id
+  proximity_placement_group_id = local.zonal_deployment ? var.ppg[count.index % max(local.db_zone_count,1)].id : var.ppg[0].id
   //If more than one servers are deployed into a single zone put them in an availability set and not a zone
   //Ultra disk requires zonal deployment
   availability_set_id = local.enable_ultradisk ? null : (
-    local.zonal_deployment && local.db_server_count == local.db_zone_count ? null : azurerm_availability_set.anydb[count.index % local.db_zone_count].id
+    local.zonal_deployment && local.db_server_count == local.db_zone_count ? null : azurerm_availability_set.anydb[count.index % max(local.db_zone_count,1)].id
   )
 
   zone = local.zonal_deployment ? (
-    local.db_server_count == local.db_zone_count ? local.zones[count.index % local.db_zone_count] : null) : (
+    local.db_server_count == local.db_zone_count ? local.zones[count.index % max(local.db_zone_count,1)] : null) : (
     null
   )
 

--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/vm-observer.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/vm-observer.tf
@@ -28,15 +28,15 @@ resource "azurerm_linux_virtual_machine" "observer" {
   resource_group_name = var.resource_group[0].name
   location            = var.resource_group[0].location
   //If more than one servers are deployed into a single zone put them in an availability set and not a zone
-  proximity_placement_group_id = local.zonal_deployment ? var.ppg[count.index % local.db_zone_count].id : var.ppg[0].id
+  proximity_placement_group_id = local.zonal_deployment ? var.ppg[count.index % max(local.db_zone_count,1)].id : var.ppg[0].id
   //If more than one servers are deployed into a single zone put them in an availability set and not a zone
   availability_set_id = local.zonal_deployment ? (
-    local.db_server_count == local.db_zone_count ? null : azurerm_availability_set.anydb[count.index % local.db_zone_count].id) : (
+    local.db_server_count == local.db_zone_count ? null : azurerm_availability_set.anydb[count.index % max(local.db_zone_count,1)].id) : (
     azurerm_availability_set.anydb[0].id
   )
 
   zone = local.zonal_deployment ? (
-    local.db_server_count == local.db_zone_count ? local.zones[count.index % local.db_zone_count] : null) : (
+    local.db_server_count == local.db_zone_count ? local.zones[count.index % max(local.db_zone_count,1)] : null) : (
     null
   )
 
@@ -83,15 +83,15 @@ resource "azurerm_windows_virtual_machine" "observer" {
   resource_group_name = var.resource_group[0].name
   location            = var.resource_group[0].location
   //If more than one servers are deployed into a single zone put them in an availability set and not a zone
-  proximity_placement_group_id = local.zonal_deployment ? var.ppg[count.index % local.db_zone_count].id : var.ppg[0].id
+  proximity_placement_group_id = local.zonal_deployment ? var.ppg[count.index % max(local.db_zone_count,1)].id : var.ppg[0].id
   //If more than one servers are deployed into a single zone put them in an availability set and not a zone
   availability_set_id = local.zonal_deployment ? (
-    local.db_server_count == local.db_zone_count ? null : azurerm_availability_set.anydb[count.index % local.db_zone_count].id) : (
+    local.db_server_count == local.db_zone_count ? null : azurerm_availability_set.anydb[count.index % max(local.db_zone_count,1)].id) : (
     azurerm_availability_set.anydb[0].id
   )
 
   zone = local.zonal_deployment ? (
-    local.db_server_count == local.db_zone_count ? local.zones[count.index % local.db_zone_count] : null) : (
+    local.db_server_count == local.db_zone_count ? local.zones[count.index % max(local.db_zone_count,1)] : null) : (
     null
   )
 

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-app.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-app.tf
@@ -52,14 +52,14 @@ resource "azurerm_linux_virtual_machine" "app" {
   availability_set_id = local.app_zonal_deployment && (local.application_server_count == local.app_zone_count) ? (
     null) : (
     local.app_zone_count > 1 ? (
-      azurerm_availability_set.app[count.index % local.app_zone_count].id) : (
+      azurerm_availability_set.app[count.index % max(local.app_zone_count,1)].id) : (
       azurerm_availability_set.app[0].id
     )
   )
 
-  proximity_placement_group_id = local.app_zonal_deployment ? var.ppg[count.index % local.app_zone_count].id : var.ppg[0].id
+  proximity_placement_group_id = local.app_zonal_deployment ? var.ppg[count.index % max(local.app_zone_count,1)].id : var.ppg[0].id
   zone = local.app_zonal_deployment && (local.application_server_count == local.app_zone_count) ? (
-    local.app_zones[count.index % local.app_zone_count]) : (
+    local.app_zones[count.index % max(local.app_zone_count,1)]) : (
   null)
 
   network_interface_ids = local.apptier_dual_nics ? (
@@ -115,13 +115,13 @@ resource "azurerm_windows_virtual_machine" "app" {
   availability_set_id = local.app_zonal_deployment && (local.application_server_count == local.app_zone_count) ? (
     null) : (
     local.app_zone_count > 1 ? (
-      azurerm_availability_set.app[count.index % local.app_zone_count].id) : (
+      azurerm_availability_set.app[count.index % max(local.app_zone_count,1)].id) : (
       azurerm_availability_set.app[0].id
     )
   )
-  proximity_placement_group_id = local.app_zonal_deployment ? var.ppg[count.index % local.app_zone_count].id : var.ppg[0].id
+  proximity_placement_group_id = local.app_zonal_deployment ? var.ppg[count.index % max(local.app_zone_count,1)].id : var.ppg[0].id
   zone = local.app_zonal_deployment && (local.application_server_count == local.app_zone_count) ? (
-    local.app_zones[count.index % local.app_zone_count]) : (
+    local.app_zones[count.index % max(local.app_zone_count,1)]) : (
   null)
 
   network_interface_ids = local.apptier_dual_nics ? (

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-scs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-scs.tf
@@ -60,13 +60,13 @@ resource "azurerm_linux_virtual_machine" "scs" {
   availability_set_id = local.scs_zonal_deployment && (local.scs_server_count == local.scs_zone_count) ? (
     null) : (
     local.scs_zone_count > 1 ? (
-      azurerm_availability_set.scs[count.index % local.scs_zone_count].id) : (
+      azurerm_availability_set.scs[count.index % max(local.scs_zone_count,1)].id) : (
       azurerm_availability_set.scs[0].id
     )
   )
-  proximity_placement_group_id = local.scs_zonal_deployment ? var.ppg[count.index % local.scs_zone_count].id : var.ppg[0].id
+  proximity_placement_group_id = local.scs_zonal_deployment ? var.ppg[count.index % max(local.scs_zone_count,1)].id : var.ppg[0].id
   zone = local.scs_zonal_deployment && (local.scs_server_count == local.scs_zone_count) ? (
-    local.scs_zones[count.index % local.scs_zone_count]) : (
+    local.scs_zones[count.index % max(local.scs_zone_count,1)]) : (
     null
   )
 
@@ -123,13 +123,13 @@ resource "azurerm_windows_virtual_machine" "scs" {
   availability_set_id = local.scs_zonal_deployment && (local.scs_server_count == local.scs_zone_count) ? (
     null) : (
     local.scs_zone_count > 1 ? (
-      azurerm_availability_set.scs[count.index % local.scs_zone_count].id) : (
+      azurerm_availability_set.scs[count.index % max(local.scs_zone_count,1)].id) : (
       azurerm_availability_set.scs[0].id
     )
   )
-  proximity_placement_group_id = local.scs_zonal_deployment ? var.ppg[count.index % local.scs_zone_count].id : var.ppg[0].id
+  proximity_placement_group_id = local.scs_zonal_deployment ? var.ppg[count.index % max(local.scs_zone_count,1)].id : var.ppg[0].id
   zone = local.scs_zonal_deployment && (local.scs_server_count == local.scs_zone_count) ? (
-    local.scs_zones[count.index % local.scs_zone_count]) : (
+    local.scs_zones[count.index % max(local.scs_zone_count,1)]) : (
     null
   )
 

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-webdisp.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-webdisp.tf
@@ -47,13 +47,13 @@ resource "azurerm_linux_virtual_machine" "web" {
   //If more than one servers are deployed into a zone put them in an availability set and not a zone
   availability_set_id = local.webdispatcher_count == local.web_zone_count ? null : (
     local.web_zone_count > 1 ? (
-      azurerm_availability_set.web[count.index % local.web_zone_count].id) : (
+      azurerm_availability_set.web[count.index % max(local.web_zone_count,1)].id) : (
       azurerm_availability_set.web[0].id
     )
   )
-  proximity_placement_group_id = local.web_zonal_deployment ? var.ppg[count.index % local.web_zone_count].id : var.ppg[0].id
+  proximity_placement_group_id = local.web_zonal_deployment ? var.ppg[count.index % max(local.web_zone_count,1)].id : var.ppg[0].id
   zone = local.web_zonal_deployment ? (
-    local.webdispatcher_count == local.web_zone_count ? local.web_zones[count.index % local.web_zone_count] : null) : (
+    local.webdispatcher_count == local.web_zone_count ? local.web_zones[count.index % max(local.web_zone_count,1)] : null) : (
     null
   )
 
@@ -109,13 +109,13 @@ resource "azurerm_windows_virtual_machine" "web" {
   //If more than one servers are deployed into a zone put them in an availability set and not a zone
   availability_set_id = local.webdispatcher_count == local.web_zone_count ? null : (
     local.web_zone_count > 1 ? (
-      azurerm_availability_set.web[count.index % local.web_zone_count].id) : (
+      azurerm_availability_set.web[count.index % max(local.web_zone_count,1)].id) : (
       azurerm_availability_set.web[0].id
     )
   )
-  proximity_placement_group_id = local.web_zonal_deployment ? var.ppg[count.index % local.web_zone_count].id : var.ppg[0].id
+  proximity_placement_group_id = local.web_zonal_deployment ? var.ppg[count.index % max(local.web_zone_count,1)].id : var.ppg[0].id
   zone = local.web_zonal_deployment ? (
-    local.webdispatcher_count == local.web_zone_count ? local.web_zones[count.index % local.web_zone_count] : null) : (
+    local.webdispatcher_count == local.web_zone_count ? local.web_zones[count.index % max(local.web_zone_count,1)] : null) : (
     null
   )
 

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/variables_local.tf
@@ -103,7 +103,7 @@ locals {
   // Zones
   zones            = try(local.hdb.zones, [])
   zonal_deployment = length(local.zones) > 0 ? true : false
-  db_zone_count    = try(length(local.zones), 1)
+  db_zone_count    = length(local.zones)
 
   hdb_platform = try(local.hdb.platform, "NONE")
   hdb_version  = try(local.hdb.db_version, "2.00.043")

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/vm-hdb.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/vm-hdb.tf
@@ -133,14 +133,14 @@ resource "azurerm_linux_virtual_machine" "vm_dbnode" {
   location            = var.resource_group[0].location
   resource_group_name = var.resource_group[0].name
 
-  proximity_placement_group_id = local.zonal_deployment ? var.ppg[count.index % local.db_zone_count].id : var.ppg[0].id
+  proximity_placement_group_id = local.zonal_deployment ? var.ppg[count.index % max(local.db_zone_count,1)].id : var.ppg[0].id
   //If more than one servers are deployed into a single zone put them in an availability set and not a zone
   //Ultra disk requires zonal deployment
   availability_set_id = local.enable_ultradisk ? null : (
-    local.zonal_deployment && local.db_server_count == local.db_zone_count ? null : azurerm_availability_set.hdb[count.index % local.db_zone_count].id
+    local.zonal_deployment && local.db_server_count == local.db_zone_count ? null : azurerm_availability_set.hdb[count.index % max(local.db_zone_count,1)].id
   )
 
-  zone = local.enable_ultradisk || local.db_server_count == local.db_zone_count ? local.zones[count.index % local.db_zone_count] : null
+  zone = local.enable_ultradisk || local.db_server_count == local.db_zone_count ? local.zones[count.index % max(local.db_zone_count,1)] : null
 
   network_interface_ids = [
     azurerm_network_interface.nics_dbnodes_admin[count.index].id,


### PR DESCRIPTION
## Problem
Deployment without zonal information fails

## Solution
Use  max(local.zone_count,1) instead of local.zone_count

## Tests
<Please provide steps to test the PR>

## Notes
<Additional comments for the PR>