### PR TITLE
Import existing vnet with arm_id

### DIFF
--- a/deploy/terraform/run/sap_landscape/saplandscape_full.json
+++ b/deploy/terraform/run/sap_landscape/saplandscape_full.json
@@ -5,12 +5,12 @@
         "environment": "np",
         "region": "eastus",
         "resource_group": {
-            "is_existing": "false",
             "arm_id": "",
             "name": "azure-test-saplandscape-rg"
         },
         "vnets": {
             "sap": {
+                "arm_id": "",
                 "address_space": "10.1.0.0/16",
                 "subnet_iscsi": {
                     "name": "global-eaus-sap0_iscsi-subnet",


### PR DESCRIPTION
## Problem
It is possible to use existing vnet by providing `arm_id`.

## Solution
1. Add `arm_id` for `vnet.sap` in `deploy/terraform/run/sap_landscape/saplandscape_full.json` which suppose to cover most possible configurations.
1. Remove `is_existing` from `resource_group`, since this key is not used:
`rg_exists = length(local.rg_arm_id) > 0 ? true : false`

## Tests
<Please provide steps to test the PR>

## Notes
<Additional comments for the PR>