### PR TITLE
Change default deployer vnet name from mgmt to dep00

### DIFF
--- a/deploy/terraform/bootstrap/sap_deployer/variables_local.tf
+++ b/deploy/terraform/bootstrap/sap_deployer/variables_local.tf
@@ -10,7 +10,7 @@ locals {
   vnet_mgmt_exists = length(local.vnet_mgmt_arm_id) > 0 ? true : false
 
   //There is no default as the name is mandatory unless arm_id is specified
-  vnet_mgmt_name = local.vnet_mgmt_exists ? split("/", local.vnet_mgmt_arm_id)[8] : try(local.vnet_mgmt.name, "MGMT")
+  vnet_mgmt_name = local.vnet_mgmt_exists ? split("/", local.vnet_mgmt_arm_id)[8] : try(local.vnet_mgmt.name, "DEP00")
 
   // Default naming of vnet has multiple parts. Taking the second-last part as the name incase the name ends with -vnet
   vnet_mgmt_parts     = length(split("-", local.vnet_mgmt_name))

--- a/deploy/terraform/run/sap_deployer/variables_local.tf
+++ b/deploy/terraform/run/sap_deployer/variables_local.tf
@@ -1,7 +1,7 @@
 locals {
-  environment          = lower(try(var.infrastructure.environment, ""))
-  location             = try(var.infrastructure.region, "")
-  codename             = lower(try(var.infrastructure.codename, ""))
+  environment = lower(try(var.infrastructure.environment, ""))
+  location    = try(var.infrastructure.region, "")
+  codename    = lower(try(var.infrastructure.codename, ""))
 
   // Management vnet
   vnet_mgmt        = try(var.infrastructure.vnets.management, {})
@@ -9,11 +9,11 @@ locals {
   vnet_mgmt_exists = length(local.vnet_mgmt_arm_id) > 0 ? true : false
 
   //There is no default as the name is mandatory unless arm_id is specified
-  vnet_mgmt_name = local.vnet_mgmt_exists ? split("/", local.vnet_mgmt_arm_id)[8] : try(local.vnet_mgmt.name, "MGMT")
+  vnet_mgmt_name = local.vnet_mgmt_exists ? split("/", local.vnet_mgmt_arm_id)[8] : try(local.vnet_mgmt.name, "DEP00")
 
   // Default naming of vnet has multiple parts. Taking the second-last part as the name incase the name ends with -vnet
   vnet_mgmt_parts     = length(split("-", local.vnet_mgmt_name))
   vnet_mgmt_name_part = try(substr(upper(local.vnet_mgmt_name), -5, 5), "") == "-VNET" ? substr(split("-", local.vnet_mgmt_name)[(local.vnet_mgmt_parts - 2)], 0, 7) : local.vnet_mgmt_name
-  
+
   deployer_vm_count = length(var.deployers)
 }


### PR DESCRIPTION
## Problem
Two variables_local.tf that are introduced with naming convention does not use DEP00 as default deployer vnet name.

## Solution
Change to use DEP00

## Tests
<Please provide steps to test the PR>

## Notes
Need to cherry-pick to beta/v2.3