### PR TITLE
Region fix, zone logic validation, DNS variables

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_landscape/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/variables_local.tf
@@ -18,7 +18,7 @@ variable naming {
 locals {
   // Resources naming
   vnet_prefix              = var.naming.prefix.VNET
-  storageaccount_name      = var.naming.storageaccount_names.SDU
+  storageaccount_name      = var.naming.storageaccount_names.VNET
   landscape_keyvault_names = var.naming.keyvault_names.VNET
   sid_keyvault_names       = var.naming.keyvault_names.SDU
   virtualmachine_names     = var.naming.virtualmachine_names.ISCSI_COMPUTERNAME

--- a/deploy/terraform/terraform-units/modules/sap_namegenerator/output.tf
+++ b/deploy/terraform/terraform-units/modules/sap_namegenerator/output.tf
@@ -35,26 +35,26 @@ output naming {
     }
     virtualmachine_names = {
       APP_COMPUTERNAME         = local.app_computer_names
-      APP_SECONDARY_DNSNAME    = local.app_computer_dnsnames
+      APP_SECONDARY_DNSNAME    = local.app_secondary_dnsnames
       APP_VMNAME               = local.app_server_vm_names
       ANCHOR_COMPUTERNAME      = local.anchor_computer_names
-      ANCHOR_SECONDARY_DNSNAME = local.anchor_computer_dnsnames
+      ANCHOR_SECONDARY_DNSNAME = local.anchor_secondary_dnsnames
       ANCHOR_VMNAME            = local.anchor_vm_names
       ANYDB_COMPUTERNAME       = concat(local.anydb_computer_names, local.anydb_computer_names_ha)
-      ANYDB_SECONDARY_DNSNAME  = concat(local.anydb_computer_dnsnames, local.anydb_computer_dnsnames_ha)
+      ANYDB_SECONDARY_DNSNAME  = concat(local.anydb_secondary_dnsnames, local.anydb_secondary_dnsnames_ha)
       ANYDB_VMNAME             = concat(local.anydb_vm_names, local.anydb_vm_names_ha)
       DEPLOYER                 = local.deployer_vm_names
       HANA_COMPUTERNAME        = concat(local.hana_computer_names, local.hana_computer_names_ha)
-      HANA_SECONDARY_DNSNAME   = concat(local.hana_computer_dnsnames, local.hana_computer_dnsnames_ha)
+      HANA_SECONDARY_DNSNAME   = concat(local.hana_secondary_dnsnames, local.hana_secondary_dnsnames_ha)
       HANA_VMNAME              = concat(local.hana_server_vm_names, local.hana_server_vm_names_ha)
       ISCSI_COMPUTERNAME       = local.iscsi_server_names
       OBSERVER_COMPUTERNAME    = local.observer_computer_names
       OBSERVER_VMNAME          = local.observer_vm_names
       SCS_COMPUTERNAME         = local.scs_computer_names
-      SCS_SECONDARY_DNSNAME    = local.scs_computer_dnsnames
+      SCS_SECONDARY_DNSNAME    = local.scs_secondary_dnsnames
       SCS_VMNAME               = local.scs_server_vm_names
       WEB_COMPUTERNAME         = local.web_computer_names
-      WEB_SECONDARY_DNSNAME    = local.web_computer_dnsnames
+      WEB_SECONDARY_DNSNAME    = local.web_secondary_dnsnames
       WEB_VMNAME               = local.web_server_vm_names
     }
 

--- a/deploy/terraform/terraform-units/modules/sap_namegenerator/output.tf
+++ b/deploy/terraform/terraform-units/modules/sap_namegenerator/output.tf
@@ -2,7 +2,7 @@ output naming {
   value = {
     prefix = {
       DEPLOYER = local.deployer_name
-      SDU      = local.sdu_name
+      SDU      = length(var.custom_prefix) > 0 ? var.custom_prefix : local.sdu_name
       VNET     = local.vnet_name
       LIBRARY  = local.library_name
     }
@@ -34,23 +34,30 @@ output naming {
       }
     }
     virtualmachine_names = {
-      ANCHOR_COMPUTERNAME   = local.anchor_computer_names
-      ANCHOR_VMNAME         = local.anchor_vm_names
-      ANYDB_COMPUTERNAME    = concat(local.anydb_computer_names, local.anydb_computer_names_ha)
-      ANYDB_VMNAME          = concat(local.anydb_vm_names, local.anydb_vm_names_ha)
-      APP_COMPUTERNAME      = local.app_computer_names
-      APP_VMNAME            = local.app_server_vm_names
-      DEPLOYER              = local.deployer_vm_names
-      HANA_COMPUTERNAME     = concat(local.hana_computer_names, local.hana_computer_names_ha)
-      HANA_VMNAME           = concat(local.hana_server_vm_names, local.hana_server_vm_names_ha)
-      ISCSI_COMPUTERNAME    = local.iscsi_server_names
-      SCS_COMPUTERNAME      = local.scs_computer_names
-      SCS_VMNAME            = local.scs_server_vm_names
-      WEB_COMPUTERNAME      = local.web_computer_names
-      WEB_VMNAME            = local.web_server_vm_names
-      OBSERVER_COMPUTERNAME = local.observer_computer_names
-      OBSERVER_VMNAME       = local.observer_vm_names
+      APP_COMPUTERNAME         = local.app_computer_names
+      APP_SECONDARY_DNSNAME    = local.app_computer_dnsnames
+      APP_VMNAME               = local.app_server_vm_names
+      ANCHOR_COMPUTERNAME      = local.anchor_computer_names
+      ANCHOR_SECONDARY_DNSNAME = local.anchor_computer_dnsnames
+      ANCHOR_VMNAME            = local.anchor_vm_names
+      ANYDB_COMPUTERNAME       = concat(local.anydb_computer_names, local.anydb_computer_names_ha)
+      ANYDB_SECONDARY_DNSNAME  = concat(local.anydb_computer_dnsnames, local.anydb_computer_dnsnames_ha)
+      ANYDB_VMNAME             = concat(local.anydb_vm_names, local.anydb_vm_names_ha)
+      DEPLOYER                 = local.deployer_vm_names
+      HANA_COMPUTERNAME        = concat(local.hana_computer_names, local.hana_computer_names_ha)
+      HANA_SECONDARY_DNSNAME   = concat(local.hana_computer_dnsnames, local.hana_computer_dnsnames_ha)
+      HANA_VMNAME              = concat(local.hana_server_vm_names, local.hana_server_vm_names_ha)
+      ISCSI_COMPUTERNAME       = local.iscsi_server_names
+      OBSERVER_COMPUTERNAME    = local.observer_computer_names
+      OBSERVER_VMNAME          = local.observer_vm_names
+      SCS_COMPUTERNAME         = local.scs_computer_names
+      SCS_SECONDARY_DNSNAME    = local.scs_computer_dnsnames
+      SCS_VMNAME               = local.scs_server_vm_names
+      WEB_COMPUTERNAME         = local.web_computer_names
+      WEB_SECONDARY_DNSNAME    = local.web_computer_dnsnames
+      WEB_VMNAME               = local.web_server_vm_names
     }
+
     resource_suffixes = var.resource_suffixes
 
     separator = local.separator

--- a/deploy/terraform/terraform-units/modules/sap_namegenerator/resourcegroup.tf
+++ b/deploy/terraform/terraform-units/modules/sap_namegenerator/resourcegroup.tf
@@ -8,10 +8,11 @@ locals {
   vnet_name     = upper(format("%s-%s-%s", local.env_verified, local.location_short, local.vnet_verified))
   library_name  = upper(format("%s-%s", local.env_verified, local.location_short))
 
-  sdu_storageaccount_name            = replace(lower(format("%s%s%sdiag%s", local.env_verified, local.location_short, local.vnet_verified, local.random_id_verified)),"/[^a-z0-9]/","")
-  library_storageaccount_name        = replace(lower(format("%s%s%ssaplib%s", local.env_verified, local.location_short, local.vnet_verified, local.random_id_verified)),"/[^a-z0-9]/","")
-  terraformstate_storageaccount_name = replace(lower(format("%s%s%stfstate%s", local.env_verified, local.location_short, local.vnet_verified, local.random_id_verified)),"/[^a-z0-9]/","")
-  deployer_storageaccount_name       = replace(lower(format("%s%s%sdiag%s", local.env_verified, local.location_short, local.dep_vnet_verified, local.random_id_verified)),"/[^a-z0-9]/","")
-  vnet_storageaccount_name           = replace(lower(format("%s%s%sdiag%s", local.env_verified, local.location_short, local.dep_vnet_verified, local.random_id_verified)),"/[^a-z0-9]/","")
+  // Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only. The name must be unique.
+  sdu_storageaccount_name            = substr(replace(lower(format("%s%s%sdiag%s", local.env_verified, local.location_short, local.vnet_verified, local.random_id_verified)),"/[^a-z0-9]/",""),0,var.azlimits.stgaccnt)
+  library_storageaccount_name        = substr(replace(lower(format("%s%s%ssaplib%s", local.env_verified, local.location_short, local.vnet_verified, local.random_id_verified)),"/[^a-z0-9]/",""),0,var.azlimits.stgaccnt)
+  terraformstate_storageaccount_name = substr(replace(lower(format("%s%s%stfstate%s", local.env_verified, local.location_short, local.vnet_verified, local.random_id_verified)),"/[^a-z0-9]/",""),0,var.azlimits.stgaccnt)
+  deployer_storageaccount_name       = substr(replace(lower(format("%s%s%sdiag%s", local.env_verified, local.location_short, local.dep_vnet_verified, local.random_id_verified)),"/[^a-z0-9]/",""),0,var.azlimits.stgaccnt)
+  vnet_storageaccount_name           = substr(replace(lower(format("%s%s%sdiag%s", local.env_verified, local.location_short, local.dep_vnet_verified, local.random_id_verified)),"/[^a-z0-9]/",""),0,var.azlimits.stgaccnt)
 
 }

--- a/deploy/terraform/terraform-units/modules/sap_namegenerator/resourcegroup.tf
+++ b/deploy/terraform/terraform-units/modules/sap_namegenerator/resourcegroup.tf
@@ -8,10 +8,10 @@ locals {
   vnet_name     = upper(format("%s-%s-%s", local.env_verified, local.location_short, local.vnet_verified))
   library_name  = upper(format("%s-%s", local.env_verified, local.location_short))
 
-  sdu_storageaccount_name            = lower(format("%s%s%sdiag%s", local.env_verified, local.location_short, local.vnet_verified, local.random_id_verified))
-  library_storageaccount_name        = lower(format("%s%s%ssaplib%s", local.env_verified, local.location_short, local.vnet_verified, local.random_id_verified))
-  terraformstate_storageaccount_name = lower(format("%s%s%stfstate%s", local.env_verified, local.location_short, local.vnet_verified, local.random_id_verified))
-  deployer_storageaccount_name       = lower(format("%s%s%sdiag%s", local.env_verified, local.location_short, local.dep_vnet_verified, local.random_id_verified))
-  vnet_storageaccount_name           = lower(format("%s%s%sdiag%s", local.env_verified, local.location_short, local.dep_vnet_verified, local.random_id_verified))
+  sdu_storageaccount_name            = replace(lower(format("%s%s%sdiag%s", local.env_verified, local.location_short, local.vnet_verified, local.random_id_verified)),"/[^a-z0-9]/","")
+  library_storageaccount_name        = replace(lower(format("%s%s%ssaplib%s", local.env_verified, local.location_short, local.vnet_verified, local.random_id_verified)),"/[^a-z0-9]/","")
+  terraformstate_storageaccount_name = replace(lower(format("%s%s%stfstate%s", local.env_verified, local.location_short, local.vnet_verified, local.random_id_verified)),"/[^a-z0-9]/","")
+  deployer_storageaccount_name       = replace(lower(format("%s%s%sdiag%s", local.env_verified, local.location_short, local.dep_vnet_verified, local.random_id_verified)),"/[^a-z0-9]/","")
+  vnet_storageaccount_name           = replace(lower(format("%s%s%sdiag%s", local.env_verified, local.location_short, local.dep_vnet_verified, local.random_id_verified)),"/[^a-z0-9]/","")
 
 }

--- a/deploy/terraform/terraform-units/modules/sap_namegenerator/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_namegenerator/variables_local.tf
@@ -146,7 +146,7 @@ variable region_mapping {
     "centralus"          = "ceus"
     "eastasia"           = "eaas"
     "eastus"             = "eaus"
-    "eastus2"            = "eau2"
+    "eastus2"            = "eus2"
     "francecentral"      = "frce"
     "francesouth"        = "frso"
     "germanynorth"       = "geno"
@@ -264,14 +264,19 @@ variable db_zones {
   default     = []
 }
 
+variable custom_prefix {
+  type        = string
+  description = "Custom prefix"
+  default     = ""
+}
 
 locals {
 
   location_short = upper(try(var.region_mapping[var.location], "unkn"))
 
   env_verified      = upper(substr(var.environment, 0, var.sapautomation_name_limits.environment_variable_length))
-  vnet_verified     = upper(substr(var.sap_vnet_name, 0, var.sapautomation_name_limits.sap_vnet_length))
-  dep_vnet_verified = upper(substr(var.management_vnet_name, 0, var.sapautomation_name_limits.sap_vnet_length))
+  vnet_verified     = upper(trim(substr(var.sap_vnet_name, 0, var.sapautomation_name_limits.sap_vnet_length), "-_"))
+  dep_vnet_verified = upper(trim(substr(var.management_vnet_name, 0, var.sapautomation_name_limits.sap_vnet_length), "-_"))
 
   random_id_verified    = upper(substr(var.random_id, 0, var.sapautomation_name_limits.random_id_length))
   random_id_vm_verified = lower(substr(var.random_id, 0, var.sapautomation_name_limits.random_id_length))

--- a/deploy/terraform/terraform-units/modules/sap_namegenerator/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_namegenerator/variables_local.tf
@@ -109,7 +109,7 @@ variable azlimits {
     afw         = 50
     rg          = 80
     kv          = 24
-    st          = 24
+    stgaccnt    = 24
     vnet        = 38
     nsg         = 80
     snet        = 80

--- a/deploy/terraform/terraform-units/modules/sap_namegenerator/vm.tf
+++ b/deploy/terraform/terraform-units/modules/sap_namegenerator/vm.tf
@@ -109,35 +109,35 @@ locals {
   ]
 
   //For customer who want to have an alternative name for the second IP address
-  app_computer_dnsnames = [for idx in range(var.app_server_count) :
+  app_secondary_dnsnames = [for idx in range(var.app_server_count) :
     format("%sapp%02d%s%s", lower(var.sap_sid), idx, local.app_oscode, local.random_id_vm_verified)
   ]
 
-  anchor_computer_dnsnames = [for idx in range(length(local.zones)) :
+  anchor_secondary_dnsnames = [for idx in range(length(local.zones)) :
     format("%sanchorz%s%02d%s%s", lower(var.sap_sid), local.zones[idx % max(length(local.zones), 1)], idx, local.anchor_oscode, local.random_id_vm_verified)
   ]
 
-  anydb_computer_dnsnames = [for idx in range(var.db_server_count) :
+  anydb_secondary_dnsnames = [for idx in range(var.db_server_count) :
     format("%sd%s%02dl%d%s", lower(var.sap_sid), lower(var.db_sid), idx, 0, local.random_id_vm_verified)
   ]
 
-  anydb_computer_dnsnames_ha = [for idx in range(var.db_server_count) :
+  anydb_secondary_dnsnames_ha = [for idx in range(var.db_server_count) :
     format("%sd%s%02dl%d%s", lower(var.sap_sid), lower(var.db_sid), idx, 1, local.random_id_vm_verified)
   ]
 
-  hana_computer_dnsnames = [for idx in range(var.db_server_count) :
+  hana_secondary_dnsnames = [for idx in range(var.db_server_count) :
     format("%sd%s%02dl%d%s", lower(var.sap_sid), lower(var.db_sid), idx, 0, local.random_id_vm_verified)
   ]
 
-  hana_computer_dnsnames_ha = [for idx in range(var.db_server_count) :
+  hana_secondary_dnsnames_ha = [for idx in range(var.db_server_count) :
     format("%sd%s%02dl%d%s", lower(var.sap_sid), lower(var.db_sid), idx, 1, local.random_id_vm_verified)
   ]
 
-  scs_computer_dnsnames = [for idx in range(var.scs_server_count) :
+  scs_secondary_dnsnames = [for idx in range(var.scs_server_count) :
     format("%sscs%02d%s%s", lower(var.sap_sid), idx, local.app_oscode, local.random_id_vm_verified)
   ]
 
-  web_computer_dnsnames = [for idx in range(var.web_server_count) :
+  web_secondary_dnsnames = [for idx in range(var.web_server_count) :
     format("%sweb%02d%s%s", lower(var.sap_sid), idx, local.app_oscode, local.random_id_vm_verified)
   ]
 

--- a/deploy/terraform/terraform-units/modules/sap_namegenerator/vm.tf
+++ b/deploy/terraform/terraform-units/modules/sap_namegenerator/vm.tf
@@ -1,15 +1,15 @@
 locals {
 
-  db_oscode       = upper(var.db_ostype) == "LINUX" ? "l" : "w"
-  app_oscode      = upper(var.app_ostype) == "LINUX" ? "l" : "w"
-  anchor_oscode   = upper(var.anchor_ostype) == "LINUX" ? "l" : "w"
+  db_oscode     = upper(var.db_ostype) == "LINUX" ? "l" : "w"
+  app_oscode    = upper(var.app_ostype) == "LINUX" ? "l" : "w"
+  anchor_oscode = upper(var.anchor_ostype) == "LINUX" ? "l" : "w"
 
   anchor_computer_names = [for idx in range(length(local.zones)) :
-    format("%sanchorz%s%02d%s%s", lower(var.sap_sid), local.zones[idx % length(local.zones)], idx, local.anchor_oscode, local.random_id_vm_verified)
+    format("%sanchorz%s%02d%s%s", lower(var.sap_sid), local.zones[idx % max(length(local.zones), 1)], idx, local.anchor_oscode, local.random_id_vm_verified)
   ]
 
   anchor_vm_names = [for idx in range(length(local.zones)) :
-    format("%sanchor_z%s_%02d%s%s", lower(var.sap_sid), local.zones[idx % length(local.zones)], idx, local.anchor_oscode, local.random_id_vm_verified)
+    format("%sanchor_z%s_%02d%s%s", lower(var.sap_sid), local.zones[idx % max(length(local.zones), 1)], idx, local.anchor_oscode, local.random_id_vm_verified)
   ]
 
   deployer_vm_names = [for idx in range(var.deployer_vm_count) :
@@ -25,15 +25,15 @@ locals {
   ]
 
   anydb_vm_names = [for idx in range(var.db_server_count) :
-    local.zonal_deployment ? (
-      format("%sd%s%sz%s%s%02dl%d%s", lower(var.sap_sid), lower(var.db_sid), local.separator, var.db_zones[idx % length(var.db_zones)], local.separator, idx, 0, local.random_id_vm_verified)) : (
+    length(var.db_zones) > 0 ? (
+      format("%sd%s%sz%s%s%02dl%d%s", lower(var.sap_sid), lower(var.db_sid), local.separator, var.db_zones[idx % max(length(var.db_zones), 1)], local.separator, idx, 0, local.random_id_vm_verified)) : (
       format("%sd%s%02dl%d%s", lower(var.sap_sid), lower(var.db_sid), idx, 0, local.random_id_vm_verified)
     )
   ]
 
   anydb_vm_names_ha = [for idx in range(var.db_server_count) :
-    local.zonal_deployment ? (
-      format("%sd%s%sz%s%s%02dl%d%s", lower(var.sap_sid), lower(var.db_sid), local.separator, var.db_zones[idx % length(var.db_zones)], local.separator, idx, 1, local.random_id_vm_verified)) : (
+    length(var.db_zones) > 0 ? (
+      format("%sd%s%sz%s%s%02dl%d%s", lower(var.sap_sid), lower(var.db_sid), local.separator, var.db_zones[idx % max(length(var.db_zones), 1)], local.separator, idx, 1, local.random_id_vm_verified)) : (
       format("%sd%s%02dl%d%s", lower(var.sap_sid), lower(var.db_sid), idx, 1, local.random_id_vm_verified)
     )
   ]
@@ -43,8 +43,8 @@ locals {
   ]
 
   app_server_vm_names = [for idx in range(var.app_server_count) :
-    local.zonal_deployment ? (
-      format("%sapp%sz%s%s%02d%s%s", lower(var.sap_sid), local.separator, var.app_zones[idx % length(var.app_zones)], local.separator, idx, local.app_oscode, local.random_id_vm_verified)) : (
+    length(var.app_zones) > 0 ? (
+      format("%sapp%sz%s%s%02d%s%s", lower(var.sap_sid), local.separator, var.app_zones[idx % max(length(var.app_zones), 1)], local.separator, idx, local.app_oscode, local.random_id_vm_verified)) : (
       format("%sapp%02d%s%s", lower(var.sap_sid), idx, local.app_oscode, local.random_id_vm_verified)
     )
   ]
@@ -62,15 +62,15 @@ locals {
   ]
 
   hana_server_vm_names = [for idx in range(var.db_server_count) :
-    local.zonal_deployment ? (
-      format("%sd%s%sz%s%s%02dl%d%s", lower(var.sap_sid), lower(var.db_sid), local.separator, var.db_zones[idx % length(var.db_zones)], local.separator, idx, 0, local.random_id_vm_verified)) : (
+    length(var.db_zones) > 0 ? (
+      format("%sd%s%sz%s%s%02dl%d%s", lower(var.sap_sid), lower(var.db_sid), local.separator, var.db_zones[idx % max(length(var.db_zones), 1)], local.separator, idx, 0, local.random_id_vm_verified)) : (
       format("%sd%s%02dl%d%s", lower(var.sap_sid), lower(var.db_sid), idx, 0, local.random_id_vm_verified)
     )
   ]
 
   hana_server_vm_names_ha = [for idx in range(var.db_server_count) :
-    local.zonal_deployment ? (
-      format("%sd%s%sz%s%s%02dl%d%s", lower(var.sap_sid), lower(var.db_sid), local.separator, var.db_zones[idx % length(var.db_zones)], local.separator, idx, 1, local.random_id_vm_verified)) : (
+    length(var.db_zones) > 0 ? (
+      format("%sd%s%sz%s%s%02dl%d%s", lower(var.sap_sid), lower(var.db_sid), local.separator, var.db_zones[idx % max(length(var.db_zones), 1)], local.separator, idx, 1, local.random_id_vm_verified)) : (
       format("%sd%s%02dl%d%s", lower(var.sap_sid), lower(var.db_sid), idx, 1, local.random_id_vm_verified)
     )
   ]
@@ -80,8 +80,8 @@ locals {
   ]
 
   scs_server_vm_names = [for idx in range(var.scs_server_count) :
-    local.zonal_deployment ? (
-      format("%sscs%sz%s%s%02d%s%s", lower(var.sap_sid), local.separator, var.scs_zones[idx % length(var.scs_zones)], local.separator, idx, local.app_oscode, local.random_id_vm_verified)) : (
+    length(var.scs_zones) > 0 ? (
+      format("%sscs%sz%s%s%02d%s%s", lower(var.sap_sid), local.separator, var.scs_zones[idx % max(length(var.scs_zones), 1)], local.separator, idx, local.app_oscode, local.random_id_vm_verified)) : (
       format("%sscs%02d%s%s", lower(var.sap_sid), idx, local.app_oscode, local.random_id_vm_verified)
     )
   ]
@@ -91,8 +91,8 @@ locals {
   ]
 
   web_server_vm_names = [for idx in range(var.scs_server_count) :
-    local.zonal_deployment ? (
-      format("%sweb%sz%s%s%02d%s%s", lower(var.sap_sid), local.separator, var.web_zones[idx % length(var.web_zones)], local.separator, idx, local.app_oscode, local.random_id_vm_verified)) : (
+    length(var.web_zones) > 0 ? (
+      format("%sweb%sz%s%s%02d%s%s", lower(var.sap_sid), local.separator, var.web_zones[idx % max(length(var.web_zones), 1)], local.separator, idx, local.app_oscode, local.random_id_vm_verified)) : (
       format("%sweb%02d%s%s", lower(var.sap_sid), idx, local.app_oscode, local.random_id_vm_verified)
     )
   ]
@@ -106,6 +106,39 @@ locals {
       format("%sobserver_z%s_%02d%s%s", lower(var.sap_sid), local.zones[idx % length(local.zones)], idx, local.db_oscode, local.random_id_vm_verified)) : (
       format("%sobserver%02d%s%s", lower(var.sap_sid), idx, local.db_oscode, local.random_id_vm_verified)
     )
+  ]
+
+  //For customer who want to have an alternative name for the second IP address
+  app_computer_dnsnames = [for idx in range(var.app_server_count) :
+    format("%sapp%02d%s%s", lower(var.sap_sid), idx, local.app_oscode, local.random_id_vm_verified)
+  ]
+
+  anchor_computer_dnsnames = [for idx in range(length(local.zones)) :
+    format("%sanchorz%s%02d%s%s", lower(var.sap_sid), local.zones[idx % max(length(local.zones), 1)], idx, local.anchor_oscode, local.random_id_vm_verified)
+  ]
+
+  anydb_computer_dnsnames = [for idx in range(var.db_server_count) :
+    format("%sd%s%02dl%d%s", lower(var.sap_sid), lower(var.db_sid), idx, 0, local.random_id_vm_verified)
+  ]
+
+  anydb_computer_dnsnames_ha = [for idx in range(var.db_server_count) :
+    format("%sd%s%02dl%d%s", lower(var.sap_sid), lower(var.db_sid), idx, 1, local.random_id_vm_verified)
+  ]
+
+  hana_computer_dnsnames = [for idx in range(var.db_server_count) :
+    format("%sd%s%02dl%d%s", lower(var.sap_sid), lower(var.db_sid), idx, 0, local.random_id_vm_verified)
+  ]
+
+  hana_computer_dnsnames_ha = [for idx in range(var.db_server_count) :
+    format("%sd%s%02dl%d%s", lower(var.sap_sid), lower(var.db_sid), idx, 1, local.random_id_vm_verified)
+  ]
+
+  scs_computer_dnsnames = [for idx in range(var.scs_server_count) :
+    format("%sscs%02d%s%s", lower(var.sap_sid), idx, local.app_oscode, local.random_id_vm_verified)
+  ]
+
+  web_computer_dnsnames = [for idx in range(var.web_server_count) :
+    format("%sweb%02d%s%s", lower(var.sap_sid), idx, local.app_oscode, local.random_id_vm_verified)
   ]
 
 }


### PR DESCRIPTION
## Problem

- The naming logic is not detecting characters that are not allowed in for instance storage account names.

- East US2 has the wrong code

- The zone logic for naming is not correct in all cases

- There second NIC allows for a separate host name but the code does not address it

## Solution
The naming module has fixes and updates

## Tests
<Please provide steps to test the PR>

## Notes
The PR also lays the foundation for support of dynamic IP addresses