### PR TITLE
Consider vnets management name if provided

### DIFF
--- a/deploy/terraform/bootstrap/sap_deployer/deployer.json
+++ b/deploy/terraform/bootstrap/sap_deployer/deployer.json
@@ -4,7 +4,6 @@
     "environment": "np",
     "vnets": {
       "management": {
-        "name": "DEP00",
         "address_space": "10.0.0.0/26",
         "subnet_mgmt": {
           "prefix": "10.0.0.16/28"

--- a/deploy/terraform/bootstrap/sap_deployer/deployer_full.json
+++ b/deploy/terraform/bootstrap/sap_deployer/deployer_full.json
@@ -4,7 +4,7 @@
         "environment": "np",
         "vnets": {
             "management": {
-                "name": "DEP00",
+                "name": "NP-EAUS-DEP00-vnet",
                 "address_space": "10.0.0.0/26",
                 "subnet_mgmt": {
                     "prefix": "10.0.0.16/28"

--- a/deploy/terraform/terraform-units/modules/sap_deployer/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/variables_local.tf
@@ -46,7 +46,7 @@ locals {
   sub_mgmt_nsg             = try(local.sub_mgmt.nsg, {})
   sub_mgmt_nsg_arm_id      = try(local.sub_mgmt_nsg.arm_id, "")
   sub_mgmt_nsg_exists      = length(local.sub_mgmt_nsg_arm_id) > 0 ? true : false
-  sub_mgmt_nsg_name        = local.sub_mgmt_nsg_exists ? "" : try(local.sub_mgmt_nsg.name, format("%s%s", local.prefix, local.resource_suffixes.deployer_subnet_nsg))
+  sub_mgmt_nsg_name        = local.sub_mgmt_nsg_exists ? split("/", local.sub_mgmt_nsg_arm_id[8]) : try(local.sub_mgmt_nsg.name, format("%s%s", local.prefix, local.resource_suffixes.deployer_subnet_nsg))
   sub_mgmt_nsg_allowed_ips = local.sub_mgmt_nsg_exists ? [] : try(local.sub_mgmt_nsg.allowed_ips, ["0.0.0.0/0"])
   sub_mgmt_nsg_deployed    = try(local.sub_mgmt_nsg_exists ? data.azurerm_network_security_group.nsg_mgmt[0] : azurerm_network_security_group.nsg_mgmt[0], null)
 

--- a/deploy/terraform/terraform-units/modules/sap_deployer/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/variables_local.tf
@@ -31,7 +31,7 @@ locals {
   vnet_mgmt        = try(var.infrastructure.vnets.management, {})
   vnet_mgmt_arm_id = try(local.vnet_mgmt.arm_id, "")
   vnet_mgmt_exists = length(local.vnet_mgmt_arm_id) > 0 ? true : false
-  vnet_mgmt_name   = local.vnet_mgmt_exists ? split("/", local.vnet_mgmt_arm_id)[8] : format("%s-vnet", local.prefix)
+  vnet_mgmt_name   = local.vnet_mgmt_exists ? split("/", local.vnet_mgmt_arm_id)[8] : try(local.vnet_mgmt.name, format("%s-vnet", local.prefix))
   vnet_mgmt_addr   = local.vnet_mgmt_exists ? "" : try(local.vnet_mgmt.address_space, "")
 
   // Management subnet


### PR DESCRIPTION
## Problem
1. The vnet management name is only used as prefix but not vnet name itself.
1. NSG name is incorrect if one import an existing NSG with arm_id.

## Solution
1. Consider vnet name if provided.
1. Parse arm_id of NSG to get nsg name.

## Tests
<Please provide steps to test the PR>

## Notes
<Additional comments for the PR>