### PR TITLE
Support import multiple existing ppgs

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/infrastructure.tf
@@ -70,7 +70,7 @@ resource "azurerm_proximity_placement_group" "ppg" {
 }
 
 data "azurerm_proximity_placement_group" "ppg" {
-  count               = local.ppg_exists ? 1 : 0
-  name                = split("/", local.ppg_arm_id)[8]
-  resource_group_name = split("/", local.ppg_arm_id)[4]
+  count               = local.ppg_exists ? max(length(local.zones), 1) : 0
+  name                = split("/", local.ppg_arm_ids[count.index])[8]
+  resource_group_name = split("/", local.ppg_arm_ids[count.index])[4]
 }

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/infrastructure.tf
@@ -64,7 +64,7 @@ resource "azurerm_storage_account" "storage_bootdiag" {
 // PROXIMITY PLACEMENT GROUP
 resource "azurerm_proximity_placement_group" "ppg" {
   count               = local.ppg_exists ? 0 : (local.zonal_deployment ? max(length(local.zones), 1) : 1)
-  name                = local.zonal_deployment ? format("%s%sz%s%s", local.prefix, var.naming.separator, local.zones[count.index], local.resource_suffixes.ppg) : local.ppg_name
+  name                = local.zonal_deployment ? format("%s%sz%s%s", local.prefix, var.naming.separator, local.zones[count.index], local.resource_suffixes.ppg) : local.ppg_names[count.index]
   resource_group_name = local.rg_exists ? data.azurerm_resource_group.resource_group[0].name : azurerm_resource_group.resource_group[0].name
   location            = local.rg_exists ? data.azurerm_resource_group.resource_group[0].location : azurerm_resource_group.resource_group[0].location
 }

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/variables_local.tf
@@ -176,7 +176,7 @@ locals {
   ppg_arm_ids = try(local.var_ppg.arm_ids, [])
 
   ppg_exists = length(local.ppg_arm_ids) > 0 ? true : false
-  ppg_names  = try(local.var_ppg.name, [])
+  ppg_names  = try(local.var_ppg.names, [])
   
   /* Comment out code with users.object_id for the time being
   // Additional users add to user KV
@@ -244,7 +244,7 @@ locals {
     },
     ppg = {
       is_existing = local.ppg_exists,
-      name        = local.ppg_name,
+      name        = local.ppg_names,
       arm_id      = local.ppg_arm_ids
     },
     iscsi = local.landscape_infrastructure.iscsi

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/variables_local.tf
@@ -123,7 +123,7 @@ locals {
     for db in var.databases : db
     if contains(["ORACLE", "DB2", "SQLSERVER", "ASE"], upper(try(db.platform, "NONE")))
   ]
-  
+
   enable_xdb_deployment = (length(local.xdb_list) > 0) ? true : false
   enable_db_deployment  = local.enable_xdb_deployment || local.enable_hdb_deployment
 
@@ -131,7 +131,7 @@ locals {
   enable_app_deployment = try(var.application.enable_deployment, false)
 
   //Enable SID deployment
-  enable_sid_deployment = local.enable_db_deployment || local.enable_app_deployment 
+  enable_sid_deployment = local.enable_db_deployment || local.enable_app_deployment
 
   var_infra = try(var.infrastructure, {})
 
@@ -172,12 +172,11 @@ locals {
   rg_name   = local.rg_exists ? try(split("/", local.rg_arm_id)[4], "") : try(local.var_rg.name, format("%s%s", local.prefix, local.resource_suffixes.sdu_rg))
 
   //PPG
-  var_ppg    = try(local.var_infra.ppg, {})
+  var_ppg     = try(local.var_infra.ppg, {})
   ppg_arm_ids = try(local.var_ppg.arm_ids, [])
+  ppg_exists  = length(local.ppg_arm_ids) > 0 ? true : false
+  ppg_names   = try(local.var_ppg.names, [format("%s%s", local.prefix, local.resource_suffixes.ppg)])
 
-  ppg_exists = length(local.ppg_arm_ids) > 0 ? true : false
-  ppg_names  = try(local.var_ppg.names, [])
-  
   /* Comment out code with users.object_id for the time being
   // Additional users add to user KV
   kv_users = var.deployer_user

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/variables_local.tf
@@ -173,11 +173,10 @@ locals {
 
   //PPG
   var_ppg    = try(local.var_infra.ppg, {})
-  ppg_arm_id = try(local.var_ppg.arm_id, "")
   ppg_arm_ids = try(local.var_ppg.arm_ids, [])
 
-  ppg_exists = length(local.ppg_arm_id) > 0 || length(local.ppg_arm_ids) > 0 ? true : false
-  ppg_name   = local.ppg_exists ? try(split("/", local.ppg_arm_ids[0])[8], "") : try(local.var_ppg.name, format("%s%s", local.prefix, local.resource_suffixes.ppg))
+  ppg_exists = length(local.ppg_arm_ids) > 0 ? true : false
+  ppg_names  = try(local.var_ppg.name, [])
   
   /* Comment out code with users.object_id for the time being
   // Additional users add to user KV

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/variables_local.tf
@@ -174,9 +174,11 @@ locals {
   //PPG
   var_ppg    = try(local.var_infra.ppg, {})
   ppg_arm_id = try(local.var_ppg.arm_id, "")
-  ppg_exists = length(local.ppg_arm_id) > 0 ? true : false
-  ppg_name   = local.ppg_exists ? try(split("/", local.ppg_arm_id)[8], "") : try(local.var_ppg.name, format("%s%s", local.prefix, local.resource_suffixes.ppg))
+  ppg_arm_ids = try(local.var_ppg.arm_ids, [])
 
+  ppg_exists = length(local.ppg_arm_id) > 0 || length(local.ppg_arm_ids) > 0 ? true : false
+  ppg_name   = local.ppg_exists ? try(split("/", local.ppg_arm_ids[0])[8], "") : try(local.var_ppg.name, format("%s%s", local.prefix, local.resource_suffixes.ppg))
+  
   /* Comment out code with users.object_id for the time being
   // Additional users add to user KV
   kv_users = var.deployer_user
@@ -244,7 +246,7 @@ locals {
     ppg = {
       is_existing = local.ppg_exists,
       name        = local.ppg_name,
-      arm_id      = local.ppg_arm_id
+      arm_id      = local.ppg_arm_ids
     },
     iscsi = local.landscape_infrastructure.iscsi
     vnets = {

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/vm-anchor.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/vm-anchor.tf
@@ -22,7 +22,7 @@ resource "azurerm_linux_virtual_machine" "anchor" {
   computer_name                = local.anchor_computer_names[count.index]
   resource_group_name          = local.rg_exists ? data.azurerm_resource_group.resource_group[0].name : azurerm_resource_group.resource_group[0].name
   location                     = local.rg_exists ? data.azurerm_resource_group.resource_group[0].location : azurerm_resource_group.resource_group[0].location
-  proximity_placement_group_id = azurerm_proximity_placement_group.ppg[count.index].id
+  proximity_placement_group_id = local.ppg_exists ? data.azurerm_proximity_placement_group.ppg[count.index].id : azurerm_proximity_placement_group.ppg[count.index].id
   zone                         = local.zones[count.index]
 
   network_interface_ids = [
@@ -72,7 +72,7 @@ resource "azurerm_windows_virtual_machine" "anchor" {
   computer_name                = local.anchor_computer_names[count.index]
   resource_group_name          = local.rg_exists ? data.azurerm_resource_group.resource_group[0].name : azurerm_resource_group.resource_group[0].name
   location                     = local.rg_exists ? data.azurerm_resource_group.resource_group[0].location : azurerm_resource_group.resource_group[0].location
-  proximity_placement_group_id = azurerm_proximity_placement_group.ppg[count.index].id
+  proximity_placement_group_id = local.ppg_exists ? data.azurerm_proximity_placement_group.ppg[count.index].id : azurerm_proximity_placement_group.ppg[count.index].id
   zone                         = local.zones[count.index]
 
   network_interface_ids = [


### PR DESCRIPTION
## Problem
As we suppport cross zonal deployments the customer may have more than one PPG

## Solution
Read the arm ids for the ppgs from the input json. I intentionally named the property arm_ids and not arm_id which is a single string

## Tests

Add this sction to the input json
  "ppg" :{
      "arm_ids" : ["/subscriptions/xxxx/resourceGroups/PROTO-NOEU-SAPPROT_DEMO-WOO/providers/Microsoft.Compute/proximityPlacementGroups/PROTO-NOEU-SAPPROT-WOO_z1-ppg",
        "/subscriptions/xxxx/resourceGroups/PROTO-NOEU-SAPPROT_DEMO-WOO/providers/Microsoft.Compute/proximityPlacementGroups/PROTO-NOEU-SAPPROT-WOO_z2-ppg",
        "/subscriptions/xxxx/resourceGroups/PROTO-NOEU-SAPPROT_DEMO-WOO/providers/Microsoft.Compute/proximityPlacementGroups/PROTO-NOEU-SAPPROT-WOO_z3-ppg"]
    },

## Notes
<Additional comments for the PR>