### PR TITLE
Dont deploy webdipatcher lb if no webdispatchers

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/infrastructure.tf
@@ -145,7 +145,7 @@ resource "azurerm_availability_set" "app" {
 
 # Create the Web dispatcher Load Balancer
 resource "azurerm_lb" "web" {
-  count               = local.enable_deployment ? 1 : 0
+  count               = local.enable_deployment  && local.webdispatcher_count > 0 ? 1 : 0
   name                = format("%s%s", local.prefix, local.resource_suffixes.web_alb)
   resource_group_name = var.resource_group[0].name
   location            = var.resource_group[0].location
@@ -160,7 +160,7 @@ resource "azurerm_lb" "web" {
 }
 
 resource "azurerm_lb_backend_address_pool" "web" {
-  count               = local.enable_deployment ? 1 : 0
+  count               = local.enable_deployment  && local.webdispatcher_count > 0 ? 1 : 0
   name                = format("%s%s", local.prefix, local.resource_suffixes.web_alb_bepool)
   resource_group_name = var.resource_group[0].name
   loadbalancer_id     = azurerm_lb.web[0].id
@@ -170,7 +170,7 @@ resource "azurerm_lb_backend_address_pool" "web" {
 
 # Create the Web dispatcher Load Balancer Rules
 resource "azurerm_lb_rule" "web" {
-  count                          = local.enable_deployment ? length(local.lb_ports.web) : 0
+  count                          = local.enable_deployment  && local.webdispatcher_count > 0 ? length(local.lb_ports.web) : 0
   resource_group_name            = var.resource_group[0].name
   loadbalancer_id                = azurerm_lb.web[0].id
   name                           = format("%s%s%05d-%02d", local.prefix, local.resource_suffixes.web_alb_inrule, local.lb_ports.web[count.index], count.index)
@@ -184,7 +184,7 @@ resource "azurerm_lb_rule" "web" {
 
 # Associate Web dispatcher VM NICs with the Load Balancer Backend Address Pool
 resource "azurerm_network_interface_backend_address_pool_association" "web" {
-  count                   = local.enable_deployment ? local.webdispatcher_count : 0
+  count                   = local.enable_deployment  && local.webdispatcher_count > 0 ? local.webdispatcher_count : 0
   network_interface_id    = azurerm_network_interface.web[count.index].id
   ip_configuration_name   = azurerm_network_interface.web[count.index].ip_configuration[0].name
   backend_address_pool_id = azurerm_lb_backend_address_pool.web[0].id

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/nsg-webdisp.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/nsg-webdisp.tf
@@ -22,7 +22,7 @@ resource "azurerm_subnet_network_security_group_association" "Associate_nsg_web"
 
 # NSG rule to deny internet access
 resource "azurerm_network_security_rule" "webRule_internet" {
-  count                        = local.enable_deployment ? (local.sub_web_nsg_exists ? 0 : 1) : 0
+  count                        = local.enable_deployment && local.sub_web_defined ? (local.sub_web_nsg_exists ? 0 : 1) : 0
   name                         = "Internet"
   priority                     = 100
   direction                    = "Inbound"

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/outputs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/outputs.tf
@@ -47,7 +47,7 @@ output "web_admin_ip" {
 }
 
 output "web_lb_ip" {
-  value = local.enable_deployment && local.web_dispatch_count > 0 ? azurerm_lb.web[0].frontend_ip_configuration[0].private_ip_address : ""
+  value = local.enable_deployment && local.webdispatcher_count > 0 ? azurerm_lb.web[0].frontend_ip_configuration[0].private_ip_address : ""
 }
 
 output "scs_lb_ip" {

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/outputs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/outputs.tf
@@ -47,7 +47,7 @@ output "web_admin_ip" {
 }
 
 output "web_lb_ip" {
-  value = local.enable_deployment ? azurerm_lb.web[0].frontend_ip_configuration[0].private_ip_address : ""
+  value = local.enable_deployment && local.web_dispatch_count > 0 ? azurerm_lb.web[0].frontend_ip_configuration[0].private_ip_address : ""
 }
 
 output "scs_lb_ip" {
@@ -55,7 +55,7 @@ output "scs_lb_ip" {
 }
 
 output "ers_lb_ip" {
-  value = local.enable_deployment ? azurerm_lb.web[0].frontend_ip_configuration[0].private_ip_address : ""
+  value = local.enable_deployment ? azurerm_lb.scs[0].frontend_ip_configuration[1].private_ip_address : ""
 }
 
 output "application" {


### PR DESCRIPTION
## Problem
If there are no web dispatcher there is no need for a load balancer

## Solution
Control the creation of the load balancer based on the webdispatcher_count

## Tests
<Please provide steps to test the PR>

## Notes
<Additional comments for the PR>