### PR TITLE
Trim whitespace from custom prefix

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/variables_local.tf
@@ -58,7 +58,7 @@ locals {
   sap_sid   = upper(try(var.application.sid, ""))
   anydb_sid = (length(local.anydb_databases) > 0) ? try(local.anydb.instance.sid, lower(substr(local.anydb_platform, 0, 3))) : lower(substr(local.anydb_platform, 0, 3))
   sid       = upper(try(var.application.sid, local.anydb_sid))
-  prefix    = try(var.infrastructure.resource_group.name, var.naming.prefix.SDU)
+  prefix    = try(var.infrastructure.resource_group.name, trimspace(var.naming.prefix.SDU))
   rg_name   = try(var.infrastructure.resource_group.name, format("%s%s", local.prefix, local.resource_suffixes.sdu_rg))
 
   // Zones

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/variables_local.tf
@@ -57,7 +57,7 @@ locals {
 
   region  = try(var.infrastructure.region, "")
   sid     = upper(try(var.application.sid, ""))
-  prefix  = try(var.infrastructure.resource_group.name, var.naming.prefix.SDU)
+  prefix  = try(var.infrastructure.resource_group.name, trimspace(var.naming.prefix.SDU))
   rg_name = try(var.infrastructure.resource_group.name, format("%s%s", local.prefix, local.resource_suffixes.sdu_rg))
 
   // Zones

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/variables_local.tf
@@ -39,7 +39,7 @@ variable "custom_disk_sizes_filename" {
 
 locals {
   // Resources naming
-  vnet_prefix                 = var.naming.prefix.VNET
+  vnet_prefix                 = trimspace(var.naming.prefix.VNET)
   storageaccount_name         = var.naming.storageaccount_names.SDU
   sid_keyvault_names          = var.naming.keyvault_names.SDU
   anchor_virtualmachine_names = var.naming.virtualmachine_names.ANCHOR_VMNAME
@@ -51,7 +51,7 @@ locals {
   //Region and metadata
   region = try(local.var_infra.region, "")
   sid    = upper(try(var.application.sid, ""))
-  prefix = try(var.infrastructure.resource_group.name, var.naming.prefix.SDU)
+  prefix = try(var.infrastructure.resource_group.name, trimspace(var.naming.prefix.SDU))
 
   // Zonal support - 1 PPG by default and with zonal 1 PPG per zone
   db_list = [

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/variables_local.tf
@@ -56,7 +56,7 @@ locals {
 
   region = try(var.infrastructure.region, "")
   sid    = upper(try(var.application.sid, ""))
-  prefix = try(var.infrastructure.resource_group.name, var.naming.prefix.SDU)
+  prefix = try(var.infrastructure.resource_group.name, trimspace(var.naming.prefix.SDU))
 
   rg_name = try(var.infrastructure.resource_group.name, format("%s%s", local.prefix, local.resource_suffixes.sdu_rg))
 


### PR DESCRIPTION
## Problem
An Azure resource name cannot begin with whitespace

## Solution
Trim the whitespace from the resource prefix. The reason why the trimming is in the module and not the naming module is that it allows the customers to override the prefix by providing a value for custom_prefix.

## Tests
<Please provide steps to test the PR>

## Notes
<Additional comments for the PR>