### PR TITLE
Add provider constraints

### DIFF
--- a/deploy/terraform/bootstrap/sap_deployer/providers.tf
+++ b/deploy/terraform/bootstrap/sap_deployer/providers.tf
@@ -21,23 +21,23 @@ terraform {
   required_providers {
     external = {
       source  = "hashicorp/external"
-      version = "~> 1.2"
+      version = "~> 2.0.0"
     }
     local = {
       source  = "hashicorp/local"
-      version = "~> 1.4"
+      version = "~> 2.0.0"
     }
     random = {
       source  = "hashicorp/random"
-      version = "~> 2.2"
+      version = "~> 3.0.0"
     }
     null = {
       source  = "hashicorp/null"
-      version = "~> 2.1"
+      version = "~> 3.0.0"
     }
     tls = {
       source  = "hashicorp/tls"
-      version = "~> 2.2"
+      version = "~> 3.0.0"
     }
     azurerm = {
       source = "hashicorp/azurerm"

--- a/deploy/terraform/bootstrap/sap_library/providers.tf
+++ b/deploy/terraform/bootstrap/sap_library/providers.tf
@@ -37,23 +37,23 @@ terraform {
   required_providers {
     external = {
       source  = "hashicorp/external"
-      version = "~> 1.2"
+      version = "~> 2.0.0"
     }
     local = {
       source  = "hashicorp/local"
-      version = "~> 1.4"
+      version = "~> 2.0.0"
     }
     random = {
       source  = "hashicorp/random"
-      version = "~> 2.2"
+      version = "~> 3.0.0"
     }
     null = {
       source  = "hashicorp/null"
-      version = "~> 2.1"
+      version = "~> 3.0.0"
     }
     azuread = {
       source = "hashicorp/azuread"
-      version = ">= 0.10.0"
+      version = "~> 1.0.0"
     }
     azurerm = {
       source = "hashicorp/azurerm"

--- a/deploy/terraform/run/sap_deployer/providers.tf
+++ b/deploy/terraform/run/sap_deployer/providers.tf
@@ -22,23 +22,23 @@ terraform {
   required_providers {
     external = {
       source  = "hashicorp/external"
-      version = "~> 1.2"
+      version = "~> 2.0.0"
     }
     local = {
       source  = "hashicorp/local"
-      version = "~> 1.4"
+      version = "~> 2.0.0"
     }
     random = {
       source  = "hashicorp/random"
-      version = "~> 2.2"
+      version = "~> 3.0.0"
     }
     null = {
       source  = "hashicorp/null"
-      version = "~> 2.1"
+      version = "~> 3.0.0"
     }
     tls = {
       source  = "hashicorp/tls"
-      version = "~> 2.2"
+      version = "~> 3.0.0"
     }
     azurerm = {
       source = "hashicorp/azurerm"

--- a/deploy/terraform/run/sap_landscape/providers.tf
+++ b/deploy/terraform/run/sap_landscape/providers.tf
@@ -36,19 +36,23 @@ terraform {
   required_providers {
     external = {
       source  = "hashicorp/external"
-      version = "~> 1.2"
+      version = "~> 2.0.0"
     }
     local = {
       source  = "hashicorp/local"
-      version = "~> 1.4"
+      version = "~> 2.0.0"
     }
     random = {
       source  = "hashicorp/random"
-      version = "~> 2.2"
+      version = "~> 3.0.0"
     }
     null = {
       source  = "hashicorp/null"
-      version = "~> 2.1"
+      version = "~> 3.0.0"
+    }
+    azuread = {
+      source = "hashicorp/azuread"
+      version = "~> 1.0.0"
     }
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/deploy/terraform/run/sap_library/providers.tf
+++ b/deploy/terraform/run/sap_library/providers.tf
@@ -37,23 +37,23 @@ terraform {
   required_providers {
     external = {
       source  = "hashicorp/external"
-      version = "~> 1.2"
+      version = "~> 2.0.0"
     }
     local = {
       source  = "hashicorp/local"
-      version = "~> 1.4"
+      version = "~> 2.0.0"
     }
     random = {
       source  = "hashicorp/random"
-      version = "~> 2.2"
+      version = "~> 3.0.0"
     }
     null = {
       source  = "hashicorp/null"
-      version = "~> 2.1"
+      version = "~> 3.0.0"
     }
     azuread = {
       source = "hashicorp/azuread"
-      version = ">= 0.10.0"
+      version = "~> 1.0.0"
     }
     azurerm = {
       source = "hashicorp/azurerm"

--- a/deploy/terraform/run/sap_system/providers.tf
+++ b/deploy/terraform/run/sap_system/providers.tf
@@ -36,27 +36,27 @@ terraform {
   required_providers {
     external = {
       source  = "hashicorp/external"
-      version = "~> 1.2"
+      version = "~> 2.0.0"
     }
     local = {
       source  = "hashicorp/local"
-      version = "~> 1.4"
+      version = "~> 2.0.0"
     }
     random = {
       source  = "hashicorp/random"
-      version = "~> 2.2"
+      version = "~> 3.0.0"
     }
     null = {
       source  = "hashicorp/null"
-      version = "~> 2.1"
+      version = "~> 3.0.0"
     }
     tls = {
       source  = "hashicorp/tls"
-      version = "~> 2.2"
+      version = "~> 3.0.0"
     }
     azuread = {
       source = "hashicorp/azuread"
-      version = ">= 0.10.0"
+      version = "~> 1.0.0"
     }
     azurerm = {
       source = "hashicorp/azurerm"


### PR DESCRIPTION
## Problem
<Please describe what problem this PR is trying to resolve>

## Solution
<Please elaborate the solution for the problem>

Add more strict constraints to provider 

    external = {
      source  = "hashicorp/external"
      version = "~> 2.0.0"
    }
    local = {
      source  = "hashicorp/local"
      version = "~> 2.0.0"
    }
    random = {
      source  = "hashicorp/random"
      version = "~> 3.0.0"
    }
    null = {
      source  = "hashicorp/null"
      version = "~> 3.0.0"
    }
    tls = {
      source  = "hashicorp/tls"
      version = "~> 3.0.0"
    }
    azuread = {
      source = "hashicorp/azuread"
      version = "~> 1.0.0"
    }
    azurerm = {
      source = "hashicorp/azurerm"
      version = "~> 2.35.0"
    }
Allows the specified version, plus newer versions that only increase the most specific segment of the specified version number. 


## Tests
<Please provide steps to test the PR>
see test pipeline

## Notes
<Additional comments for the PR>