### PR TITLE
make output same between bootstrap/run deployer

### DIFF
--- a/deploy/terraform/run/sap_deployer/output.tf
+++ b/deploy/terraform/run/sap_deployer/output.tf
@@ -4,6 +4,11 @@ Description:
   Output from sap_deployer module.
 */
 
+output "deployer_id" {
+  sensitive = true
+  value     = module.sap_deployer.deployer_id
+}
+
 output "vnet_mgmt" {
   sensitive = true
   value     = module.sap_deployer.vnet_mgmt


### PR DESCRIPTION
## Problem
<Please describe what problem this PR is trying to resolve>

The output of bootstrap/run deployer has difference which leads to the resource change when provisioning against these two.

## Solution
<Please elaborate the solution for the problem>
Add deployer_id as output in run/sap_deployer

## Tests
<Please provide steps to test the PR>

## Notes
<Additional comments for the PR>