### PR TITLE
Revert changes on depends on in module

### DIFF
--- a/deploy/terraform/run/sap_system/module.tf
+++ b/deploy/terraform/run/sap_system/module.tf
@@ -43,7 +43,6 @@ module "sap_namegenerator" {
 
 // Create HANA database nodes
 module "hdb_node" {
-  depends_on       = [module.common_infrastructure]
   source           = "../../terraform-units/modules/sap_system/hdb_node"
   application      = var.application
   databases        = var.databases
@@ -67,7 +66,6 @@ module "hdb_node" {
 
 // Create Application Tier nodes
 module "app_tier" {
-  depends_on       = [module.common_infrastructure, module.hdb_node, module.anydb_node]
   source           = "../../terraform-units/modules/sap_system/app_tier"
   application      = var.application
   databases        = var.databases
@@ -90,7 +88,6 @@ module "app_tier" {
 
 // Create anydb database nodes
 module "anydb_node" {
-  depends_on                 = [module.common_infrastructure]
   source                     = "../../terraform-units/modules/sap_system/anydb_node"
   application                = var.application
   databases                  = var.databases


### PR DESCRIPTION
## Problem
After adding depends_on to module, the VMs and disks gets recreated:
Example here: https://dev.azure.com/azuresaphana/Azure-SAP-HANA/_build/results?buildId=15508&view=logs&j=13cfa893-be7e-5723-d322-b6d1bcec6aca&t=db06c169-d1c1-5686-3df8-26b990a5af64

## Solution
Remove the depends_on in modules until we figure out why that cause VM recreation.

## Tests
Tested locally, without depends_on, terraform plan after terraform apply works as expected.
Also in pipeline, looks fine again:
https://dev.azure.com/azuresaphana/Azure-SAP-HANA/_build/results?buildId=15526&view=logs&j=ed898bca-1be4-5573-ffb5-764df6a725fe&t=3515a1e6-b72c-5f3d-99f5-7289c6342fae

## Notes
<Additional comments for the PR>