### PR TITLE
Add depends_on from anchor to db to app

### DIFF
--- a/deploy/terraform/run/sap_system/module.tf
+++ b/deploy/terraform/run/sap_system/module.tf
@@ -62,6 +62,8 @@ module "hdb_node" {
   admin_subnet               = module.common_infrastructure.admin_subnet
   db_subnet                  = module.common_infrastructure.db_subnet
   landscape_tfstate          = data.terraform_remote_state.landscape.outputs
+  // Workaround to create dependency from anchor to db to app
+  anchor_vm = module.common_infrastructure.anchor_vm
 }
 
 // Create Application Tier nodes
@@ -84,6 +86,9 @@ module "app_tier" {
   admin_subnet               = module.common_infrastructure.admin_subnet
   custom_disk_sizes_filename = var.app_disk_sizes_filename
   landscape_tfstate          = data.terraform_remote_state.landscape.outputs
+  // Workaround to create dependency from anchor to db to app
+  anydb_vms = module.anydb_node.anydb_vms
+  hdb_vms   = module.hdb_node.hdb_vms
 }
 
 // Create anydb database nodes
@@ -105,6 +110,8 @@ module "anydb_node" {
   admin_subnet               = module.common_infrastructure.admin_subnet
   db_subnet                  = module.common_infrastructure.db_subnet
   landscape_tfstate          = data.terraform_remote_state.landscape.outputs
+  // Workaround to create dependency from anchor to db to app
+  anchor_vm = module.common_infrastructure.anchor_vm
 }
 
 // Generate output files

--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/outputs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/outputs.tf
@@ -1,3 +1,10 @@
+output "anydb_vms" {
+  value = (upper(local.anydb_ostype) == "LINUX") ? [
+    azurerm_linux_virtual_machine.dbserver, azurerm_linux_virtual_machine.observer] : [
+    azurerm_windows_virtual_machine.dbserver, azurerm_windows_virtual_machine.observer
+  ]
+}
+
 output "nics_anydb" {
   value = local.enable_deployment ? azurerm_network_interface.anydb_db : []
 }

--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/variables_local.tf
@@ -1,3 +1,7 @@
+variable "anchor_vm" {
+  description = "Deployed anchor VM"
+}
+
 variable "resource_group" {
   description = "Details of the resource group"
 }

--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/vm-anydb.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/vm-anydb.tf
@@ -46,6 +46,7 @@ resource "azurerm_network_interface" "anydb_admin" {
 
 // Section for Linux Virtual machine 
 resource "azurerm_linux_virtual_machine" "dbserver" {
+  depends_on          = [var.anchor_vm]
   count               = local.enable_deployment ? ((upper(local.anydb_ostype) == "LINUX") ? local.db_server_count : 0) : 0
   name                = local.anydb_vms[count.index].name
   computer_name       = local.anydb_vms[count.index].computername
@@ -120,6 +121,7 @@ resource "azurerm_linux_virtual_machine" "dbserver" {
 
 // Section for Windows Virtual machine 
 resource "azurerm_windows_virtual_machine" "dbserver" {
+  depends_on          = [var.anchor_vm]
   count               = local.enable_deployment ? ((upper(local.anydb_ostype) == "WINDOWS") ? local.db_server_count : 0) : 0
   name                = local.anydb_vms[count.index].name
   computer_name       = local.anydb_vms[count.index].computername

--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/vm-observer.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/vm-observer.tf
@@ -19,6 +19,7 @@ resource "azurerm_network_interface" "observer" {
 
 # Create the Linux Application VM(s)
 resource "azurerm_linux_virtual_machine" "observer" {
+  depends_on          = [var.anchor_vm]
   count               = local.deploy_observer && upper(local.anydb_ostype) == "LINUX" ? length(local.zones) : 0
   name                = format("%s%s%s%s", local.prefix, var.naming.separator, local.observer_virtualmachine_names[count.index], local.resource_suffixes.vm)
   computer_name       = local.observer_computer_names[count.index]

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/variables_local.tf
@@ -1,3 +1,11 @@
+variable "anydb_vms" {
+  description = "Deployed anydb VMs"
+}
+
+variable "hdb_vms" {
+  description = "Deployed HDB VMs"
+}
+
 variable "resource_group" {
   description = "Details of the resource group"
 }

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-app.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-app.tf
@@ -42,6 +42,7 @@ resource "azurerm_network_interface" "app_admin" {
 
 # Create the Linux Application VM(s)
 resource "azurerm_linux_virtual_machine" "app" {
+  depends_on          = [var.anydb_vms, var.hdb_vms]
   count               = local.enable_deployment ? (upper(local.app_ostype) == "LINUX" ? local.application_server_count : 0) : 0
   name                = format("%s%s%s%s", local.prefix, var.naming.separator, local.app_virtualmachine_names[count.index], local.resource_suffixes.vm)
   computer_name       = local.app_computer_names[count.index]
@@ -105,6 +106,7 @@ resource "azurerm_linux_virtual_machine" "app" {
 
 # Create the Windows Application VM(s)
 resource "azurerm_windows_virtual_machine" "app" {
+  depends_on          = [var.anydb_vms, var.hdb_vms]
   count               = local.enable_deployment ? (upper(local.app_ostype) == "WINDOWS" ? local.application_server_count : 0) : 0
   name                = format("%s%s%s%s", local.prefix, var.naming.separator, local.app_virtualmachine_names[count.index], local.resource_suffixes.vm)
   computer_name       = local.app_computer_names[count.index]

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-scs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-scs.tf
@@ -50,6 +50,7 @@ resource "azurerm_network_interface_backend_address_pool_association" "scs" {
 
 # Create the SCS Linux VM(s)
 resource "azurerm_linux_virtual_machine" "scs" {
+  depends_on          = [var.anydb_vms, var.hdb_vms]
   count               = local.enable_deployment && (upper(local.scs_ostype) == "LINUX") ? local.scs_server_count : 0
   name                = format("%s%s%s%s", local.prefix, var.naming.separator, local.scs_virtualmachine_names[count.index], local.resource_suffixes.vm)
   computer_name       = local.scs_computer_names[count.index]
@@ -113,6 +114,7 @@ resource "azurerm_linux_virtual_machine" "scs" {
 
 # Create the SCS Windows VM(s)
 resource "azurerm_windows_virtual_machine" "scs" {
+  depends_on          = [var.anydb_vms, var.hdb_vms]
   count               = local.enable_deployment && (upper(local.scs_ostype) == "WINDOWS") ? local.scs_server_count : 0
   name                = format("%s%s%s%s", local.prefix, var.naming.separator, local.scs_virtualmachine_names[count.index], local.resource_suffixes.vm)
   computer_name       = local.scs_computer_names[count.index]

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-webdisp.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-webdisp.tf
@@ -38,6 +38,7 @@ resource "azurerm_network_interface" "web_admin" {
 
 # Create the Linux Web dispatcher VM(s)
 resource "azurerm_linux_virtual_machine" "web" {
+  depends_on          = [var.anydb_vms, var.hdb_vms]
   count               = local.enable_deployment ? (upper(local.web_ostype) == "LINUX" ? local.webdispatcher_count : 0) : 0
   name                = format("%s%s%s%s", local.prefix, var.naming.separator, local.web_virtualmachine_names[count.index], local.resource_suffixes.vm)
   computer_name       = local.web_computer_names[count.index]
@@ -100,6 +101,7 @@ resource "azurerm_linux_virtual_machine" "web" {
 
 # Create the Windows Web dispatcher VM(s)
 resource "azurerm_windows_virtual_machine" "web" {
+  depends_on          = [var.anydb_vms, var.hdb_vms]
   count               = local.enable_deployment ? (upper(local.web_ostype) == "WINDOWS" ? local.webdispatcher_count : 0) : 0
   name                = format("%s%s%s%s", local.prefix, var.naming.separator, local.web_virtualmachine_names[count.index], local.resource_suffixes.vm)
   computer_name       = local.web_computer_names[count.index]

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/outputs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/outputs.tf
@@ -1,3 +1,7 @@
+output "anchor_vm" {
+  value = local.anchor_ostype == "LINUX" ? azurerm_linux_virtual_machine.anchor : azurerm_windows_virtual_machine.anchor
+}
+
 output "resource_group" {
   value = local.rg_exists ? data.azurerm_resource_group.resource_group : azurerm_resource_group.resource_group
 }

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/outputs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/outputs.tf
@@ -1,3 +1,6 @@
+output "hdb_vms" {
+  value = azurerm_linux_virtual_machine.vm_dbnode
+}
 
 output "nics_dbnodes_admin" {
   value = local.enable_deployment ? azurerm_network_interface.nics_dbnodes_admin : []

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/variables_local.tf
@@ -1,3 +1,7 @@
+variable "anchor_vm" {
+  description = "Deployed anchor VM"
+}
+
 variable "resource_group" {
   description = "Details of the resource group"
 }

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/vm-hdb.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/vm-hdb.tf
@@ -70,9 +70,9 @@ resource "azurerm_lb" "hdb" {
     name                          = format("%s%s", local.prefix, local.resource_suffixes.db_alb_feip)
     subnet_id                     = var.db_subnet.id
     private_ip_address_allocation = "Static"
-    private_ip_address = try(local.hana_database.loadbalancer.frontend_ip, cidrhost(var.db_subnet.address_prefixes[0], tonumber(count.index) + local.hdb_ip_offsets.hdb_lb))
+    private_ip_address            = try(local.hana_database.loadbalancer.frontend_ip, cidrhost(var.db_subnet.address_prefixes[0], tonumber(count.index) + local.hdb_ip_offsets.hdb_lb))
   }
-    
+
 }
 
 resource "azurerm_lb_backend_address_pool" "hdb" {
@@ -123,6 +123,7 @@ resource "azurerm_lb_rule" "hdb" {
 
 # Manages Linux Virtual Machine for HANA DB servers
 resource "azurerm_linux_virtual_machine" "vm_dbnode" {
+  depends_on          = [var.anchor_vm]
   count               = local.enable_deployment ? length(local.hdb_vms) : 0
   name                = local.hdb_vms[count.index].name
   computer_name       = local.hdb_vms[count.index].computername


### PR DESCRIPTION
## Problem
The depends_on for modules does not work properly (see PR #928)

## Solution
Add explicit depends_on that makes:
1. DB VMs deployment depends on anchor VM (if any).
1. APP VMs deployment depends on DB VMs.

## Tests
From the pipeline you could see app VMs only starts to create after db VMs are completed.
https://dev.azure.com/azuresaphana/Azure-SAP-HANA/_build/results?buildId=15554&view=logs&j=13cfa893-be7e-5723-d322-b6d1bcec6aca

## Notes
We will have to remove this workaround if we find what went wrong with depends_on for modules.