### PR TITLE
Disable pip for deployer by default

### DIFF
--- a/.pipeline/templates/deployer/create-deployer-steps.yml
+++ b/.pipeline/templates/deployer/create-deployer-steps.yml
@@ -41,7 +41,12 @@ steps:
           path_to_public_key: "sshkey.pub",
           path_to_private_key: "sshkey"
         }
-      }' > ${input}
+      }' \
+      | jq '. += {
+        options: {
+          enable_deployer_public_ip: true
+        }
+      }'> ${input}
 
       cat ${input}
       

--- a/deploy/terraform/bootstrap/sap_deployer/deployer_full.json
+++ b/deploy/terraform/bootstrap/sap_deployer/deployer_full.json
@@ -13,7 +13,8 @@
         }
     },
     "options": {
-        "enable_secure_transfer": true
+        "enable_secure_transfer": true,
+        "enable_deployer_public_ip": false
     },
     "user_key_vault_id": "",
     "private_key_vault_id": ""

--- a/deploy/terraform/bootstrap/sap_deployer/deployer_init.sh
+++ b/deploy/terraform/bootstrap/sap_deployer/deployer_init.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+
+# exit immediately if a command fails
+set -o errexit
+
+# exit immediately if an unset variable is used
+set -o nounset
+
+function main()
+{
+    check_command_line_arguments "$@"
+
+    local deployer_rg_name="$1"
+    local deployer_sub_id="$2"
+    local deployer_tenant_id="$3"
+
+    init "${deployer_rg_name}" "${deployer_sub_id}" "${deployer_tenant_id}"
+}
+
+function check_command_line_arguments()
+{
+    local args_count="$#"
+
+    # Check if deployer_rg_name, deployer_sub_id and deployer_tenant_id are provided
+    if [[ ${args_count} -ne 3 ]]; then
+        echo "Please run deployer_init.sh <resource group name> <deployer subscription id> <deployer tenant id>"
+        exit 1
+    fi
+}
+
+function init()
+{
+    local deployer_rg_name="$1"
+    local deployer_sub_id="$2"
+    local deployer_tenant_id="$3"
+
+    # Prepare folder structure
+    mkdir -p $HOME/Azure_SAP_Automated_Deployment/WORKSPACES/LOCAL/$deployer_rg_name
+    mkdir -p $HOME/Azure_SAP_Automated_Deployment/WORKSPACES/SAP_LIBRARY
+    mkdir -p $HOME/Azure_SAP_Automated_Deployment/WORKSPACES/SAP_SYSTEM
+    mkdir -p $HOME/Azure_SAP_Automated_Deployment/WORKSPACES/SAP_LANDSCAPE
+    mkdir -p $HOME/Azure_SAP_Automated_Deployment/WORKSPACES/DEPLOYER
+
+    # Clones project repository
+    git clone https://github.com/Azure/sap-hana.git $HOME/Azure_SAP_Automated_Deployment/sap-hana || true
+
+    # Install terraform for all users
+    sudo apt-get install unzip
+    sudo mkdir -p /opt/terraform/terraform_0.13.5
+    sudo mkdir -p /opt/terraform/bin/
+    sudo wget -c -P /opt/terraform/terraform_0.13.5 https://releases.hashicorp.com/terraform/0.13.5/terraform_0.13.5_linux_amd64.zip
+    sudo unzip -u /opt/terraform/terraform_0.13.5/terraform_0.13.5_linux_amd64.zip -d /opt/terraform/terraform_0.13.5/
+    sudo ln -sf /opt/terraform/terraform_0.13.5/terraform /opt/terraform/bin/terraform
+    sudo sh -c "echo export PATH=$PATH:/opt/terraform/bin > /etc/profile.d/deploy_server.sh"
+    
+    # Set env for MSI
+    sudo sh -c "echo export ARM_USE_MSI=true >> /etc/profile.d/deploy_server.sh"
+    sudo sh -c "echo export ARM_SUBSCRIPTION_ID=${deployer_sub_id} >> /etc/profile.d/deploy_server.sh"
+    sudo sh -c "echo export ARM_TENANT_ID=${deployer_tenant_id} >> /etc/profile.d/deploy_server.sh"
+    sudo sh -c "echo az login --identity --output none >> /etc/profile.d/deploy_server.sh"
+    
+    # Install az cli
+    curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+    
+    # Install Git
+    sudo apt update
+    sudo apt-get install git=1:2.7.4-0ubuntu1.6
+    
+    # install jq
+    sudo apt -y install jq=1.5+dfsg-2
+    
+    # Install pip3
+    sudo apt -y install python3-pip
+    
+    # Installs Ansible
+    sudo -H pip3 install "ansible>=2.8,<2.9"
+    
+    # Install pywinrm
+    sudo -H pip3 install "pywinrm>=0.3.0"
+}
+
+# Execute the main program flow with all arguments
+main "$@"

--- a/deploy/terraform/bootstrap/sap_deployer/scripts.tf
+++ b/deploy/terraform/bootstrap/sap_deployer/scripts.tf
@@ -11,7 +11,7 @@ resource "local_file" "scp" {
     ppk_name        = module.sap_deployer.ppk_name,
     pwd_name        = module.sap_deployer.pwd_name,
     deployers       = module.sap_deployer.deployers,
-    deployer-ips    = module.sap_deployer.deployer_pip[*].ip_address
+    deployer-ips    = local.enable_deployer_public_ip ? module.sap_deployer.deployer_pip[*].ip_address : module.sap_deployer.deployer_private_ip_address
   })
   filename             = "${path.cwd}/post_deployment.sh"
   file_permission      = "0770"

--- a/deploy/terraform/bootstrap/sap_deployer/variables_local.tf
+++ b/deploy/terraform/bootstrap/sap_deployer/variables_local.tf
@@ -17,4 +17,6 @@ locals {
   vnet_mgmt_name_part = substr(upper(local.vnet_mgmt_name), -5, 5) == "-VNET" ? split("-", local.vnet_mgmt_name)[(local.vnet_mgmt_parts - 2)] : local.vnet_mgmt_name
 
   deployer_vm_count = length(var.deployers)
+
+  enable_deployer_public_ip = try(var.options.enable_deployer_public_ip, false)
 }

--- a/deploy/terraform/run/sap_deployer/deployer_full.json
+++ b/deploy/terraform/run/sap_deployer/deployer_full.json
@@ -1,0 +1,19 @@
+{
+    "infrastructure": {
+        "region": "eastus",
+        "environment": "np",
+        "vnets": {
+            "management": {
+                "name": "NP-EAUS-DEP00-vnet",
+                "address_space": "10.0.0.0/26",
+                "subnet_mgmt": {
+                    "prefix": "10.0.0.16/28"
+                }
+            }
+        }
+    },
+    "options": {
+        "enable_secure_transfer": true,
+        "enable_deployer_public_ip": false
+    }
+}

--- a/deploy/terraform/terraform-units/modules/sap_deployer/IMDS.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/IMDS.tf
@@ -21,7 +21,7 @@ variable "max_timeout" {
 // Registers the current deployment state with Azure's Metadata Service (IMDS)
 resource "null_resource" "IMDS" {
   depends_on = [azurerm_linux_virtual_machine.deployer]
-  count      = length(local.deployers)
+  count      = local.enable_deployer_public_ip ? length(local.deployers) : 0
 
   connection {
     type        = "ssh"

--- a/deploy/terraform/terraform-units/modules/sap_deployer/output.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/output.tf
@@ -84,3 +84,7 @@ output "deployer_kv_user_arm_id" {
 output "deployer_public_ip_address" {
   value = local.enable_deployers ? local.deployer_public_ip_address : ""
 }
+
+output "deployer_private_ip_address" {
+  value = local.enable_deployers ? azurerm_network_interface.deployer[*].private_ip_address : []
+}

--- a/deploy/terraform/terraform-units/modules/sap_deployer/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/variables_local.tf
@@ -115,7 +115,7 @@ locals {
   // Deployer(s) information with updated pip
   deployers_updated = [
     for idx, deployer in local.deployers : merge({
-      "public_ip_address" = azurerm_public_ip.deployer[idx].ip_address
+      "public_ip_address" = local.enable_deployer_public_ip ? azurerm_public_ip.deployer[idx].ip_address : ""
     }, deployer)
   ]
 

--- a/deploy/terraform/terraform-units/modules/sap_deployer/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/variables_local.tf
@@ -16,7 +16,8 @@ locals {
   resource_suffixes    = var.naming.resource_suffixes
 
   // Default option(s):
-  enable_secure_transfer = try(var.options.enable_secure_transfer, true)
+  enable_secure_transfer    = try(var.options.enable_secure_transfer, true)
+  enable_deployer_public_ip = try(var.options.enable_deployer_public_ip, false)
 
   // Resource group and location
   region  = try(var.infrastructure.region, "")
@@ -134,7 +135,7 @@ locals {
   ]))
 
   // public ip address of the first deployer
-  deployer_public_ip_address = local.enable_deployers ? local.deployer_public_ip_address_list[0] : ""
+  deployer_public_ip_address = local.enable_deployers && local.enable_deployer_public_ip ? local.deployer_public_ip_address_list[0] : ""
 
   // Comment out code with users.object_id for the time being.
   // deployer_users_id_list = distinct(compact(concat(local.deployer_users_id)))

--- a/deploy/terraform/terraform-units/modules/sap_deployer/vm-deployer.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/vm-deployer.tf
@@ -11,7 +11,7 @@ data azurerm_client_config "current" {}
 
 // Public IP addresse and nic for Deployer
 resource "azurerm_public_ip" "deployer" {
-  count               = length(local.deployers)
+  count               = local.enable_deployer_public_ip ? length(local.deployers) : 0
   name                = format("%s%s%s%s", local.prefix, var.naming.separator, local.deployers[count.index].name, local.resource_suffixes.pip)
   location            = azurerm_resource_group.deployer[0].location
   resource_group_name = azurerm_resource_group.deployer[0].name
@@ -29,7 +29,7 @@ resource "azurerm_network_interface" "deployer" {
     subnet_id                     = local.sub_mgmt_deployed.id
     private_ip_address            = local.deployers[count.index].private_ip_address
     private_ip_address_allocation = "static"
-    public_ip_address_id          = azurerm_public_ip.deployer[count.index].id
+    public_ip_address_id          = local.enable_deployer_public_ip ? azurerm_public_ip.deployer[count.index].id : ""
   }
 }
 

--- a/deploy/terraform/terraform-units/modules/sap_deployer/vm-deployer.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/vm-deployer.tf
@@ -109,10 +109,10 @@ resource "azurerm_linux_virtual_machine" "deployer" {
   }
 }
 
-// Prepare deployer with pre-installed softwares
+// Prepare deployer with pre-installed softwares if pip is created
 resource "null_resource" "prepare-deployer" {
   depends_on = [azurerm_linux_virtual_machine.deployer]
-  count      = length(local.deployers)
+  count      = local.enable_deployer_public_ip ? length(local.deployers) : 0
 
   connection {
     type        = "ssh"


### PR DESCRIPTION
## Problem
In general pip should not be added deployer for customer.

## Solution
1. Add key `enable_deployer_public_ip` under `options` to enable pip if required.
1. If no public ip is generated for deployer, we use private ip for generating scripts.
1. Add pip in azure pipeline, otherwise other unit test can't be done.

## Tests
<Please provide steps to test the PR>

## Notes
<Additional comments for the PR>