### PR TITLE
Trim output of saplandscape

### DIFF
--- a/deploy/terraform/run/sap_landscape/output.tf
+++ b/deploy/terraform/run/sap_landscape/output.tf
@@ -14,6 +14,11 @@ output "iscsi_private_ip" {
   value = try(module.sap_landscape.nics_iscsi[*].private_ip_address, [])
 }
 
-output "landscape_infrastructure" {
-  value = try(module.sap_landscape.infrastructure_w_defaults, {})
+output "iscsi_authentication_type" {
+  value = try(module.sap_landscape.iscsi_authentication_type, "")
 }
+
+output "iscsi_authentication_username" {
+  value = try(module.sap_landscape.iscsi_authentication_username, "")
+}
+

--- a/deploy/terraform/run/sap_system/module.tf
+++ b/deploy/terraform/run/sap_system/module.tf
@@ -135,4 +135,5 @@ module "output_files" {
   any_database_info         = module.anydb_node.any_database_info
   anydb_loadbalancers       = module.anydb_node.anydb_loadbalancers
   random_id                 = module.common_infrastructure.random_id
+  landscape_tfstate         = data.terraform_remote_state.landscape.outputs
 }

--- a/deploy/terraform/terraform-units/modules/sap_landscape/outputs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/outputs.tf
@@ -37,3 +37,11 @@ output "sid_public_key_secret_name" {
 output "sid_private_key_secret_name" {
   value = local.enable_landscape_kv ? azurerm_key_vault_secret.sid_ppk[0].name : ""
 }
+
+output "iscsi_authentication_type" {
+  value = local.iscsi_auth_type
+}
+
+output "iscsi_authentication_username" {
+  value = local.iscsi_auth_username
+}

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/variables_local.tf
@@ -182,9 +182,6 @@ locals {
   kv_users = var.deployer_user
   */
 
-  // SAP Landscape infrastructure
-  landscape_infrastructure = try(local.landscape_tfstate.landscape_infrastructure, {})
-
   //SAP vnet
   vnet_sap_arm_id              = try(local.landscape_tfstate.vnet_sap_arm_id, "")
   vnet_sap_name                = split("/", local.vnet_sap_arm_id)[8]
@@ -246,9 +243,8 @@ locals {
       name        = local.ppg_names,
       arm_id      = local.ppg_arm_ids
     },
-    iscsi = local.landscape_infrastructure.iscsi
     vnets = {
-      sap = merge(local.landscape_infrastructure.vnets.sap, {
+      sap = merge({
         subnet_admin = {
           is_existing = local.sub_admin_exists,
           arm_id      = local.sub_admin_arm_id,

--- a/deploy/terraform/terraform-units/modules/sap_system/output_files/inventory.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/output_files/inventory.tf
@@ -82,7 +82,7 @@ resource "local_file" "output_json" {
 # Generates the Ansible Inventory file
 resource "local_file" "ansible_inventory" {
   content = templatefile("${path.module}/ansible_inventory.tmpl", {
-    iscsi             = var.infrastructure_w_defaults.iscsi,
+    iscsi             = local.iscsi,
     ips_iscsi         = local.ips_iscsi,
     ips_dbnodes_admin = local.ips_dbnodes_admin,
     ips_dbnodes_db    = local.ips_dbnodes_db,
@@ -103,7 +103,7 @@ resource "local_file" "ansible_inventory" {
 # Generates the Ansible Inventory file
 resource "local_file" "ansible_inventory_yml" {
   content = templatefile("${path.module}/ansible_inventory.yml.tmpl", {
-    iscsi             = var.infrastructure_w_defaults.iscsi,
+    iscsi             = local.iscsi,
     ips_iscsi         = local.ips_iscsi,
     ips_dbnodes_admin = local.ips_dbnodes_admin,
     ips_dbnodes_db    = local.ips_dbnodes_db,

--- a/deploy/terraform/terraform-units/modules/sap_system/output_files/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/output_files/variables_local.tf
@@ -77,11 +77,24 @@ variable "software" {
   default     = {}
 }
 
+variable "landscape_tfstate" {
+  description = "Landscape remote tfstate file"
+}
+
 locals {
 
+  landscape_tfstate = var.landscape_tfstate
   ips_iscsi         = var.iscsi_private_ip
   ips_dbnodes_admin = [for key, value in var.nics_dbnodes_admin : value.private_ip_address]
   ips_dbnodes_db    = [for key, value in var.nics_dbnodes_db : value.private_ip_address]
+
+  iscsi = {
+    iscsi_count = length(local.ips_iscsi)
+    authentication = {
+      type     = local.landscape_tfstate.iscsi_authentication_type
+      username = local.landscape_tfstate.iscsi_authentication_username
+    }
+  }
 
   databases = [
     var.hana_database_info


### PR DESCRIPTION
## Problem
<Please describe what problem this PR is trying to resolve>
The output of saplandscape needs to be trimmed. Only pass the parameters being used

## Solution
<Please elaborate the solution for the problem>
Since Ansible needs iscsi authentication type and username, only these two variables will be output.

## Tests
<Please provide steps to test the PR>
https://dev.azure.com/azuresaphana/Azure-SAP-HANA/_build/results?buildId=15622&view=results

## Notes
<Additional comments for the PR>