### PR TITLE
Change git to use 1:2.17.1-1ubuntu0.7

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_deployer/vm-deployer.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/vm-deployer.tf
@@ -150,7 +150,7 @@ resource "null_resource" "prepare-deployer" {
       "curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash",
       // Install Git
       "sudo apt update",
-      "sudo apt-get install git=1:2.7.4-0ubuntu1.6",
+      "sudo apt-get install git=1:2.17.1-1ubuntu0.7",
       // install jq
       "sudo apt -y install jq=1.5+dfsg-2",
       // Install pip3


### PR DESCRIPTION
## Problem
Current with 18.04, the git has a different version.
The current git version won't work:
`module.sap_deployer.null_resource.prepare-deployer[0] (remote-exec): E: Version '1:2.7.4-0ubuntu1.6' for 'git' was not found
`

## Solution
Set to `1:2.17.1-1ubuntu0.7` which is currently available for ubuntu 18.04.

## Tests
<Please provide steps to test the PR>

## Notes
<Additional comments for the PR>