### PR TITLE
import existing key vaults to sap deployer

### DIFF
--- a/deploy/terraform/bootstrap/sap_deployer/deployer_full.json
+++ b/deploy/terraform/bootstrap/sap_deployer/deployer_full.json
@@ -14,5 +14,7 @@
     },
     "options": {
         "enable_secure_transfer": true
-    }
+    },
+    "user_key_vault_id": "",
+    "private_key_vault_id": ""
 }

--- a/deploy/terraform/bootstrap/sap_deployer/module.tf
+++ b/deploy/terraform/bootstrap/sap_deployer/module.tf
@@ -4,13 +4,15 @@ Description:
   Example to deploy deployer(s) using local backend.
 */
 module "sap_deployer" {
-  source         = "../../terraform-units/modules/sap_deployer"
-  infrastructure = var.infrastructure
-  deployers      = var.deployers
-  options        = var.options
-  ssh-timeout    = var.ssh-timeout
-  sshkey         = var.sshkey
-  naming         = module.sap_namegenerator.naming
+  source               = "../../terraform-units/modules/sap_deployer"
+  infrastructure       = var.infrastructure
+  deployers            = var.deployers
+  options              = var.options
+  ssh-timeout          = var.ssh-timeout
+  sshkey               = var.sshkey
+  user_key_vault_id    = var.user_key_vault_id
+  private_key_vault_id = var.private_key_vault_id
+  naming               = module.sap_namegenerator.naming
 }
 
 module "sap_namegenerator" {

--- a/deploy/terraform/bootstrap/sap_deployer/providers.tf
+++ b/deploy/terraform/bootstrap/sap_deployer/providers.tf
@@ -40,7 +40,7 @@ terraform {
       version = "~> 3.0.0"
     }
     azurerm = {
-      source = "hashicorp/azurerm"
+      source  = "hashicorp/azurerm"
       version = "~> 2.35.0"
     }
   }

--- a/deploy/terraform/bootstrap/sap_deployer/variables_global.tf
+++ b/deploy/terraform/bootstrap/sap_deployer/variables_global.tf
@@ -28,3 +28,13 @@ variable "sshkey" {
   description = "Details of ssh key pair"
   default     = {}
 }
+
+variable "user_key_vault_id" {
+  description = "The user brings an existing user Key Vault"
+  default     = ""
+}
+
+variable "private_key_vault_id" {
+  description = "The user brings an existing private Key Vault"
+  default     = ""
+}

--- a/deploy/terraform/run/sap_deployer/module.tf
+++ b/deploy/terraform/run/sap_deployer/module.tf
@@ -4,13 +4,15 @@ Description:
   Example to deploy deployer(s) using local backend.
 */
 module "sap_deployer" {
-  source         = "../../terraform-units/modules/sap_deployer/"
-  infrastructure = var.infrastructure
-  deployers      = var.deployers
-  options        = var.options
-  ssh-timeout    = var.ssh-timeout
-  sshkey         = var.sshkey
-  naming         = module.sap_namegenerator.naming
+  source               = "../../terraform-units/modules/sap_deployer/"
+  infrastructure       = var.infrastructure
+  deployers            = var.deployers
+  options              = var.options
+  ssh-timeout          = var.ssh-timeout
+  sshkey               = var.sshkey
+  user_key_vault_id    = var.user_key_vault_id
+  private_key_vault_id = var.private_key_vault_id
+  naming               = module.sap_namegenerator.naming
 }
 
 module "sap_namegenerator" {
@@ -21,5 +23,5 @@ module "sap_namegenerator" {
   management_vnet_name = local.vnet_mgmt_name_part
   random_id            = module.sap_deployer.random_id
   deployer_vm_count    = local.deployer_vm_count
- }
+}
 

--- a/deploy/terraform/run/sap_deployer/providers.tf
+++ b/deploy/terraform/run/sap_deployer/providers.tf
@@ -41,7 +41,7 @@ terraform {
       version = "~> 3.0.0"
     }
     azurerm = {
-      source = "hashicorp/azurerm"
+      source  = "hashicorp/azurerm"
       version = "~> 2.35.0"
     }
   }

--- a/deploy/terraform/run/sap_deployer/variables_global.tf
+++ b/deploy/terraform/run/sap_deployer/variables_global.tf
@@ -28,3 +28,13 @@ variable "sshkey" {
   description = "Details of ssh key pair"
   default     = {}
 }
+
+variable "user_key_vault_id" {
+  description = "The user brings an existing user Key Vault"
+  default     = ""
+}
+
+variable "private_key_vault_id" {
+  description = "The user brings an existing private Key Vault"
+  default     = ""
+}

--- a/deploy/terraform/terraform-units/modules/sap_deployer/key_vault.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/key_vault.tf
@@ -2,8 +2,8 @@
 data "azurerm_client_config" "deployer" {}
 
 resource "azurerm_key_vault" "kv_prvt" {
-  count                      = local.enable_deployers ? 1 : 0
-  name                       = local.keyvault_names.private_access
+  count                      = (local.enable_deployers && ! local.prvt_kv_exist) ? 1 : 0
+  name                       = local.prvt_kv_name
   location                   = azurerm_resource_group.deployer[0].location
   resource_group_name        = azurerm_resource_group.deployer[0].name
   tenant_id                  = data.azurerm_client_config.deployer.tenant_id
@@ -14,8 +14,15 @@ resource "azurerm_key_vault" "kv_prvt" {
   sku_name = "standard"
 }
 
+// Import an existing private Key Vault
+data "azurerm_key_vault" "kv_prvt" {
+  count               = (local.enable_deployers && local.prvt_kv_exist) ? 1 : 0
+  name                = local.prvt_kv_name
+  resource_group_name = local.prvt_kv_rg_name
+}
+
 resource "azurerm_key_vault_access_policy" "kv_prvt_msi" {
-  count        = local.enable_deployers ? 1 : 0
+  count        = (local.enable_deployers && ! local.prvt_kv_exist) ? 1 : 0
   key_vault_id = azurerm_key_vault.kv_prvt[0].id
 
   tenant_id = data.azurerm_client_config.deployer.tenant_id
@@ -28,8 +35,8 @@ resource "azurerm_key_vault_access_policy" "kv_prvt_msi" {
 
 // Create user KV with access policy
 resource "azurerm_key_vault" "kv_user" {
-  count                      = local.enable_deployers ? 1 : 0
-  name                       = local.keyvault_names.user_access
+  count                      = (local.enable_deployers && ! local.user_kv_exist) ? 1 : 0
+  name                       = local.user_kv_name
   location                   = azurerm_resource_group.deployer[0].location
   resource_group_name        = azurerm_resource_group.deployer[0].name
   tenant_id                  = data.azurerm_client_config.deployer.tenant_id
@@ -40,8 +47,15 @@ resource "azurerm_key_vault" "kv_user" {
   sku_name = "standard"
 }
 
+// Import an existing user Key Vault
+data "azurerm_key_vault" "kv_user" {
+  count               = (local.enable_deployers && local.user_kv_exist) ? 1 : 0
+  name                = local.user_kv_name
+  resource_group_name = local.user_kv_rg_name
+}
+
 resource "azurerm_key_vault_access_policy" "kv_user_msi" {
-  count        = local.enable_deployers ? 1 : 0
+  count        = (local.enable_deployers && ! local.user_kv_exist) ? 1 : 0
   key_vault_id = azurerm_key_vault.kv_user[0].id
 
   tenant_id = data.azurerm_client_config.deployer.tenant_id
@@ -56,7 +70,7 @@ resource "azurerm_key_vault_access_policy" "kv_user_msi" {
 }
 
 resource "azurerm_key_vault_access_policy" "kv_user_pre_deployer" {
-  count        = local.enable_deployers ? 1 : 0
+  count        = (local.enable_deployers && ! local.user_kv_exist) ? 1 : 0
   key_vault_id = azurerm_key_vault.kv_user[0].id
 
   tenant_id = data.azurerm_client_config.deployer.tenant_id
@@ -100,6 +114,7 @@ resource "tls_private_key" "deployer" {
   count = (
     local.enable_deployers
     && local.enable_key
+    && ! local.user_kv_exist
     && (try(file(var.sshkey.path_to_public_key), "") == "" ? true : false)
   ) ? 1 : 0
   algorithm = "RSA"
@@ -113,16 +128,16 @@ resource "tls_private_key" "deployer" {
 
 resource "azurerm_key_vault_secret" "ppk" {
   depends_on   = [azurerm_key_vault_access_policy.kv_user_pre_deployer[0]]
-  count        = (local.enable_deployers && local.enable_key) ? 1 : 0
-  name         = format("%s-sshkey", local.prefix)
+  count        = (local.enable_deployers && local.enable_key && ! local.user_kv_exist) ? 1 : 0
+  name         = local.ppk_name
   value        = local.private_key
   key_vault_id = azurerm_key_vault.kv_user[0].id
 }
 
 resource "azurerm_key_vault_secret" "pk" {
   depends_on   = [azurerm_key_vault_access_policy.kv_user_pre_deployer[0]]
-  count        = (local.enable_deployers && local.enable_key) ? 1 : 0
-  name         = format("%s-sshkey-pub", local.prefix)
+  count        = (local.enable_deployers && local.enable_key && ! local.user_kv_exist) ? 1 : 0
+  name         = local.pk_name
   value        = local.public_key
   key_vault_id = azurerm_key_vault.kv_user[0].id
 }
@@ -132,6 +147,7 @@ resource "random_password" "deployer" {
   count = (
     local.enable_deployers
     && local.enable_password
+    && ! local.user_kv_exist
     && local.input_pwd == null ? true : false
   ) ? 1 : 0
   length           = 16
@@ -141,8 +157,26 @@ resource "random_password" "deployer" {
 
 resource "azurerm_key_vault_secret" "pwd" {
   depends_on   = [azurerm_key_vault_access_policy.kv_user_pre_deployer[0]]
-  count        = (local.enable_deployers && local.enable_password) ? 1 : 0
-  name         = format("%s-password", local.prefix)
+  count        = (local.enable_deployers && local.enable_password && ! local.user_kv_exist) ? 1 : 0
+  name         = local.pwd_name
   value        = local.password
   key_vault_id = azurerm_key_vault.kv_user[0].id
+}
+
+data "azurerm_key_vault_secret" "pk" {
+  count        = (local.enable_deployers && local.enable_key && local.user_kv_exist) ? 1 : 0
+  name         = local.pk_name
+  key_vault_id = local.user_key_vault_id
+}
+
+data "azurerm_key_vault_secret" "ppk" {
+  count        = (local.enable_deployers && local.enable_key && local.user_kv_exist) ? 1 : 0
+  name         = local.ppk_name
+  key_vault_id = local.user_key_vault_id
+}
+
+data "azurerm_key_vault_secret" "pwd" {
+  count        = (local.enable_deployers && local.enable_password && local.user_kv_exist) ? 1 : 0
+  name         = local.pwd_name
+  key_vault_id = local.user_key_vault_id
 }

--- a/deploy/terraform/terraform-units/modules/sap_deployer/output.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/output.tf
@@ -49,25 +49,25 @@ output "random_id" {
 }
 
 output "user_vault_name" {
-  value = azurerm_key_vault.kv_user[0].name
+  value = local.user_kv_exist ? data.azurerm_key_vault.kv_user[0].name : azurerm_key_vault.kv_user[0].name
 }
 
 output "prvt_vault_name" {
-  value = azurerm_key_vault.kv_prvt[0].name
+  value = local.prvt_kv_exist ? data.azurerm_key_vault.kv_prvt[0].name : azurerm_key_vault.kv_prvt[0].name
 }
 
 // output the secret name of public key
 output "ppk_name" {
-  value = local.enable_deployers && local.enable_key ? azurerm_key_vault_secret.ppk[0].name : ""
+  value = local.enable_deployers && local.enable_key ? local.ppk_name : ""
 }
 
 // output the secret name of private key
 output "pk_name" {
-  value = local.enable_deployers && local.enable_key ? azurerm_key_vault_secret.pk[0].name : ""
+  value = local.enable_deployers && local.enable_key ? local.pk_name : ""
 }
 
 output "pwd_name" {
-  value = local.enable_deployers && local.enable_password ? azurerm_key_vault_secret.pwd[0].name : ""
+  value = local.enable_deployers && local.enable_password ? local.pwd_name : ""
 }
 
 // Comment out code with users.object_id for the time being.
@@ -78,7 +78,7 @@ output "deployer_user" {
 */
 
 output "deployer_kv_user_arm_id" {
-  value = local.enable_deployers ? azurerm_key_vault.kv_user[0].id : ""
+  value = local.enable_deployers ? (local.user_kv_exist ? data.azurerm_key_vault.kv_user[0].id : azurerm_key_vault.kv_user[0].id) : ""
 }
 
 output "deployer_public_ip_address" {

--- a/deploy/terraform/terraform-units/modules/sap_deployer/variables_global.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/variables_global.tf
@@ -9,3 +9,12 @@ variable "deployers" {}
 variable "options" {}
 variable "ssh-timeout" {}
 variable "sshkey" {}
+variable "user_key_vault_id" {
+  description = "The user brings an existing user Key Vault"
+  default     = ""
+}
+
+variable "private_key_vault_id" {
+  description = "The user brings an existing private Key Vault"
+  default     = ""
+}

--- a/deploy/terraform/terraform-units/modules/sap_deployer/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/variables_local.tf
@@ -23,7 +23,6 @@ locals {
   prefix  = try(var.infrastructure.resource_group.name, var.naming.prefix.DEPLOYER)
   rg_name = try(var.infrastructure.resource_group.name, format("%s%s", local.prefix, local.resource_suffixes.deployer_rg))
 
-
   // Post fix for all deployed resources
   postfix = random_id.deployer.hex
 
@@ -68,7 +67,7 @@ locals {
     try(deployer.authentication.password, "")
   ])
   input_pwd = length(local.input_pwd_list) > 0 ? local.input_pwd_list[0] : null
-  password  = (local.enable_deployers && local.enable_password) ? try(local.input_pwd_list[0], random_password.deployer[0].result) : null
+  password  = (local.enable_deployers && local.enable_password) ? (local.user_kv_exist ? data.azurerm_key_vault_secret.pwd[0].value : try(local.input_pwd_list[0], random_password.deployer[0].result)) : null
 
   enable_key = contains(compact([
     for deployer in local.deployer_input :
@@ -76,8 +75,8 @@ locals {
   ]), "true")
 
   // By default use generated public key. Provide sshkey.path_to_public_key and path_to_private_key overides it
-  public_key  = (local.enable_deployers && local.enable_key) ? try(file(var.sshkey.path_to_public_key), tls_private_key.deployer[0].public_key_openssh) : null
-  private_key = (local.enable_deployers && local.enable_key) ? try(file(var.sshkey.path_to_private_key), tls_private_key.deployer[0].private_key_pem) : null
+  public_key  = (local.enable_deployers && local.enable_key) ? (local.user_kv_exist ? data.azurerm_key_vault_secret.pk[0].value : try(file(var.sshkey.path_to_public_key), tls_private_key.deployer[0].public_key_openssh)) : null
+  private_key = (local.enable_deployers && local.enable_key) ? (local.user_kv_exist ? data.azurerm_key_vault_secret.ppk[0].value : try(file(var.sshkey.path_to_private_key), tls_private_key.deployer[0].private_key_pem)) : null
 
   deployers = [
     for idx, deployer in local.deployer_input : {
@@ -139,4 +138,22 @@ locals {
 
   // Comment out code with users.object_id for the time being.
   // deployer_users_id_list = distinct(compact(concat(local.deployer_users_id)))
+
+  // If the user specifies arm id of key vaults in input, the key vault will be imported instead of creating new key vaults
+  user_key_vault_id    = try(var.user_key_vault_id, "")
+  prvt_key_vault_id    = try(var.private_key_vault_id, "")
+  user_kv_exist        = try(length(local.user_key_vault_id) > 0, false)
+  prvt_kv_exist        = try(length(local.prvt_key_vault_id) > 0, false)
+
+  ppk_name = format("%s-sshkey", local.prefix)
+  pk_name  = format("%s-sshkey-pub", local.prefix)
+  pwd_name = format("%s-password", local.prefix)
+
+  // Extract information from the specified key vault arm ids
+  user_kv_name    = local.user_kv_exist ? split("/", local.user_key_vault_id)[8] : local.keyvault_names.user_access
+  user_kv_rg_name = local.user_kv_exist ? split("/", local.user_key_vault_id)[4] : ""
+
+  prvt_kv_name    = local.prvt_kv_exist ? split("/", local.prvt_key_vault_id)[8] : local.keyvault_names.private_access
+  prvt_kv_rg_name = local.prvt_kv_exist ? split("/", local.prvt_key_vault_id)[4] : ""
+
 }


### PR DESCRIPTION
## Problem
<Please describe what problem this PR is trying to resolve>
Based on the backlog feature of phase 2

## Solution
<Please elaborate the solution for the problem>
use case 1:
The user specifies user_key_vault_id in input json, then the corresponding key vault will be used as the user keyvault of deployer.
There should exist {environment}-sshkey-pub, {environment}-sshkey in this keyvault to fetch public key from. 

use case 2:
The user specifies private_key_vault_id in input json, then the corresponding key vault will be used as the private keyvault of deployer.

Note:
As soon as bootstraping deployer is done, the user should make sure deployer-msi has access to the secrets of keyvault for subsequent steps in the workflow.

## Tests
<Please provide steps to test the PR>
Test locally

## Notes
<Additional comments for the PR>