### PR TITLE
Recover secrets in pipeline if rerun failed test is required

### DIFF
--- a/.pipeline/templates/deployer/post-deployer-steps.yml
+++ b/.pipeline/templates/deployer/post-deployer-steps.yml
@@ -22,6 +22,12 @@ steps:
 
       # Copy local key pair to deployer. Temporary workaround until kv feature completes.
       scp -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no -o ConnectTimeout=$(ssh_timeout_s) ${ws_dir}/sshkey* "$(username)"@"$(publicIP)":${remote_dir}
+
+      echo "=== Add access policy recover for deployer MSI to deployer KV ==="
+      deployer_msi="${deployer_prefix}-EAUS-DEP00-msi"
+      deployer_msi_objectId=$(az ad sp list --display-name ${deployer_msi} | jq -r '.[].objectId')
+      deployer_kv_name=$(az keyvault list --resource-group ${deployer_rg} | jq -r '.[] | select(.name | contains("user")).name')
+      az keyvault set-policy --name ${deployer_kv_name} --secret-permissions get list set delete recover --object-id ${deployer_msi_objectId} --output none
     displayName: "Post deployment"
     env:
       ARM_CLIENT_ID: $(hana-pipeline-spn-id)

--- a/.pipeline/templates/saplandscape/create-saplandscape-steps.yml
+++ b/.pipeline/templates/saplandscape/create-saplandscape-steps.yml
@@ -100,6 +100,12 @@ steps:
       az keyvault secret set --vault-name ${deployer_kv_name} --name ${saplandscape_prefix}-subscription-id --value $(landscape-subscription) --output none
       az keyvault secret set --vault-name ${deployer_kv_name} --name ${saplandscape_prefix}-tenant-id --value $(landscape-tenant) --output none
 
+      echo "=== Recovery SPN in deployer KV when rerun same build ==="
+      az keyvault secret recover --vault-name ${deployer_kv_name} --name ${saplandscape_prefix}-client-id --output none
+      az keyvault secret recover --vault-name ${deployer_kv_name} --name ${saplandscape_prefix}-client-secret --output none
+      az keyvault secret recover --vault-name ${deployer_kv_name} --name ${saplandscape_prefix}-subscription-id --output none
+      az keyvault secret recover --vault-name ${deployer_kv_name} --name ${saplandscape_prefix}-tenant-id --output none
+
       cp ${repo_dir}/deploy/terraform/run/sap_landscape/saplandscape.json ${ws_dir}/saplandscape.json
       cat ${ws_dir}/saplandscape.json \
       | jq --arg saplandscape_rg "${saplandscape_rg}" .infrastructure.resource_group.name\ =\ \$saplandscape_rg \

--- a/.pipeline/templates/saplandscape/create-saplandscape-steps.yml
+++ b/.pipeline/templates/saplandscape/create-saplandscape-steps.yml
@@ -105,6 +105,8 @@ steps:
       az keyvault secret recover --vault-name ${deployer_kv_name} --name ${saplandscape_prefix}-client-secret --output none
       az keyvault secret recover --vault-name ${deployer_kv_name} --name ${saplandscape_prefix}-subscription-id --output none
       az keyvault secret recover --vault-name ${deployer_kv_name} --name ${saplandscape_prefix}-tenant-id --output none
+      echo "=== Wait for 30s for secrets to be available === "
+      sleep 30s
 
       cp ${repo_dir}/deploy/terraform/run/sap_landscape/saplandscape.json ${ws_dir}/saplandscape.json
       cat ${ws_dir}/saplandscape.json \

--- a/.pipeline/templates/saplib/create-saplib-steps.yml
+++ b/.pipeline/templates/saplib/create-saplib-steps.yml
@@ -45,6 +45,12 @@ steps:
       az keyvault secret set --vault-name ${deployer_kv_name} --name ${saplib_prefix}-subscription-id --value $(landscape-subscription) --output none
       az keyvault secret set --vault-name ${deployer_kv_name} --name ${saplib_prefix}-tenant-id --value $(landscape-tenant) --output none
 
+      echo "=== Recovery SPN in deployer KV when rerun same build ==="
+      az keyvault secret recover --vault-name ${deployer_kv_name} --name ${saplib_prefix}-client-id --output none
+      az keyvault secret recover --vault-name ${deployer_kv_name} --name ${saplib_prefix}-client-secret --output none
+      az keyvault secret recover --vault-name ${deployer_kv_name} --name ${saplib_prefix}-subscription-id --output none
+      az keyvault secret recover --vault-name ${deployer_kv_name} --name ${saplib_prefix}-tenant-id --output none
+
       echo "=== Checkout required branch ${{parameters.branch_name}} ==="
       if [ ! -d "${repo_dir}" ]
       then

--- a/.pipeline/templates/saplib/create-saplib-steps.yml
+++ b/.pipeline/templates/saplib/create-saplib-steps.yml
@@ -50,6 +50,8 @@ steps:
       az keyvault secret recover --vault-name ${deployer_kv_name} --name ${saplib_prefix}-client-secret --output none
       az keyvault secret recover --vault-name ${deployer_kv_name} --name ${saplib_prefix}-subscription-id --output none
       az keyvault secret recover --vault-name ${deployer_kv_name} --name ${saplib_prefix}-tenant-id --output none
+      echo "=== Wait for 30s for secrets to be available === "
+      sleep 30s
 
       echo "=== Checkout required branch ${{parameters.branch_name}} ==="
       if [ ! -d "${repo_dir}" ]

--- a/.pipeline/templates/sapsystem/create-sapsystem-steps.yml
+++ b/.pipeline/templates/sapsystem/create-sapsystem-steps.yml
@@ -92,6 +92,12 @@ steps:
       az keyvault secret set --vault-name ${deployer_kv_name} --name ${sapsystem_prefix}-subscription-id --value $(landscape-subscription) --output none
       az keyvault secret set --vault-name ${deployer_kv_name} --name ${sapsystem_prefix}-tenant-id --value $(landscape-tenant) --output none
 
+      echo "=== Recovery SPN in deployer KV when rerun same build ==="
+      az keyvault secret recover --vault-name ${deployer_kv_name} --name ${sapsystem_prefix}-client-id --output none
+      az keyvault secret recover --vault-name ${deployer_kv_name} --name ${sapsystem_prefix}-client-secret --output none
+      az keyvault secret recover --vault-name ${deployer_kv_name} --name ${sapsystem_prefix}-subscription-id --output none
+      az keyvault secret recover --vault-name ${deployer_kv_name} --name ${sapsystem_prefix}-tenant-id --output none
+     
       # If no osImage provided, deploy SLES12SP5
       [ -z "${{parameters.osImage_offer}}" ] && osImage_offer="sles-sap-12-sp5" || osImage_offer=${{parameters.osImage_offer}}
       [ -z "${{parameters.osImage_publisher}}" ] && osImage_publisher="SUSE" || osImage_publisher=${{parameters.osImage_publisher}}

--- a/.pipeline/templates/sapsystem/create-sapsystem-steps.yml
+++ b/.pipeline/templates/sapsystem/create-sapsystem-steps.yml
@@ -97,7 +97,9 @@ steps:
       az keyvault secret recover --vault-name ${deployer_kv_name} --name ${sapsystem_prefix}-client-secret --output none
       az keyvault secret recover --vault-name ${deployer_kv_name} --name ${sapsystem_prefix}-subscription-id --output none
       az keyvault secret recover --vault-name ${deployer_kv_name} --name ${sapsystem_prefix}-tenant-id --output none
-     
+      echo "=== Wait for 30s for secrets to be available === "
+      sleep 30s
+
       # If no osImage provided, deploy SLES12SP5
       [ -z "${{parameters.osImage_offer}}" ] && osImage_offer="sles-sap-12-sp5" || osImage_offer=${{parameters.osImage_offer}}
       [ -z "${{parameters.osImage_publisher}}" ] && osImage_publisher="SUSE" || osImage_publisher=${{parameters.osImage_publisher}}


### PR DESCRIPTION
## Problem
Rerun the test will try to create the same secrets that were deleted, which will fail due to soft deletion.
```
=== Store SPN in deployer KV ===
Secret U5660-client-id is currently in a deleted but recoverable state, and its name cannot be reused; in this state, the secret can only be recovered or purged.
Secret U5660-client-secret is currently in a deleted but recoverable state, and its name cannot be reused; in this state, the secret can only be recovered or purged.
Secret U5660-subscription-id is currently in a deleted but recoverable state, and its name cannot be reused; in this state, the secret can only be recovered or purged.
Secret U5660-tenant-id is currently in a deleted but recoverable state, and its name cannot be reused; in this state, the secret can only be recovered or purged.

```
## Solution
Add attempt to recover the deleted secrets.
`=== Recovery SPN in deployer KV when rerun same build ===
`

## Tests
Run a test then cancel, then rerun, then it was able to recover the secrets:
https://dev.azure.com/azuresaphana/Azure-SAP-HANA/_build/results?buildId=15663&view=logs&j=ba0a2017-571a-59b4-0850-4a1116b20bb3&t=195c0f60-e3e1-5deb-a401-93acc5f4aecb


## Notes
<Additional comments for the PR>