### PR TITLE
Fix config path for sap_landscape pipeline

### DIFF
--- a/.pipeline/templates/saplandscape/delete-saplandscape-steps.yml
+++ b/.pipeline/templates/saplandscape/delete-saplandscape-steps.yml
@@ -57,7 +57,7 @@ steps:
       
       echo "=== Delete SAP system from deployer with terraform ==="
       echo "=== This may take quite a while, please be patient ==="
-      terraform destroy -auto-approve -var-file=${input} ${repo_dir}/deploy/terraform/run/sap_system/
+      terraform destroy -auto-approve -var-file=${input} ${repo_dir}/deploy/terraform/run/sap_landscape/
       
       echo "=== Delete git clone for the build from deployer ==="
       rm -rf ~/${saplandscape_rg}

--- a/.pipeline/templates/saplandscape/validate-saplandscape-steps.yml
+++ b/.pipeline/templates/saplandscape/validate-saplandscape-steps.yml
@@ -29,8 +29,8 @@ steps:
       echo "=== Enter workspace ${ws_dir} ==="
       cd ${ws_dir}
 
-      terraform init -upgrade=true ${repo_dir}/deploy/terraform/run/sap_system/
-      terraform plan -var-file=${input} ${repo_dir}/deploy/terraform/run/sap_system/ > plan_output.log
+      terraform init -upgrade=true ${repo_dir}/deploy/terraform/run/sap_landscape/
+      terraform plan -var-file=${input} ${repo_dir}/deploy/terraform/run/sap_landscape/ > plan_output.log
       cat plan_output.log
       
       if ! grep "No changes\|0 to change, 0 to destroy" plan_output.log; then exit 1; fi;


### PR DESCRIPTION
## Problem
sap_landscape validate and destroy templates use configuration under `run/sap_system`

## Solution
Change to use `run/sap_landscape`

## Tests
https://dev.azure.com/azuresaphana/Azure-SAP-HANA/_build/results?buildId=15678&view=results

## Notes
<Additional comments for the PR>