### PR TITLE
Add condition for sap_system validation step

### DIFF
--- a/.pipeline/templates/sapsystem/validate-sapsystem-steps.yml
+++ b/.pipeline/templates/sapsystem/validate-sapsystem-steps.yml
@@ -33,7 +33,8 @@ steps:
       terraform plan -var-file=${input} ${repo_dir}/deploy/terraform/run/sap_system/ > plan_output.log
       cat plan_output.log
       
-      if ! grep "No changes\|0 to change, 0 to destroy" plan_output.log; then exit 1; fi;
+      # include 1 to add, 0 to change, 1 to destroy as expected result, due to regeneration of output.json
+      if ! grep "No changes\|0 to change, 0 to destroy\|1 to add, 0 to change, 1 to destroy" plan_output.log; then exit 1; fi;
       '
     displayName: "Validate sap system new config"
     env:


### PR DESCRIPTION
## Problem
When rerun sap_system config, it will recreate output.json, this behavior should be correct and expected.

## Solution
Add condition that if only 1 resource get recreated, we assume test succeed.

## Tests
<Please provide steps to test the PR>

## Notes
<Additional comments for the PR>