### PR TITLE
Control anchor deployment

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/variables_local.tf
@@ -137,7 +137,7 @@ locals {
 
   //Anchor VM
   anchor                      = try(local.var_infra.anchor_vms, {})
-  deploy_anchor               = length(local.anchor) > 0 ? true : false
+  deploy_anchor               = length(local.anchor) > 0 && local.enable_db_deployment ? true : false
   anchor_size                 = try(local.anchor.sku, "Standard_D8s_v3")
   anchor_authentication       = try(local.anchor.authentication, local.db_auth)
   anchor_auth_type            = try(local.anchor.authentication.type, "key")


### PR DESCRIPTION
Don't deploy anchor if there are no databases deployed

## Problem
Anchor deployment is not dependent on database deployment

## Solution
Add additional check

## Tests
<Please provide steps to test the PR>

## Notes
<Additional comments for the PR>