### PR TITLE
import kvs to saplandscape

### DIFF
--- a/deploy/terraform/run/sap_landscape/module.tf
+++ b/deploy/terraform/run/sap_landscape/module.tf
@@ -11,6 +11,7 @@ module "sap_landscape" {
   sshkey            = var.sshkey
   naming            = module.sap_namegenerator.naming
   service_principal = local.service_principal
+  key_vault         = var.key_vault
   deployer_tfstate  = data.terraform_remote_state.deployer.outputs
 }
 

--- a/deploy/terraform/run/sap_landscape/output.tf
+++ b/deploy/terraform/run/sap_landscape/output.tf
@@ -6,6 +6,10 @@ output "landscape_key_vault_user_arm_id" {
   value = try(module.sap_landscape.kv_user[0].id, "")
 }
 
+output "landscape_key_vault_private_arm_id" {
+  value = try(module.sap_landscape.kv_prvt[0].id, "")
+}
+
 output "sid_public_key_secret_name" {
   value = try(module.sap_landscape.sid_public_key_secret_name, "")
 }

--- a/deploy/terraform/run/sap_landscape/saplandscape_full.json
+++ b/deploy/terraform/run/sap_landscape/saplandscape_full.json
@@ -23,6 +23,16 @@
             "use_DHCP": false
         }
     },
+    "key_vault": {
+        "kv_user_id": "",
+        "kv_prvt_id": "",
+        "kv_sid_sshkey_prvt" : "",
+        "kv_sid_sshkey_pub" : "",
+        "kv_iscsi_username": "",
+        "kv_iscsi_sshkey_prvt" : "",
+        "kv_iscsi_sshkey_pub" : "",
+        "kv_iscsi_pwd": ""
+    },
     "sshkey": {},
     "options": {}
 }

--- a/deploy/terraform/run/sap_landscape/variables_global.tf
+++ b/deploy/terraform/run/sap_landscape/variables_global.tf
@@ -20,3 +20,8 @@ variable "sshkey" {
     path_to_private_key = "~/.ssh/id_rsa"
   }
 }
+
+variable "key_vault" {
+  description = "The user brings existing Azure Key Vaults"
+  default     = ""
+}

--- a/deploy/terraform/terraform-units/modules/sap_landscape/key_vault_sap_landscape.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/key_vault_sap_landscape.tf
@@ -5,8 +5,8 @@
 
 // Create private KV with access policy
 resource "azurerm_key_vault" "kv_prvt" {
-  count                      = local.enable_landscape_kv ? 1 : 0
-  name                       = local.landscape_keyvault_names.private_access
+  count                      = (local.enable_landscape_kv && ! local.prvt_kv_exist) ? 1 : 0
+  name                       = local.prvt_kv_name
   location                   = local.region
   resource_group_name        = local.rg_exists ? data.azurerm_resource_group.resource_group[0].name : azurerm_resource_group.resource_group[0].name
   tenant_id                  = local.service_principal.tenant_id
@@ -26,10 +26,18 @@ resource "azurerm_key_vault" "kv_prvt" {
   }
 }
 
+// Import an existing private Key Vault
+data "azurerm_key_vault" "kv_prvt" {
+  count               = (local.enable_landscape_kv && local.prvt_kv_exist) ? 1 : 0
+  name                = local.prvt_kv_name
+  resource_group_name = local.prvt_kv_rg_name
+}
+
+
 // Create user KV with access policy
 resource "azurerm_key_vault" "kv_user" {
-  count                      = local.enable_landscape_kv ? 1 : 0
-  name                       = local.landscape_keyvault_names.user_access
+  count                      = (local.enable_landscape_kv && ! local.user_kv_exist) ? 1 : 0
+  name                       = local.user_kv_name
   location                   = local.region
   resource_group_name        = local.rg_exists ? data.azurerm_resource_group.resource_group[0].name : azurerm_resource_group.resource_group[0].name
   tenant_id                  = local.service_principal.tenant_id
@@ -52,70 +60,118 @@ resource "azurerm_key_vault" "kv_user" {
   }
 }
 
+// Import an existing user Key Vault
+data "azurerm_key_vault" "kv_user" {
+  count               = (local.enable_landscape_kv && local.user_kv_exist) ? 1 : 0
+  name                = local.user_kv_name
+  resource_group_name = local.user_kv_rg_name
+}
+
 // Using TF tls to generate SSH key pair for iscsi devices and store in user KV
 resource "tls_private_key" "iscsi" {
   count = (
-    local.enable_landscape_kv && local.enable_iscsi_auth_key
-  && try(file(var.sshkey.path_to_public_key), null) == null) ? 1 : 0
+    local.enable_landscape_kv
+    && local.enable_iscsi_auth_key
+    && ! local.iscsi_key_exist
+    && try(file(var.sshkey.path_to_public_key), null) == null
+  ) ? 1 : 0
   algorithm = "RSA"
   rsa_bits  = 2048
 }
 
 resource "azurerm_key_vault_secret" "iscsi_ppk" {
-  count        = (local.enable_landscape_kv && local.enable_iscsi_auth_key) ? 1 : 0
-  name         = format("%s-iscsi-sshkey", local.prefix)
+  count        = (local.enable_landscape_kv && local.enable_iscsi_auth_key && ! local.iscsi_key_exist) ? 1 : 0
+  name         = local.iscsi_ppk_name
   value        = local.iscsi_private_key
-  key_vault_id = azurerm_key_vault.kv_user[0].id
+  key_vault_id = local.user_kv_exist ? local.user_key_vault_id : azurerm_key_vault.kv_user[0].id
 }
 
 resource "azurerm_key_vault_secret" "iscsi_pk" {
-  count        = (local.enable_landscape_kv && local.enable_iscsi_auth_key) ? 1 : 0
-  name         = format("%s-iscsi-sshkey-pub", local.prefix)
+  count        = (local.enable_landscape_kv && local.enable_iscsi_auth_key && ! local.iscsi_key_exist) ? 1 : 0
+  name         = local.iscsi_pk_name
   value        = local.iscsi_public_key
-  key_vault_id = azurerm_key_vault.kv_user[0].id
+  key_vault_id = local.user_kv_exist ? local.user_key_vault_id : azurerm_key_vault.kv_user[0].id
 }
 
 resource "azurerm_key_vault_secret" "iscsi_username" {
   count        = (local.enable_landscape_kv && local.enable_iscsi_auth_password) ? 1 : 0
   name         = format("%s-iscsi-username", local.prefix)
   value        = local.iscsi_auth_username
-  key_vault_id = azurerm_key_vault.kv_user[0].id
+  key_vault_id = local.user_kv_exist ? local.user_key_vault_id : azurerm_key_vault.kv_user[0].id
 }
 
 resource "azurerm_key_vault_secret" "iscsi_password" {
-  count        = (local.enable_landscape_kv && local.enable_iscsi_auth_password) ? 1 : 0
-  name         = format("%s-iscsi-password", local.prefix)
+  count        = (local.enable_landscape_kv && local.enable_iscsi_auth_password && ! local.iscsi_pwd_exist) ? 1 : 0
+  name         = local.iscsi_pwd_name
   value        = local.iscsi_auth_password
-  key_vault_id = azurerm_key_vault.kv_user[0].id
+  key_vault_id = local.user_kv_exist ? local.user_key_vault_id : azurerm_key_vault.kv_user[0].id
 }
 
 // Generate random password if password is set as authentication type and user doesn't specify a password, and save in KV
 resource "random_password" "iscsi_password" {
   count = (
-    local.enable_landscape_kv && local.enable_iscsi_auth_password
+    local.enable_landscape_kv
+    && local.enable_iscsi_auth_password
+    && ! local.iscsi_pwd_exist
   && try(local.var_iscsi.authentication.password, null) == null) ? 1 : 0
   length           = 16
   special          = true
   override_special = "_%@"
 }
 
-// Using TF tls to generate SSH key pair for SID and store in user KV
+// Import secrets about iSCSI
+data "azurerm_key_vault_secret" "iscsi_pk" {
+  count        = (local.enable_landscape_kv && local.enable_iscsi_auth_key && local.iscsi_key_exist) ? 1 : 0
+  name         = local.iscsi_pk_name
+  key_vault_id = local.user_key_vault_id
+}
+
+data "azurerm_key_vault_secret" "iscsi_ppk" {
+  count        = (local.enable_landscape_kv && local.enable_iscsi_auth_key && local.iscsi_key_exist) ? 1 : 0
+  name         = local.iscsi_ppk_name
+  key_vault_id = local.user_key_vault_id
+}
+
+data "azurerm_key_vault_secret" "iscsi_password" {
+  count        = (local.enable_landscape_kv && local.enable_iscsi_auth_password && local.iscsi_pwd_exist) ? 1 : 0
+  name         = local.iscsi_pwd_name
+  key_vault_id = local.user_key_vault_id
+}
+
+// Using TF tls to generate SSH key pair for SID
 resource "tls_private_key" "sid" {
-  count     = (local.enable_landscape_kv && try(file(var.sshkey.path_to_public_key), null) == null) ? 1 : 0
+  count = (
+    local.enable_landscape_kv
+    && try(file(var.sshkey.path_to_public_key), null) == null
+    && ! local.sid_key_exist
+  ) ? 1 : 0
   algorithm = "RSA"
   rsa_bits  = 2048
 }
 
+// Key pair/password will be stored in the existing KV if specified, otherwise will be stored in a newly provisioned KV 
 resource "azurerm_key_vault_secret" "sid_ppk" {
-  count        = local.enable_landscape_kv ? 1 : 0
-  name         = format("%s-sid-sshkey", local.prefix)
+  count        = (local.enable_landscape_kv && ! local.sid_key_exist) ? 1 : 0
+  name         = local.sid_ppk_name
   value        = local.sid_private_key
-  key_vault_id = azurerm_key_vault.kv_user[0].id
+  key_vault_id = local.user_kv_exist ? local.user_key_vault_id : azurerm_key_vault.kv_user[0].id
 }
 
 resource "azurerm_key_vault_secret" "sid_pk" {
-  count        = local.enable_landscape_kv ? 1 : 0
-  name         = format("%s-sid-sshkey-pub", local.prefix)
+  count        = (local.enable_landscape_kv && ! local.sid_key_exist) ? 1 : 0
+  name         = local.sid_pk_name
   value        = local.sid_public_key
-  key_vault_id = azurerm_key_vault.kv_user[0].id
+  key_vault_id = local.user_kv_exist ? local.user_key_vault_id : azurerm_key_vault.kv_user[0].id
+}
+
+data "azurerm_key_vault_secret" "sid_pk" {
+  count        = (local.enable_landscape_kv && local.sid_key_exist) ? 1 : 0
+  name         = local.sid_pk_name
+  key_vault_id = local.user_key_vault_id
+}
+
+data "azurerm_key_vault_secret" "sid_ppk" {
+  count        = (local.enable_landscape_kv && local.sid_key_exist) ? 1 : 0
+  name         = local.sid_ppk_name
+  key_vault_id = local.user_key_vault_id
 }

--- a/deploy/terraform/terraform-units/modules/sap_landscape/outputs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/outputs.tf
@@ -23,19 +23,19 @@ output "infrastructure_w_defaults" {
 }
 
 output "kv_user" {
-  value = azurerm_key_vault.kv_user
+  value = local.user_kv_exist ? data.azurerm_key_vault.kv_user : azurerm_key_vault.kv_user
 }
 
 output "kv_prvt" {
-  value = azurerm_key_vault.kv_prvt
+  value = local.prvt_kv_exist ? data.azurerm_key_vault.kv_prvt : azurerm_key_vault.kv_prvt
 }
 
 output "sid_public_key_secret_name" {
-  value = local.enable_landscape_kv ? azurerm_key_vault_secret.sid_pk[0].name : ""
+  value = local.enable_landscape_kv ? local.sid_pk_name : ""
 }
 
 output "sid_private_key_secret_name" {
-  value = local.enable_landscape_kv ? azurerm_key_vault_secret.sid_ppk[0].name : ""
+  value = local.enable_landscape_kv ? local.sid_ppk_name : ""
 }
 
 output "iscsi_authentication_type" {
@@ -48,5 +48,5 @@ output "iscsi_authentication_username" {
 
 // Output for DNS
 output "dns_info_vms" {
-  value =  local.iscsi_count > 0 ? zipmap(local.full_iscsiserver_names,azurerm_network_interface.iscsi[*].private_ip_address) : null
+  value = local.iscsi_count > 0 ? zipmap(local.full_iscsiserver_names, azurerm_network_interface.iscsi[*].private_ip_address) : null
 }

--- a/deploy/terraform/terraform-units/modules/sap_landscape/variables_global.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/variables_global.tf
@@ -2,3 +2,7 @@ variable "infrastructure" {}
 variable "options" {}
 variable "ssh-timeout" {}
 variable "sshkey" {}
+variable "key_vault" {
+  description = "The user brings existing Azure Key Vaults"
+  default     = ""
+}

--- a/deploy/terraform/terraform-units/modules/sap_landscape/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/variables_local.tf
@@ -64,12 +64,12 @@ locals {
 
   // By default, ssh key for iSCSI uses generated public key. Provide sshkey.path_to_public_key and path_to_private_key overides it
   enable_iscsi_auth_key = local.iscsi_count > 0 && local.iscsi_auth_type == "key"
-  iscsi_public_key      = local.enable_iscsi_auth_key ? try(file(var.sshkey.path_to_public_key), tls_private_key.iscsi[0].public_key_openssh) : null
-  iscsi_private_key     = local.enable_iscsi_auth_key ? try(file(var.sshkey.path_to_private_key), tls_private_key.iscsi[0].private_key_pem) : null
+  iscsi_public_key      = local.enable_iscsi_auth_key ? (local.iscsi_key_exist ? data.azurerm_key_vault_secret.iscsi_pk[0].value : try(file(var.sshkey.path_to_public_key), tls_private_key.iscsi[0].public_key_openssh)) : null
+  iscsi_private_key     = local.enable_iscsi_auth_key ? (local.iscsi_key_exist ? data.azurerm_key_vault_secret.iscsi_ppk[0].value : try(file(var.sshkey.path_to_private_key), tls_private_key.iscsi[0].private_key_pem)) : null
 
   // By default, authentication type of iSCSI target is ssh key pair but using username/password is a potential usecase.
   enable_iscsi_auth_password = local.iscsi_count > 0 && local.iscsi_auth_type == "password"
-  iscsi_auth_password        = local.enable_iscsi_auth_password ? try(local.var_iscsi.authentication.password, random_password.iscsi_password[0].result) : null
+  iscsi_auth_password        = local.enable_iscsi_auth_password ? (local.iscsi_pwd_exist ? data.azurerm_key_vault_secret.iscsi_password[0].value : try(local.var_iscsi.authentication.password, random_password.iscsi_password[0].result)) : null
 
   iscsi = merge(local.var_iscsi, {
     iscsi_count = local.iscsi_count,
@@ -91,8 +91,8 @@ locals {
 
   // By default, Ansible ssh key for SID uses generated public key. Provide sshkey.path_to_public_key and path_to_private_key overides it
   enable_landscape_kv = true
-  sid_public_key      = local.enable_landscape_kv ? try(file(var.sshkey.path_to_public_key), tls_private_key.sid[0].public_key_openssh) : null
-  sid_private_key     = local.enable_landscape_kv ? try(file(var.sshkey.path_to_private_key), tls_private_key.sid[0].private_key_pem) : null
+  sid_public_key      = local.enable_landscape_kv ? (local.sid_key_exist ? data.azurerm_key_vault_secret.sid_pk[0].value : try(file(var.sshkey.path_to_public_key), tls_private_key.sid[0].public_key_openssh)) : null
+  sid_private_key     = local.enable_landscape_kv ? (local.sid_key_exist ? data.azurerm_key_vault_secret.sid_ppk[0].value : try(file(var.sshkey.path_to_private_key), tls_private_key.sid[0].private_key_pem)) : null
 
   // iSCSI subnet
   var_sub_iscsi    = try(local.var_vnet_sap.subnet_iscsi, {})
@@ -156,5 +156,36 @@ locals {
   full_iscsiserver_names = flatten([for vm in local.virtualmachine_names :
     format("%s%s%s%s", local.prefix, var.naming.separator, vm, local.resource_suffixes.vm)]
   )
+
+  // If the user specifies arm id of key vaults in input, the key vault will be imported instead of creating new key vaults
+  user_key_vault_id = try(var.key_vault.kv_user_id, "")
+  prvt_key_vault_id = try(var.key_vault.kv_prvt_id, "")
+  user_kv_exist     = try(length(local.user_key_vault_id) > 0, false)
+  prvt_kv_exist     = try(length(local.prvt_key_vault_id) > 0, false)
+
+  // If the user specifies the secret name of key pair/password in input, the secrets will be imported instead of creating new secrets
+  input_sid_public_key_secret_name  = try(var.key_vault.kv_sid_sshkey_pub, "")
+  input_sid_private_key_secret_name = try(var.key_vault.kv_sid_sshkey_prvt, "")
+  sid_key_exist                     = try(length(local.input_sid_public_key_secret_name) > 0, false)
+
+  input_iscsi_public_key_secret_name  = try(var.key_vault.kv_iscsi_sshkey_pub, "")
+  input_iscsi_private_key_secret_name = try(var.key_vault.kv_iscsi_sshkey_prvt, "")
+  input_iscsi_password_secret_name    = try(var.key_vault.kv_iscsi_pwd, "")
+  iscsi_key_exist                     = try(length(local.input_iscsi_public_key_secret_name) > 0, false)
+  iscsi_pwd_exist                     = try(length(local.input_iscsi_password_secret_name) > 0, false)
+
+  sid_ppk_name = local.sid_key_exist ? local.input_sid_private_key_secret_name : format("%s-sid-sshkey", local.prefix)
+  sid_pk_name  = local.sid_key_exist ? local.input_sid_public_key_secret_name : format("%s-sid-sshkey-pub", local.prefix)
+
+  iscsi_ppk_name = local.iscsi_key_exist ? local.input_iscsi_private_key_secret_name : format("%s-iscsi-sshkey", local.prefix)
+  iscsi_pk_name  = local.iscsi_key_exist ? local.input_iscsi_public_key_secret_name : format("%s-iscsi-sshkey-pub", local.prefix)
+  iscsi_pwd_name = local.iscsi_pwd_exist ? local.input_iscsi_password_secret_name : format("%s-iscsi-password", local.prefix)
+
+  // Extract information from the specified key vault arm ids
+  user_kv_name    = local.user_kv_exist ? split("/", local.user_key_vault_id)[8] : local.landscape_keyvault_names.user_access
+  user_kv_rg_name = local.user_kv_exist ? split("/", local.user_key_vault_id)[4] : ""
+
+  prvt_kv_name    = local.prvt_kv_exist ? split("/", local.prvt_key_vault_id)[8] : local.landscape_keyvault_names.private_access
+  prvt_kv_rg_name = local.prvt_kv_exist ? split("/", local.prvt_key_vault_id)[4] : ""
 
 }


### PR DESCRIPTION
## Problem
<Please describe what problem this PR is trying to resolve>
Users should be able to bring their own KVs when provisioning landscape.


## Solution
<Please elaborate the solution for the problem>


## Tests
<Please provide steps to test the PR>
Test locally


## Notes
<Additional comments for the PR>
1. Importing the username of iSCSI will be implemented in another pr.
"kv_iscsi_username": ""

2. output will be enhanced in another pr.