### PR TITLE
Store username as secret in deployer KV if password is used

### DIFF
--- a/deploy/terraform/bootstrap/sap_deployer/output.tf
+++ b/deploy/terraform/bootstrap/sap_deployer/output.tf
@@ -56,11 +56,19 @@ output "deployer_kv_user_name" {
 }
 
 output "deployer_public_key_secret_name" {
-  value = module.sap_deployer.pk_name
+  value = module.sap_deployer.pk_secret_name
 }
 
 output "deployer_private_key_secret_name" {
-  value = module.sap_deployer.ppk_name
+  value = module.sap_deployer.ppk_secret_name
+}
+
+output "deployer_username_secret_name" {
+  value = module.sap_deployer.username_secret_name
+}
+
+output "deployer_password_secret_name" {
+  value = module.sap_deployer.pwd_secret_name
 }
 
 output "deployer_rg_name" {

--- a/deploy/terraform/bootstrap/sap_deployer/scripts.tf
+++ b/deploy/terraform/bootstrap/sap_deployer/scripts.tf
@@ -8,8 +8,8 @@ Description:
 resource "local_file" "scp" {
   content = templatefile("${path.module}/deployer_scp.tmpl", {
     user_vault_name = module.sap_deployer.user_vault_name,
-    ppk_name        = module.sap_deployer.ppk_name,
-    pwd_name        = module.sap_deployer.pwd_name,
+    ppk_name        = module.sap_deployer.ppk_secret_name,
+    pwd_name        = module.sap_deployer.pwd_secret_name,
     deployers       = module.sap_deployer.deployers,
     deployer-ips    = local.enable_deployer_public_ip ? module.sap_deployer.deployer_pip[*].ip_address : module.sap_deployer.deployer_private_ip_address
   })

--- a/deploy/terraform/run/sap_deployer/output.tf
+++ b/deploy/terraform/run/sap_deployer/output.tf
@@ -56,11 +56,19 @@ output "deployer_kv_user_name" {
 }
 
 output "deployer_public_key_secret_name" {
-  value = module.sap_deployer.pk_name
+  value = module.sap_deployer.pk_secret_name
 }
 
 output "deployer_private_key_secret_name" {
-  value = module.sap_deployer.ppk_name
+  value = module.sap_deployer.ppk_secret_name
+}
+
+output "deployer_username_secret_name" {
+  value = module.sap_deployer.username_secret_name
+}
+
+output "deployer_password_secret_name" {
+  value = module.sap_deployer.pwd_secret_name
 }
 
 output "deployer_rg_name" {

--- a/deploy/terraform/terraform-units/modules/sap_deployer/key_vault.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/key_vault.tf
@@ -129,7 +129,7 @@ resource "tls_private_key" "deployer" {
 resource "azurerm_key_vault_secret" "ppk" {
   depends_on   = [azurerm_key_vault_access_policy.kv_user_pre_deployer[0]]
   count        = (local.enable_deployers && local.enable_key && ! local.key_exist) ? 1 : 0
-  name         = local.ppk_name
+  name         = local.ppk_secret_name
   value        = local.private_key
   key_vault_id = local.user_kv_exist ? local.user_key_vault_id : azurerm_key_vault.kv_user[0].id
 }
@@ -137,8 +137,16 @@ resource "azurerm_key_vault_secret" "ppk" {
 resource "azurerm_key_vault_secret" "pk" {
   depends_on   = [azurerm_key_vault_access_policy.kv_user_pre_deployer[0]]
   count        = (local.enable_deployers && local.enable_key && ! local.key_exist) ? 1 : 0
-  name         = local.pk_name
+  name         = local.pk_secret_name
   value        = local.public_key
+  key_vault_id = local.user_kv_exist ? local.user_key_vault_id : azurerm_key_vault.kv_user[0].id
+}
+
+resource "azurerm_key_vault_secret" "username" {
+  depends_on   = [azurerm_key_vault_access_policy.kv_user_pre_deployer[0]]
+  count        = (local.enable_deployers && local.enable_password && ! local.username_exist) ? 1 : 0
+  name         = local.username_secret_name
+  value        = local.username
   key_vault_id = local.user_kv_exist ? local.user_key_vault_id : azurerm_key_vault.kv_user[0].id
 }
 
@@ -158,25 +166,31 @@ resource "random_password" "deployer" {
 resource "azurerm_key_vault_secret" "pwd" {
   depends_on   = [azurerm_key_vault_access_policy.kv_user_pre_deployer[0]]
   count        = (local.enable_deployers && local.enable_password && ! local.pwd_exist) ? 1 : 0
-  name         = local.pwd_name
+  name         = local.pwd_secret_name
   value        = local.password
   key_vault_id = local.user_kv_exist ? local.user_key_vault_id : azurerm_key_vault.kv_user[0].id
 }
 
 data "azurerm_key_vault_secret" "pk" {
   count        = (local.enable_deployers && local.enable_key && local.key_exist) ? 1 : 0
-  name         = local.pk_name
+  name         = local.pk_secret_name
   key_vault_id = local.user_key_vault_id
 }
 
 data "azurerm_key_vault_secret" "ppk" {
   count        = (local.enable_deployers && local.enable_key && local.key_exist) ? 1 : 0
-  name         = local.ppk_name
+  name         = local.ppk_secret_name
+  key_vault_id = local.user_key_vault_id
+}
+
+data "azurerm_key_vault_secret" "username" {
+  count        = (local.enable_deployers && local.enable_password && local.username_exist) ? 1 : 0
+  name         = local.username_secret_name
   key_vault_id = local.user_key_vault_id
 }
 
 data "azurerm_key_vault_secret" "pwd" {
   count        = (local.enable_deployers && local.enable_password && local.pwd_exist) ? 1 : 0
-  name         = local.pwd_name
+  name         = local.pwd_secret_name
   key_vault_id = local.user_key_vault_id
 }

--- a/deploy/terraform/terraform-units/modules/sap_deployer/output.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/output.tf
@@ -57,17 +57,21 @@ output "prvt_vault_name" {
 }
 
 // output the secret name of private key
-output "ppk_name" {
-  value = local.enable_deployers && local.enable_key ? local.ppk_name : ""
+output "ppk_secret_name" {
+  value = local.enable_deployers && local.enable_key ? local.ppk_secret_name : ""
 }
 
 // output the secret name of public key
-output "pk_name" {
-  value = local.enable_deployers && local.enable_key ? local.pk_name : ""
+output "pk_secret_name" {
+  value = local.enable_deployers && local.enable_key ? local.pk_secret_name : ""
 }
 
-output "pwd_name" {
-  value = local.enable_deployers && local.enable_password ? local.pwd_name : ""
+output "username_secret_name" {
+  value = local.enable_deployers && local.enable_password ? local.username : ""
+}
+
+output "pwd_secret_name" {
+  value = local.enable_deployers && local.enable_password ? local.pwd_secret_name : ""
 }
 
 // Comment out code with users.object_id for the time being.


### PR DESCRIPTION
## Problem
Add username to deployer KV.

## Solution
1. Add username in KV as secret.
1. Rename some variable to distinguish between input value and actual secret name.
1. Add username and password secret names to the output to be consistent with sshkey secrets.

## Tests
<Please provide steps to test the PR>

## Notes
<Additional comments for the PR>