### PR TITLE
[BUG] Deployer deployment with existing NSG fails

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_deployer/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/variables_local.tf
@@ -46,7 +46,7 @@ locals {
   sub_mgmt_nsg             = try(local.sub_mgmt.nsg, {})
   sub_mgmt_nsg_arm_id      = try(local.sub_mgmt_nsg.arm_id, "")
   sub_mgmt_nsg_exists      = length(local.sub_mgmt_nsg_arm_id) > 0 ? true : false
-  sub_mgmt_nsg_name        = local.sub_mgmt_nsg_exists ? split("/", local.sub_mgmt_nsg_arm_id[8]) : try(local.sub_mgmt_nsg.name, format("%s%s", local.prefix, local.resource_suffixes.deployer_subnet_nsg))
+  sub_mgmt_nsg_name        = local.sub_mgmt_nsg_exists ? split("/", local.sub_mgmt_nsg_arm_id)[8] : try(local.sub_mgmt_nsg.name, format("%s%s", local.prefix, local.resource_suffixes.deployer_subnet_nsg))
   sub_mgmt_nsg_allowed_ips = local.sub_mgmt_nsg_exists ? [] : try(local.sub_mgmt_nsg.allowed_ips, ["0.0.0.0/0"])
   sub_mgmt_nsg_deployed    = try(local.sub_mgmt_nsg_exists ? data.azurerm_network_security_group.nsg_mgmt[0] : azurerm_network_security_group.nsg_mgmt[0], null)
 


### PR DESCRIPTION
the code was 
split("/", local.sub_mgmt_nsg_arm_id[8]) when is should have been 
split("/", local.sub_mgmt_nsg_arm_id)[8]

## Problem
Deployer fails when deployed with existing nsg

## Solution
<Please elaborate the solution for the problem>

## Tests
<Please provide steps to test the PR>

## Notes
<Additional comments for the PR>