### PR TITLE
[NO DEPLOYER VM] Decouple SAP Library from SAP Deployer

### DIFF
--- a/deploy/terraform/bootstrap/sap_library/imports.tf
+++ b/deploy/terraform/bootstrap/sap_library/imports.tf
@@ -4,6 +4,7 @@
 */
 
 data "terraform_remote_state" "deployer" {
+  count = local.use_deployer ? 1 : 0
   backend = "local"
   config = {
     path = "${abspath(path.cwd)}/../../LOCAL/${local.deployer_rg_name}/terraform.tfstate"

--- a/deploy/terraform/bootstrap/sap_library/variables_local.tf
+++ b/deploy/terraform/bootstrap/sap_library/variables_local.tf
@@ -51,7 +51,13 @@ locals {
   deployer_rg_name = try(local.deployer.resource_group_name, format("%s-INFRASTRUCTURE", local.deployer_prefix))
 
   // Retrieve the arm_id of deployer's Key Vault from deployer's terraform.tfstate
-  deployer_key_vault_arm_id = try(data.terraform_remote_state.deployer.outputs.deployer_kv_user_arm_id, "")
+  deployer_key_vault_arm_id = try(var.key_vault.kv_user_id, try(data.terraform_remote_state.deployer[0].outputs.deployer_kv_user_arm_id, ""))
+
+  // If the user specifies arm id of key vaults in input, the key vault will be imported instead of creating new key vaults
+  user_key_vault_id = try(var.key_vault.kv_user_id, "")
+  user_kv_exist     = try(length(local.user_key_vault_id) > 0, false)
+
+  use_deployer = try(local.deployer.use_deployer, true)
 
   spn = {
     subscription_id = data.azurerm_key_vault_secret.subscription_id.value,

--- a/deploy/terraform/run/sap_library/imports.tf
+++ b/deploy/terraform/run/sap_library/imports.tf
@@ -4,6 +4,7 @@
 */
 
 data "terraform_remote_state" "deployer" {
+  count = local.use_deployer ? 1 : 0
   backend = "azurerm"
   config = {
     resource_group_name  = local.saplib_resource_group_name

--- a/deploy/terraform/run/sap_library/saplibrary_full.json
+++ b/deploy/terraform/run/sap_library/saplibrary_full.json
@@ -6,7 +6,8 @@
     "deployer": {
         "environment": "np",
         "region": "eastus",
-        "vnet": "DEP00"
+        "vnet": "DEP00",
+        "use_deployer": true
     },
     "key_vault":{
         "kv_user_id": "",

--- a/deploy/terraform/run/sap_library/variables_local.tf
+++ b/deploy/terraform/run/sap_library/variables_local.tf
@@ -56,7 +56,14 @@ locals {
   deployer_rg_name = try(local.deployer.resource_group_name, format("%s-INFRASTRUCTURE", local.deployer_prefix))
 
   // Retrieve the arm_id of deployer's Key Vault from deployer's terraform.tfstate
-  deployer_key_vault_arm_id = try(data.terraform_remote_state.deployer.outputs.deployer_kv_user_arm_id, "")
+  deployer_key_vault_arm_id = try(var.key_vault.kv_user_id, try(data.terraform_remote_state.deployer[0].outputs.deployer_kv_user_arm_id, ""))
+
+  // If the user specifies arm id of key vaults in input, the key vault will be imported instead of creating new key vaults
+  user_key_vault_id = try(var.key_vault.kv_user_id, "")
+  user_kv_exist     = try(length(local.user_key_vault_id) > 0, false)
+
+  use_deployer = try(local.deployer.use_deployer, true)
+
 
   // Locate the tfstate storage account
   tfstate_resource_id          = try(var.tfstate_resource_id, "")

--- a/deploy/terraform/terraform-units/modules/sap_library/storage_accounts.tf
+++ b/deploy/terraform/terraform-units/modules/sap_library/storage_accounts.tf
@@ -93,6 +93,7 @@ TBD: two options
 */
 // Assign contributor role to deployer's msi to access tfstate storage account
 resource "azurerm_role_assignment" "deployer_msi_sa_tfstate" {
+  count                = length(local.deployer_msi_principal_id) > 0 ? 1 : 0
   scope                = local.sa_sapbits_exists ? data.azurerm_storage_account.storage_tfstate[0].id : azurerm_storage_account.storage_tfstate[0].id
   role_definition_name = "Storage Account Contributor"
   principal_id         = local.deployer_msi_principal_id

--- a/deploy/terraform/terraform-units/modules/sap_library/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_library/variables_local.tf
@@ -84,7 +84,7 @@ locals {
 
   // deployer terraform.tfstate
   deployer_tfstate          = var.deployer_tfstate
-  deployer_msi_principal_id = local.deployer_tfstate.outputs.deployer_uai.principal_id
+  deployer_msi_principal_id = try(local.deployer_tfstate.outputs.deployer_uai.principal_id,"")
 
   // If the user specifies arm id of key vaults in input, the key vault will be imported instead of creating new key vaults
   user_key_vault_id = try(var.key_vault.kv_user_id, "")


### PR DESCRIPTION
## Problem
If the customer provides a key vault the code should use that. This would remove the dependency on the deployer state file and would allow a deployment with out it

## Solution
deployer_key_vault_arm_id = try(var.key_vault.kv_user_id, try(data.terraform_remote_state.deployer[0].outputs.deployer_kv_user_arm_id, ""))

## Tests
<Please provide steps to test the PR>

## Notes
<Additional comments for the PR>