### PR TITLE
Remove unnecessary input from sap_system json

### DIFF
--- a/deploy/terraform/run/sap_system/sapsystem.json
+++ b/deploy/terraform/run/sap_system/sapsystem.json
@@ -33,8 +33,7 @@
         "publisher": "SUSE",
         "offer": "sles-sap-12-sp5",
         "sku": "gen1"
-      },
-      "zones": []
+      }
     }
   ],
   "application": {
@@ -45,9 +44,6 @@
     "scs_high_availability": false,
     "application_server_count": 1,
     "webdispatcher_count": 1,
-    "app_zones": [],
-    "scs_zones": [],
-    "web_zones": [],
     "authentication": {
       "type": "key",
       "username": "azureadm"


### PR DESCRIPTION
## Problem
Zone is not required information for `sap_system` deployment.

## Solution
Remove zone info from `sapsystem.json`, but keep them in `sapsystem_full.json`.

## Tests
<Please provide steps to test the PR>

## Notes
<Additional comments for the PR>