### PR TITLE
use import username as logon username

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_deployer/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/variables_local.tf
@@ -62,10 +62,7 @@ locals {
     try(deployer.authentication.type, "key") == "password" ? true : false
   ]), "true")
 
-  username = compact([
-    for deployer in local.deployer_input :
-    try(deployer.authentication.username, "azureadm")
-  ])[0]
+  username = local.enable_deployers ? (local.username_exist ? data.azurerm_key_vault_secret.username[0].value : try(local.deployer_input[0].authentication.username, "azureadm")): "" 
 
   // By default use generated password. Provide password under authentication overides it
   input_pwd_list = compact([
@@ -99,7 +96,7 @@ locals {
       },
       "authentication" = {
         "type"     = try(deployer.authentication.type, "key")
-        "username" = try(deployer.authentication.username, "azureadm")
+        "username" = local.username
         "sshkey" = {
           "public_key"  = local.public_key
           "private_key" = local.private_key


### PR DESCRIPTION
## Problem
<Please describe what problem this PR is trying to resolve>
If the user specify the name of secret which is used to store username, the imported username should be used as the logon username.

## Solution
<Please elaborate the solution for the problem>

## Tests
<Please provide steps to test the PR>
Tests locally.

## Notes
<Additional comments for the PR>