### PR TITLE
[BUG] Move spn to kv from deployer to agent

### DIFF
--- a/.pipeline/templates/deployer/post-deployer-steps.yml
+++ b/.pipeline/templates/deployer/post-deployer-steps.yml
@@ -23,11 +23,9 @@ steps:
       # Copy local key pair to deployer. Temporary workaround until kv feature completes.
       scp -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no -o ConnectTimeout=$(ssh_timeout_s) ${ws_dir}/sshkey* "$(username)"@"$(publicIP)":${remote_dir}
 
-      echo "=== Add access policy recover for deployer MSI to deployer KV ==="
-      deployer_msi="${deployer_prefix}-EAUS-DEP00-msi"
-      deployer_msi_objectId=$(az ad sp list --display-name ${deployer_msi} | jq -r '.[].objectId')
-      deployer_kv_name=$(az keyvault list --resource-group ${deployer_rg} | jq -r '.[] | select(.name | contains("user")).name')
-      az keyvault set-policy --name ${deployer_kv_name} --secret-permissions get list set delete recover --object-id ${deployer_msi_objectId} --output none
+      echo "=== Add access policy recover for pipeline SPN to deployer KV ==="
+      deployer_kv_name=$(az keyvault list --resource-group ${deployer_rg} | jq -r '.[] | select(.name | contains("user")).name')  
+      az keyvault set-policy --name ${deployer_kv_name} --secret-permissions get list set delete recover --object-id $(hana-pipeline-spn-objId) --output none
     displayName: "Post deployment"
     env:
       ARM_CLIENT_ID: $(hana-pipeline-spn-id)

--- a/.pipeline/templates/saplandscape/create-saplandscape-steps.yml
+++ b/.pipeline/templates/saplandscape/create-saplandscape-steps.yml
@@ -1,5 +1,50 @@
 steps:
   - script: |
+      set +e
+
+      az login --service-principal --user $(hana-pipeline-spn-id) --password $(hana-pipeline-spn-pw) --tenant $(landscape-tenant) --output none
+
+      # Modify environment value so it starts with u and with length of 5
+      deployer_env=${{parameters.deployer_env}}
+      buildId=$(Build.BuildId)
+      deployer_isRelease=${deployer_env%%$buildId*}
+
+      if [ -z "${deployer_isRelease}" ]
+      then 
+        deployer_prefix="U$(echo $(Build.BuildId) | rev | cut -c1-4 | rev)"
+      else
+        deployer_prefix=${deployer_env}
+      fi
+
+      deployer_rg="${deployer_prefix}-EAUS-DEP00-INFRASTRUCTURE"
+
+      # Modify environment value so it starts with u and with length of 5
+      saplandscape_env=${{parameters.saplandscape_env}}
+      saplandscape_isRelease=${saplandscape_env%%$buildId*}
+
+      if [ -z "${saplandscape_isRelease}" ]
+      then 
+        saplandscape_prefix="U$(echo $(Build.BuildId) | rev | cut -c1-4 | rev)"
+      else
+        saplandscape_prefix=${saplandscape_env}
+      fi
+
+      # Store SPN in deployer KV
+      echo "=== Store SPN in deployer KV ==="
+      deployer_kv_name=$(az keyvault list --resource-group ${deployer_rg} | jq -r '.[] | select(.name | contains("user")).name')
+      az keyvault secret set --vault-name ${deployer_kv_name} --name ${saplandscape_prefix}-client-id --value $(hana-pipeline-spn-id) --output none
+      az keyvault secret set --vault-name ${deployer_kv_name} --name ${saplandscape_prefix}-client-secret --value $(hana-pipeline-spn-pw) --output none
+      az keyvault secret set --vault-name ${deployer_kv_name} --name ${saplandscape_prefix}-subscription-id --value $(landscape-subscription) --output none
+      az keyvault secret set --vault-name ${deployer_kv_name} --name ${saplandscape_prefix}-tenant-id --value $(landscape-tenant) --output none
+
+      echo "=== Recovery SPN in deployer KV when rerun same build ==="
+      az keyvault secret recover --vault-name ${deployer_kv_name} --name ${saplandscape_prefix}-client-id --output none
+      az keyvault secret recover --vault-name ${deployer_kv_name} --name ${saplandscape_prefix}-client-secret --output none
+      az keyvault secret recover --vault-name ${deployer_kv_name} --name ${saplandscape_prefix}-subscription-id --output none
+      az keyvault secret recover --vault-name ${deployer_kv_name} --name ${saplandscape_prefix}-tenant-id --output none
+      echo "=== Wait for 30s for secrets to be available === "
+      sleep 30s
+
       set -e
 
       echo "=== Logon deployer ==="
@@ -91,22 +136,6 @@ steps:
       deployer_tfstate_key=$(az storage blob list --account-name ${tfstate_sa_name} --container-name tfstate --only-show-errors | jq -r "'".[] | select(.name | contains(\\\"DEP00-INFRASTRUCTURE\\\")).name"'")
       saplib_tfstate_key=$(az storage blob list --account-name ${tfstate_sa_name} --container-name tfstate --only-show-errors | jq -r "'".[] | select(.name | contains(\\\"LIBRARY\\\")).name"'")
       tfstate_resource_id=$(az storage account list --resource-group ${saplib_rg} | jq -r "'".[] | select(.name | contains(\\\"tfstate\\\")).id"'")
-
-      # Store SPN in deployer KV
-      echo "=== Store SPN in deployer KV ==="
-      deployer_kv_name=$(az keyvault list --resource-group ${deployer_rg} | jq -r "'".[] | select(.name | contains(\\\"user\\\")).name"'")
-      az keyvault secret set --vault-name ${deployer_kv_name} --name ${saplandscape_prefix}-client-id --value $(hana-pipeline-spn-id) --output none
-      az keyvault secret set --vault-name ${deployer_kv_name} --name ${saplandscape_prefix}-client-secret --value $(hana-pipeline-spn-pw) --output none
-      az keyvault secret set --vault-name ${deployer_kv_name} --name ${saplandscape_prefix}-subscription-id --value $(landscape-subscription) --output none
-      az keyvault secret set --vault-name ${deployer_kv_name} --name ${saplandscape_prefix}-tenant-id --value $(landscape-tenant) --output none
-
-      echo "=== Recovery SPN in deployer KV when rerun same build ==="
-      az keyvault secret recover --vault-name ${deployer_kv_name} --name ${saplandscape_prefix}-client-id --output none
-      az keyvault secret recover --vault-name ${deployer_kv_name} --name ${saplandscape_prefix}-client-secret --output none
-      az keyvault secret recover --vault-name ${deployer_kv_name} --name ${saplandscape_prefix}-subscription-id --output none
-      az keyvault secret recover --vault-name ${deployer_kv_name} --name ${saplandscape_prefix}-tenant-id --output none
-      echo "=== Wait for 30s for secrets to be available === "
-      sleep 30s
 
       cp ${repo_dir}/deploy/terraform/run/sap_landscape/saplandscape.json ${ws_dir}/saplandscape.json
       cat ${ws_dir}/saplandscape.json \

--- a/.pipeline/templates/saplib/create-saplib-steps.yml
+++ b/.pipeline/templates/saplib/create-saplib-steps.yml
@@ -1,7 +1,48 @@
 steps:
   - script: |
+      set +e
+
+      # Modify environment value so it starts with u and with length of 5
+      deployer_env=${{parameters.deployer_env}}
+      buildId=$(Build.BuildId)
+      isRelease=${deployer_env%%$buildId*}
+      if [ -z "${isRelease}" ]
+      then 
+        deployer_prefix="U$(echo $(Build.BuildId) | rev | cut -c1-4 | rev)"
+      else
+        deployer_prefix=${deployer_env}
+      fi
+      
+      deployer_environment=${deployer_prefix}
+      deployer_rg="${deployer_prefix}-EAUS-DEP00-INFRASTRUCTURE"
+
+      # Modify environment value so it starts with u and with length of 5
+      saplib_env=${{parameters.saplib_env}}
+      buildId=$(Build.BuildId)
+      isRelease=${saplib_env%%$buildId*}
+      if [ -z "${isRelease}" ]
+      then 
+        saplib_prefix="U$(echo $(Build.BuildId) | rev | cut -c1-4 | rev)"
+      else
+        saplib_prefix=${saplib_env}
+      fi
+
+      echo "=== Store SPN in deployer KV ==="
+      deployer_kv_name=$(az keyvault list --resource-group ${deployer_rg} | jq -r '.[] | select(.name | contains("user")).name')
+      az keyvault secret set --vault-name ${deployer_kv_name} --name ${saplib_prefix}-client-id --value $(hana-pipeline-spn-id) --output none
+      az keyvault secret set --vault-name ${deployer_kv_name} --name ${saplib_prefix}-client-secret --value $(hana-pipeline-spn-pw) --output none
+      az keyvault secret set --vault-name ${deployer_kv_name} --name ${saplib_prefix}-subscription-id --value $(landscape-subscription) --output none
+      az keyvault secret set --vault-name ${deployer_kv_name} --name ${saplib_prefix}-tenant-id --value $(landscape-tenant) --output none
+
+      echo "=== Recovery SPN in deployer KV when rerun same build ==="
+      az keyvault secret recover --vault-name ${deployer_kv_name} --name ${saplib_prefix}-client-id --output none
+      az keyvault secret recover --vault-name ${deployer_kv_name} --name ${saplib_prefix}-client-secret --output none
+      az keyvault secret recover --vault-name ${deployer_kv_name} --name ${saplib_prefix}-subscription-id --output none
+      az keyvault secret recover --vault-name ${deployer_kv_name} --name ${saplib_prefix}-tenant-id --output none
+      echo "=== Wait for 30s for secrets to be available === "
+      sleep 30s
+
       set -e
-      set -o errexit
 
       echo "=== Deploy SAP library from deployer ==="
       ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no -o ConnectTimeout=$(ssh_timeout_s) "$(username)"@"$(publicIP)" '
@@ -37,21 +78,6 @@ steps:
       repo_dir=$HOME/${saplib_rg}/sap-hana
       ws_dir=$HOME/Azure_SAP_Automated_Deployment/WORKSPACES/SAP_LIBRARY/${saplib_rg}
       input=${ws_dir}/${saplib_rg}.json
-
-      echo "=== Store SPN in deployer KV ==="
-      deployer_kv_name=$(az keyvault list --resource-group ${deployer_rg} | jq -r "'".[] | select(.name | contains(\\\"user\\\")).name"'")
-      az keyvault secret set --vault-name ${deployer_kv_name} --name ${saplib_prefix}-client-id --value $(hana-pipeline-spn-id) --output none
-      az keyvault secret set --vault-name ${deployer_kv_name} --name ${saplib_prefix}-client-secret --value $(hana-pipeline-spn-pw) --output none
-      az keyvault secret set --vault-name ${deployer_kv_name} --name ${saplib_prefix}-subscription-id --value $(landscape-subscription) --output none
-      az keyvault secret set --vault-name ${deployer_kv_name} --name ${saplib_prefix}-tenant-id --value $(landscape-tenant) --output none
-
-      echo "=== Recovery SPN in deployer KV when rerun same build ==="
-      az keyvault secret recover --vault-name ${deployer_kv_name} --name ${saplib_prefix}-client-id --output none
-      az keyvault secret recover --vault-name ${deployer_kv_name} --name ${saplib_prefix}-client-secret --output none
-      az keyvault secret recover --vault-name ${deployer_kv_name} --name ${saplib_prefix}-subscription-id --output none
-      az keyvault secret recover --vault-name ${deployer_kv_name} --name ${saplib_prefix}-tenant-id --output none
-      echo "=== Wait for 30s for secrets to be available === "
-      sleep 30s
 
       echo "=== Checkout required branch ${{parameters.branch_name}} ==="
       if [ ! -d "${repo_dir}" ]

--- a/.pipeline/templates/saplib/post-saplib-steps.yml
+++ b/.pipeline/templates/saplib/post-saplib-steps.yml
@@ -82,6 +82,26 @@ steps:
 
       terraform apply -auto-approve -var-file=${input} ${repo_dir}/deploy/terraform/run/sap_library/
       '
+
+      echo "=== Add access policy recover for pipeline SPN back to deployer KV ==="
+  
+      az login --service-principal --user $(hana-pipeline-spn-id) --password $(hana-pipeline-spn-pw) --tenant $(landscape-tenant) --output none
+
+      # Modify environment value so it starts with u and with length of 5
+      deployer_env=${{parameters.deployer_env}}
+      buildId=$(Build.BuildId)
+      deployer_isRelease=${deployer_env%%$buildId*}
+      if [ -z "${deployer_isRelease}" ]
+      then 
+        deployer_prefix="U$(echo $(Build.BuildId) | rev | cut -c1-4 | rev)"
+      else
+        deployer_prefix=${deployer_env}
+      fi
+
+      deployer_rg="${deployer_prefix}-EAUS-DEP00-INFRASTRUCTURE"
+
+      deployer_kv_name=$(az keyvault list --resource-group ${deployer_rg} | jq -r '.[] | select(.name | contains("user")).name')  
+      az keyvault set-policy --name ${deployer_kv_name} --secret-permissions get list set delete recover --object-id $(hana-pipeline-spn-objId) --output none
     displayName: "Post saplibrary"
     env:
       ARM_CLIENT_ID: $(hana-pipeline-spn-id)

--- a/.pipeline/templates/sapsystem/create-sapsystem-steps.yml
+++ b/.pipeline/templates/sapsystem/create-sapsystem-steps.yml
@@ -1,5 +1,49 @@
 steps:
   - script: |
+      set +e
+
+      # Modify environment value so it starts with u and with length of 5
+      deployer_env=${{parameters.deployer_env}}
+      buildId=$(Build.BuildId)
+      deployer_isRelease=${deployer_env%%$buildId*}
+
+      if [ -z "${deployer_isRelease}" ]
+      then 
+        deployer_prefix="U$(echo $(Build.BuildId) | rev | cut -c1-4 | rev)"
+      else
+        deployer_prefix=${deployer_env}
+      fi
+
+      deployer_rg="${deployer_prefix}-EAUS-DEP00-INFRASTRUCTURE"
+
+      # Modify environment value so it starts with u and with length of 5
+      sapsystem_env=${{parameters.sapsystem_env}}
+      sapsystem_isRelease=${sapsystem_env%%$buildId*}
+
+      # subnet is decided by buildId if it is unit test.
+      if [ -z "${sapsystem_isRelease}" ]
+      then 
+        sapsystem_prefix="U$(echo $(Build.BuildId) | rev | cut -c1-4 | rev)"
+      else
+        sapsystem_prefix=${sapsystem_env}
+      fi
+
+      # Store SPN in deployer KV
+      echo "=== Store SPN in deployer KV ==="
+      deployer_kv_name=$(az keyvault list --resource-group ${deployer_rg} | jq -r '.[] | select(.name | contains("user")).name')
+      az keyvault secret set --vault-name ${deployer_kv_name} --name ${sapsystem_prefix}-client-id --value $(hana-pipeline-spn-id) --output none
+      az keyvault secret set --vault-name ${deployer_kv_name} --name ${sapsystem_prefix}-client-secret --value $(hana-pipeline-spn-pw) --output none
+      az keyvault secret set --vault-name ${deployer_kv_name} --name ${sapsystem_prefix}-subscription-id --value $(landscape-subscription) --output none
+      az keyvault secret set --vault-name ${deployer_kv_name} --name ${sapsystem_prefix}-tenant-id --value $(landscape-tenant) --output none
+
+      echo "=== Recovery SPN in deployer KV when rerun same build ==="
+      az keyvault secret recover --vault-name ${deployer_kv_name} --name ${sapsystem_prefix}-client-id --output none
+      az keyvault secret recover --vault-name ${deployer_kv_name} --name ${sapsystem_prefix}-client-secret --output none
+      az keyvault secret recover --vault-name ${deployer_kv_name} --name ${sapsystem_prefix}-subscription-id --output none
+      az keyvault secret recover --vault-name ${deployer_kv_name} --name ${sapsystem_prefix}-tenant-id --output none
+      echo "=== Wait for 30s for secrets to be available === "
+      sleep 30s
+
       set -e
 
       echo "=== Logon deployer ==="
@@ -83,22 +127,6 @@ steps:
 
       sapsystem_rg="${sapsystem_prefix}-EAUS-SAP-PRD"
       sapland_rg="UNIT-EAUS-SAP0-INFRASTRUCTURE"
-
-      # Store SPN in deployer KV
-      echo "=== Store SPN in deployer KV ==="
-      deployer_kv_name=$(az keyvault list --resource-group ${deployer_rg} | jq -r "'".[] | select(.name | contains(\\\"user\\\")).name"'")
-      az keyvault secret set --vault-name ${deployer_kv_name} --name ${sapsystem_prefix}-client-id --value $(hana-pipeline-spn-id) --output none
-      az keyvault secret set --vault-name ${deployer_kv_name} --name ${sapsystem_prefix}-client-secret --value $(hana-pipeline-spn-pw) --output none
-      az keyvault secret set --vault-name ${deployer_kv_name} --name ${sapsystem_prefix}-subscription-id --value $(landscape-subscription) --output none
-      az keyvault secret set --vault-name ${deployer_kv_name} --name ${sapsystem_prefix}-tenant-id --value $(landscape-tenant) --output none
-
-      echo "=== Recovery SPN in deployer KV when rerun same build ==="
-      az keyvault secret recover --vault-name ${deployer_kv_name} --name ${sapsystem_prefix}-client-id --output none
-      az keyvault secret recover --vault-name ${deployer_kv_name} --name ${sapsystem_prefix}-client-secret --output none
-      az keyvault secret recover --vault-name ${deployer_kv_name} --name ${sapsystem_prefix}-subscription-id --output none
-      az keyvault secret recover --vault-name ${deployer_kv_name} --name ${sapsystem_prefix}-tenant-id --output none
-      echo "=== Wait for 30s for secrets to be available === "
-      sleep 30s
 
       # If no osImage provided, deploy SLES12SP5
       [ -z "${{parameters.osImage_offer}}" ] && osImage_offer="sles-sap-12-sp5" || osImage_offer=${{parameters.osImage_offer}}


### PR DESCRIPTION
## Problem
In order to recover secret, the principle (pipeline SPN or deployer MSI) need to have recover policy added to the deployer KV.
However, we need the objectId to perform above task.
Unfortunately SPN does not have the right authorization to read the directory, hence not able to fetch the objectId of MSI.

## Solution
1. Add recover policy on deployer KV to pipeline SPN since we know the SPN objectId and do not need to fetch with `az ad sp list` command. 
2. Then move the tasks related to add/recover secrets from deployer to pipeline agent.

## Tests
https://dev.azure.com/azuresaphana/Azure-SAP-HANA/_build/results?buildId=16099&view=results
## Notes
Please make sure this merges into `feature/remote-tfstate2`