### PR TITLE
[BUG] Add missing key_vault in run/sap_library

### DIFF
--- a/.pipeline/templates/saplib/post-saplib-steps.yml
+++ b/.pipeline/templates/saplib/post-saplib-steps.yml
@@ -84,7 +84,7 @@ steps:
       '
 
       echo "=== Add access policy recover for pipeline SPN back to deployer KV ==="
-  
+
       az login --service-principal --user $(hana-pipeline-spn-id) --password $(hana-pipeline-spn-pw) --tenant $(landscape-tenant) --output none
 
       # Modify environment value so it starts with u and with length of 5

--- a/deploy/terraform/run/sap_deployer/variables_global.tf
+++ b/deploy/terraform/run/sap_deployer/variables_global.tf
@@ -30,6 +30,6 @@ variable "sshkey" {
 }
 
 variable "key_vault" {
-  description = "The user brings existing Azure Key Vaults"
-  default     = ""
+  description = "Import existing Azure Key Vaults"
+  default     = {}
 }

--- a/deploy/terraform/run/sap_library/module.tf
+++ b/deploy/terraform/run/sap_library/module.tf
@@ -9,6 +9,7 @@ module "sap_library" {
   storage_account_tfstate = var.storage_account_tfstate
   software                = var.software
   deployer                = var.deployer
+  key_vault               = var.key_vault
   service_principal       = local.service_principal
   deployer_tfstate        = data.terraform_remote_state.deployer
   naming                  = module.sap_namegenerator.naming


### PR DESCRIPTION
## Problem
key_vault is missing in run/sap_library.

## Solution
<Please elaborate the solution for the problem>

## Tests
https://dev.azure.com/azuresaphana/Azure-SAP-HANA/_build/results?buildId=16097&view=logs&j=e477b44f-e359-5855-d385-6fb8e978df40&t=2d220880-151a-5c98-886c-61f53462c5a4
## Notes
Please make sure this merges into `feature/remote-tfstate2`.