### PR TITLE
[TAGGING] Support custom tagging for application tier

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/variables_local.tf
@@ -207,6 +207,11 @@ locals {
     "version"         = try(var.application.scs_os.version, local.scs_custom_image ? "" : local.app_os.version)
   }
 
+ // Tags
+  app_tags = try(var.application.app_tags,{})
+  scs_tags = try(var.application.scs_tags,{})
+  web_tags = try(var.application.web_tags,{})
+  
   application = merge(var.application,
     { authentication = local.authentication }
   )

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-app.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-app.tf
@@ -128,6 +128,9 @@ resource "azurerm_linux_virtual_machine" "app" {
   boot_diagnostics {
     storage_account_uri = var.storage_bootdiag.primary_blob_endpoint
   }
+
+  tags = local.app_tags
+  
 }
 
 # Create the Windows Application VM(s)
@@ -182,6 +185,9 @@ resource "azurerm_windows_virtual_machine" "app" {
   boot_diagnostics {
     storage_account_uri = var.storage_bootdiag.primary_blob_endpoint
   }
+
+  tags = local.app_tags
+
 }
 
 # Creates managed data disk

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-scs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-scs.tf
@@ -116,6 +116,8 @@ resource "azurerm_linux_virtual_machine" "scs" {
   boot_diagnostics {
     storage_account_uri = var.storage_bootdiag.primary_blob_endpoint
   }
+
+  tags = local.scs_tags
 }
 
 # Create the SCS Windows VM(s)
@@ -191,6 +193,8 @@ resource "azurerm_windows_virtual_machine" "scs" {
   boot_diagnostics {
     storage_account_uri = var.storage_bootdiag.primary_blob_endpoint
   }
+
+  tags = local.scs_tags
 }
 
 # Creates managed data disk

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-webdisp.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-webdisp.tf
@@ -102,6 +102,8 @@ resource "azurerm_linux_virtual_machine" "web" {
   boot_diagnostics {
     storage_account_uri = var.storage_bootdiag.primary_blob_endpoint
   }
+
+  tags = local.web_tags
 }
 
 # Create the Windows Web dispatcher VM(s)
@@ -176,6 +178,8 @@ resource "azurerm_windows_virtual_machine" "web" {
   boot_diagnostics {
     storage_account_uri = var.storage_bootdiag.primary_blob_endpoint
   }
+
+  tags = local.web_tags
 }
 
 # Creates managed data disk


### PR DESCRIPTION
## Problem
Customers want the ability to apply tags on the Virtual machines at creation time

## Solution
Add a property in the application node in the json that supports providing tags for the application tier VMs

## Tests
Add the fpollowing snippet to the input json
"app_tags" :{
"tagname": "Value",
"tagname2": "Value"
}
"scs_tags" :{
"tagname": "Value",
"tagname2": "Value"
}
"web_tags" :{
"tagname": "Value",
"tagname2": "Value"
}

## Notes
<Additional comments for the PR>