### PR TITLE
[OUTPUT] Add the VM Ids to output

### DIFF
--- a/deploy/terraform/run/sap_system/output.tf
+++ b/deploy/terraform/run/sap_system/output.tf
@@ -21,3 +21,24 @@ output "dns_information_app" {
 output "dns_information_loadbalancers_app" {
   value = module.app_tier.dns_info_loadbalancers
 }
+
+
+output "app_vm_ids" {
+  value = module.app_tier.app_vm_ids
+}
+
+output "scs_vm_ids" {
+  value = module.app_tier.scs_vm_ids
+}
+
+output "web_vm_ids" {
+  value = module.app_tier.web_vm_ids
+}
+
+output "hanadb_vm_ids" {
+  value = module.hdb_node.hanadb_vm_ids
+}
+
+output "anydb_vm_ids" {
+  value = module.anydb_node.anydb_vm_ids
+}

--- a/deploy/terraform/run/sap_system/output.tf
+++ b/deploy/terraform/run/sap_system/output.tf
@@ -21,8 +21,6 @@ output "dns_information_app" {
 output "dns_information_loadbalancers_app" {
   value = module.app_tier.dns_info_loadbalancers
 }
-
-
 output "app_vm_ids" {
   value = module.app_tier.app_vm_ids
 }

--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/outputs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/outputs.tf
@@ -59,3 +59,7 @@ output "dns_info_loadbalancers" {
     null
   )
 }
+
+output "anydb_vm_ids" {
+  value = local.enable_deployment ? concat(azurerm_windows_virtual_machine.dbserver[*].id, azurerm_linux_virtual_machine.dbserver[*].id) : []
+}

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/outputs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/outputs.tf
@@ -112,3 +112,15 @@ output "dns_info_loadbalancers" {
     )
   )
 }
+
+output "app_vm_ids" {
+  value = local.enable_deployment ? concat(azurerm_windows_virtual_machine.app[*].id, azurerm_linux_virtual_machine.app[*].id) : []
+}
+
+output "scs_vm_ids" {
+  value = local.enable_deployment ? concat(azurerm_windows_virtual_machine.scs[*].id, azurerm_linux_virtual_machine.scs[*].id) : []
+}
+
+output "web_vm_ids" {
+  value = local.enable_deployment ? concat(azurerm_windows_virtual_machine.web[*].id, azurerm_linux_virtual_machine.web[*].id) : []
+}

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/outputs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/outputs.tf
@@ -43,5 +43,3 @@ output "dns_info_loadbalancers" {
 output "hanadb_vm_ids" {
   value = local.enable_deployment ? azurerm_linux_virtual_machine.vm_dbnode[*].id : []
 }
-
-

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/outputs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/outputs.tf
@@ -22,7 +22,6 @@ output "hana_database_info" {
   value = try(local.enable_deployment ? local.hana_database : map(false), {})
 }
 
-
 // Output for DNS
 output "dns_info_vms" {
   value = local.enable_deployment ? (
@@ -34,11 +33,15 @@ output "dns_info_vms" {
   )
 }
 
-
 output "dns_info_loadbalancers" {
   value = local.enable_deployment ? (
     zipmap([format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.db_alb)], [azurerm_lb.hdb[0].private_ip_addresses[0]])) : (
     null
   )
 }
+
+output "hanadb_vm_ids" {
+  value = local.enable_deployment ? azurerm_linux_virtual_machine.vm_dbnode[*].id : []
+}
+
 


### PR DESCRIPTION
## Problem
Customers who want to deploy extensions on the deployed VMs would need the VM Ids to be able to process them

## Solution
Add the VM Ids to the output from the modules and from sap_system

## Tests
None

## Notes
<Additional comments for the PR>