### PR TITLE
Fix the broken lookups when size does not exist for that database type

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/variables_local.tf
@@ -281,7 +281,8 @@ locals {
     }
   ])
 
-  db_sizing = local.enable_deployment ? try(lookup(local.sizes, local.anydb_size).storage, []) : []
+  anydb_size_details = lookup(local.sizes, local.anydb_size, [])
+  db_sizing          = local.anydb_size_details != [] ? local.anydb_size_details.storage : []
 
   data_disk_per_dbnode = (length(local.anydb_vms) > 0) ? flatten(
     [
@@ -317,14 +318,12 @@ locals {
     ]
   ])
 
-  enable_ultradisk = local.enable_deployment ? (
-    try(compact([
-      for storage in local.db_sizing :
-      storage.disk_type == "UltraSSD_LRS" ? (
-        true) : (
-        ""
-      )
-    ])[0], false)) : (
+  enable_ultradisk = try(
+    compact(
+      [
+        for storage in local.db_sizing : storage.disk_type == "UltraSSD_LRS" ? true : ""
+      ]
+    )[0],
     false
   )
 

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/variables_local.tf
@@ -263,10 +263,13 @@ locals {
     }
   ])
 
+
+  db_sizing = local.enable_deployment ? try(lookup(local.sizes, local.hdb_size).storage, []) : []
+
   // List of data disks to be created for HANA DB nodes
-  data_disk_per_dbnode = (length(local.hdb_vms) > 0) ? flatten(
+  data_disk_per_dbnode = (length(local.hdb_vms) > 0) && local.enable_deployment ? flatten(
     [
-      for storage_type in lookup(local.sizes, local.hdb_size).storage : [
+      for storage_type in local.db_sizing : [
         for disk_count in range(storage_type.count) : {
           suffix               = format("%s%02d", storage_type.name, disk_count)
           storage_account_type = storage_type.disk_type,
@@ -299,9 +302,14 @@ locals {
     ]
   ])
 
-  storage_list = lookup(local.sizes, local.hdb_size).storage
-  enable_ultradisk = try(compact([
-    for storage in local.storage_list :
-    storage.disk_type == "UltraSSD_LRS" ? true : ""
-  ])[0], false)
+  enable_ultradisk = local.enable_deployment ? (
+    try(compact([
+      for storage in local.db_sizing :
+      storage.disk_type == "UltraSSD_LRS" ? (
+        true) : (
+        ""
+      )
+    ])[0], false)) : (
+    false
+  )
 }

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/variables_local.tf
@@ -264,7 +264,8 @@ locals {
   ])
 
 
-  db_sizing = local.enable_deployment ? try(lookup(local.sizes, local.hdb_size).storage, []) : []
+  hdb_size_details = lookup(local.sizes, local.hdb_size, [])
+  db_sizing        = local.hdb_size_details != [] ? local.hdb_size_details.storage : []
 
   // List of data disks to be created for HANA DB nodes
   data_disk_per_dbnode = (length(local.hdb_vms) > 0) && local.enable_deployment ? flatten(
@@ -302,14 +303,12 @@ locals {
     ]
   ])
 
-  enable_ultradisk = local.enable_deployment ? (
-    try(compact([
-      for storage in local.db_sizing :
-      storage.disk_type == "UltraSSD_LRS" ? (
-        true) : (
-        ""
-      )
-    ])[0], false)) : (
+  enable_ultradisk = try(
+    compact(
+      [
+        for storage in local.db_sizing : storage.disk_type == "UltraSSD_LRS" ? true : ""
+      ]
+    )[0],
     false
   )
 }


### PR DESCRIPTION
## Problem
The db size lookup fails for keys that do not exist in both the hana and anydb json files

## Solution
Add logic that will only perform the lookup if  deployed

## Tests
Deploy using a custom size json with a custom size name map

## Notes
<Additional comments for the PR>