### PR TITLE
Add code of conduct and telemetry notice to readme

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -55,6 +55,15 @@ We use [GitHub issues](https://github.com/Azure/sap-hana/issues/) for feature re
 
 <br>
 
+## Data Collection
+
+The software may collect information about you and your use of the software and send it to Microsoft. Microsoft may use this information to provide services and improve our products and services. You may turn off the telemetry as described in the repository. There are also some features in the software that may enable you and Microsoft to collect data from users of your applications. If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft's privacy statement. Our privacy statement is located at https://go.microsoft.com/fwlink/?LinkID=824704. You can learn more about data collection and use in the help documentation and our privacy statement. Your use of the software operates as your consent to these practices.
+
+
+## How to Turn off Data Collection
+
+To turn off data collection, please remove or comment out this [line](https://github.com/Azure/sap-hana/blob/ea5d0aa75910b40e5604ab916dbaaac28d2779d4/deploy/terraform/ansible.tf#L56).
+
 ## License & Copyright
 
 Copyright © 2018-2020 Microsoft Azure.

--- a/README.MD
+++ b/README.MD
@@ -53,6 +53,18 @@ If you want to contribute to our project, be sure to review the [contributing gu
 
 We use [GitHub issues](https://github.com/Azure/sap-hana/issues/) for feature requests and bugs.
 
+This project welcomes contributions and suggestions.  Most contributions require you to agree to a
+Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
+the rights to use your contribution. For details, visit https://cla.opensource.microsoft.com.
+
+When you submit a pull request, a CLA bot will automatically determine whether you need to provide
+a CLA and decorate the PR appropriately (e.g., status check, comment). Simply follow the instructions
+provided by the bot. You will only need to do this once across all repos using our CLA.
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
+contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+
 <br>
 
 ## Data Collection


### PR DESCRIPTION
## Problem
1. Microsoft Open Source Code of Conduct info is required in README.MD.
1. telemetry notice is required in README.MD 

## Solution
1. Add  Microsoft Open Source Code of Conduct info to README.MD.
1. Add telemetry notice to README.MD

## Tests
<Please provide steps to test the PR>

## Notes
Will cherry pick this to feature/remote-tfstate2