### PR TITLE
 [ENVIRONMENT] Support providing the deployer environment as a parameter

### DIFF
--- a/deploy/terraform/bootstrap/sap_library/imports.tf
+++ b/deploy/terraform/bootstrap/sap_library/imports.tf
@@ -12,25 +12,25 @@ data "terraform_remote_state" "deployer" {
 
 data "azurerm_key_vault_secret" "subscription_id" {
   provider     = azurerm.deployer
-  name         = format("%s-subscription-id", local.environment)
+  name         = format("%s-subscription-id", upper(var.infrastructure.environment))
   key_vault_id = local.deployer_key_vault_arm_id
 }
 
 data "azurerm_key_vault_secret" "client_id" {
   provider     = azurerm.deployer
-  name         = format("%s-client-id", local.environment)
+  name         = format("%s-client-id", upper(var.infrastructure.environment))
   key_vault_id = local.deployer_key_vault_arm_id
 }
 
 data "azurerm_key_vault_secret" "client_secret" {
   provider     = azurerm.deployer
-  name         = format("%s-client-secret", local.environment)
+  name         = format("%s-client-secret", upper(var.infrastructure.environment))
   key_vault_id = local.deployer_key_vault_arm_id
 }
 
 data "azurerm_key_vault_secret" "tenant_id" {
   provider     = azurerm.deployer
-  name         = format("%s-tenant-id", local.environment)
+  name         = format("%s-tenant-id", upper(var.infrastructure.environment))
   key_vault_id = local.deployer_key_vault_arm_id
 }
 

--- a/deploy/terraform/bootstrap/sap_library/module.tf
+++ b/deploy/terraform/bootstrap/sap_library/module.tf
@@ -16,8 +16,10 @@ module "sap_library" {
 }
 
 module "sap_namegenerator" {
-  source      = "../../terraform-units/modules/sap_namegenerator"
-  environment = lower(try(var.infrastructure.environment, ""))
-  location    = try(var.infrastructure.region, "")
-  random_id   = module.sap_library.random_id
+  source                = "../../terraform-units/modules/sap_namegenerator"
+  environment           = lower(try(var.infrastructure.environment, ""))
+  deployer_environment  = local.deployer_environment
+  management_vnet_name  = local.deployer_vnet
+  location              = try(var.infrastructure.region, "")
+  random_id             = module.sap_library.random_id
 }

--- a/deploy/terraform/bootstrap/sap_library/module.tf
+++ b/deploy/terraform/bootstrap/sap_library/module.tf
@@ -17,9 +17,10 @@ module "sap_library" {
 
 module "sap_namegenerator" {
   source                = "../../terraform-units/modules/sap_namegenerator"
-  environment           = lower(try(var.infrastructure.environment, ""))
-  deployer_environment  = local.deployer_environment
-  management_vnet_name  = local.deployer_vnet
-  location              = try(var.infrastructure.region, "")
+  environment           = var.infrastructure.environment
+  deployer_environment  = var.deployer.environment
+  management_vnet_name  = var.deployer.vnet
+  location              = var.infrastructure.region
+  deployer_location     = try(var.deployer.region,var.infrastructure.region)
   random_id             = module.sap_library.random_id
 }

--- a/deploy/terraform/bootstrap/sap_library/module.tf
+++ b/deploy/terraform/bootstrap/sap_library/module.tf
@@ -18,7 +18,7 @@ module "sap_library" {
 module "sap_namegenerator" {
   source                = "../../terraform-units/modules/sap_namegenerator"
   environment           = var.infrastructure.environment
-  deployer_environment  = var.deployer.environment
+  deployer_environment  = try(var.deployer.environment, var.infrastructure.environment)
   management_vnet_name  = var.deployer.vnet
   location              = var.infrastructure.region
   deployer_location     = try(var.deployer.region,var.infrastructure.region)

--- a/deploy/terraform/bootstrap/sap_library/output.tf
+++ b/deploy/terraform/bootstrap/sap_library/output.tf
@@ -52,7 +52,7 @@ output "remote_state_container_name" {
 }
 
 output "saplibrary_environment" {
-  value = local.environment
+  value = var.infrastructure.environment
 }
 
 output "saplibrary_subscription_id" {

--- a/deploy/terraform/bootstrap/sap_library/variables_local.tf
+++ b/deploy/terraform/bootstrap/sap_library/variables_local.tf
@@ -1,42 +1,3 @@
-// Input arguments 
-variable "region_mapping" {
-  type        = map(string)
-  description = "Region Mapping: Full = Single CHAR, 4-CHAR"
-
-  # 28 Regions 
-
-  default = {
-    westus             = "weus"
-    westus2            = "wus2"
-    centralus          = "ceus"
-    eastus             = "eaus"
-    eastus2            = "eus2"
-    northcentralus     = "ncus"
-    southcentralus     = "scus"
-    westcentralus      = "wcus"
-    northeurope        = "noeu"
-    westeurope         = "weeu"
-    eastasia           = "eaas"
-    southeastasia      = "seas"
-    brazilsouth        = "brso"
-    japaneast          = "jpea"
-    japanwest          = "jpwe"
-    centralindia       = "cein"
-    southindia         = "soin"
-    westindia          = "wein"
-    uksouth2           = "uks2"
-    uknorth            = "ukno"
-    canadacentral      = "cace"
-    canadaeast         = "caea"
-    australiaeast      = "auea"
-    australiasoutheast = "ause"
-    uksouth            = "ukso"
-    ukwest             = "ukwe"
-    koreacentral       = "koce"
-    koreasouth         = "koso"
-  }
-}
-
 locals {
   // Sap library's environment
   environment = upper(try(var.infrastructure.environment, ""))
@@ -44,11 +5,10 @@ locals {
   // Derive resource group name for deployer
   deployer                = try(var.deployer, {})
   deployer_environment    = try(local.deployer.environment, "")
-  deployer_location_short = try(var.region_mapping[local.deployer.region], "unkn")
   deployer_vnet           = try(local.deployer.vnet, "")
-  deployer_prefix         = upper(format("%s-%s-%s", local.deployer_environment, local.deployer_location_short, substr(local.deployer_vnet, 0, 7)))
+  deployer_prefix         = module.sap_namegenerator.naming.prefix.DEPLOYER
   // If custom names are used for deployer, providing resource_group_name and msi_name will override the naming convention
-  deployer_rg_name = try(local.deployer.resource_group_name, format("%s-INFRASTRUCTURE", local.deployer_prefix))
+  deployer_rg_name = try(local.deployer.resource_group_name, format("%s%s", local.deployer_prefix, module.sap_namegenerator.naming.resource_suffixes.deployer_rg))
 
   // Retrieve the arm_id of deployer's Key Vault from deployer's terraform.tfstate
   deployer_key_vault_arm_id = try(data.terraform_remote_state.deployer.outputs.deployer_kv_user_arm_id, "")

--- a/deploy/terraform/bootstrap/sap_library/variables_local.tf
+++ b/deploy/terraform/bootstrap/sap_library/variables_local.tf
@@ -1,14 +1,8 @@
 locals {
-  // Sap library's environment
-  environment = upper(try(var.infrastructure.environment, ""))
-
-  // Derive resource group name for deployer
-  deployer                = try(var.deployer, {})
-  deployer_environment    = try(local.deployer.environment, "")
-  deployer_vnet           = try(local.deployer.vnet, "")
   deployer_prefix         = module.sap_namegenerator.naming.prefix.DEPLOYER
+  
   // If custom names are used for deployer, providing resource_group_name and msi_name will override the naming convention
-  deployer_rg_name = try(local.deployer.resource_group_name, format("%s%s", local.deployer_prefix, module.sap_namegenerator.naming.resource_suffixes.deployer_rg))
+  deployer_rg_name = try(var.deployer.resource_group_name, format("%s%s", local.deployer_prefix, module.sap_namegenerator.naming.resource_suffixes.deployer_rg))
 
   // Retrieve the arm_id of deployer's Key Vault from deployer's terraform.tfstate
   deployer_key_vault_arm_id = try(data.terraform_remote_state.deployer.outputs.deployer_kv_user_arm_id, "")

--- a/deploy/terraform/run/sap_library/imports.tf
+++ b/deploy/terraform/run/sap_library/imports.tf
@@ -16,25 +16,25 @@ data "terraform_remote_state" "deployer" {
 
 data "azurerm_key_vault_secret" "subscription_id" {
   provider     = azurerm.deployer
-  name         = format("%s-subscription-id", local.environment)
+  name         = format("%s-subscription-id", upper(var.infrastructure.environment))
   key_vault_id = local.deployer_key_vault_arm_id
 }
 
 data "azurerm_key_vault_secret" "client_id" {
   provider     = azurerm.deployer
-  name         = format("%s-client-id", local.environment)
+  name         = format("%s-client-id", upper(var.infrastructure.environment))
   key_vault_id = local.deployer_key_vault_arm_id
 }
 
 data "azurerm_key_vault_secret" "client_secret" {
   provider     = azurerm.deployer
-  name         = format("%s-client-secret", local.environment)
+  name         = format("%s-client-secret", upper(var.infrastructure.environment))
   key_vault_id = local.deployer_key_vault_arm_id
 }
 
 data "azurerm_key_vault_secret" "tenant_id" {
   provider     = azurerm.deployer
-  name         = format("%s-tenant-id", local.environment)
+  name         = format("%s-tenant-id", upper(var.infrastructure.environment))
   key_vault_id = local.deployer_key_vault_arm_id
 }
 

--- a/deploy/terraform/run/sap_library/module.tf
+++ b/deploy/terraform/run/sap_library/module.tf
@@ -16,8 +16,10 @@ module "sap_library" {
 }
 
 module sap_namegenerator {
-  source      = "../../terraform-units/modules/sap_namegenerator"
-  environment = lower(try(var.infrastructure.environment, ""))
-  location    = try(var.infrastructure.region, "")
-  random_id   = module.sap_library.random_id
+  source                = "../../terraform-units/modules/sap_namegenerator"
+  environment           = lower(try(var.infrastructure.environment, ""))
+  deployer_environment  = local.deployer_environment
+  management_vnet_name  = local.deployer_vnet
+  location              = try(var.infrastructure.region, "")
+  random_id             = module.sap_library.random_id
 }

--- a/deploy/terraform/run/sap_library/module.tf
+++ b/deploy/terraform/run/sap_library/module.tf
@@ -17,9 +17,10 @@ module "sap_library" {
 
 module sap_namegenerator {
   source                = "../../terraform-units/modules/sap_namegenerator"
-  environment           = lower(try(var.infrastructure.environment, ""))
-  deployer_environment  = local.deployer_environment
-  management_vnet_name  = local.deployer_vnet
-  location              = try(var.infrastructure.region, "")
+  environment           = var.infrastructure.environment
+  deployer_environment  = var.deployer.environment
+  management_vnet_name  = var.deployer.vnet
+  location              = var.infrastructure.region
+  deployer_location     = try(var.deployer.region,var.infrastructure.region)
   random_id             = module.sap_library.random_id
 }

--- a/deploy/terraform/run/sap_library/module.tf
+++ b/deploy/terraform/run/sap_library/module.tf
@@ -18,7 +18,7 @@ module "sap_library" {
 module sap_namegenerator {
   source                = "../../terraform-units/modules/sap_namegenerator"
   environment           = var.infrastructure.environment
-  deployer_environment  = var.deployer.environment
+  deployer_environment  = try(var.deployer.environment, var.infrastructure.environment)
   management_vnet_name  = var.deployer.vnet
   location              = var.infrastructure.region
   deployer_location     = try(var.deployer.region,var.infrastructure.region)

--- a/deploy/terraform/run/sap_library/output.tf
+++ b/deploy/terraform/run/sap_library/output.tf
@@ -56,7 +56,7 @@ output "deployer_tfstate_key" {
 }
 
 output "saplibrary_environment" {
-  value = local.environment
+  value = var.infrastructure.environment
 }
 
 output "saplibrary_subscription_id" {

--- a/deploy/terraform/run/sap_library/variables_local.tf
+++ b/deploy/terraform/run/sap_library/variables_local.tf
@@ -1,41 +1,3 @@
-// Input arguments 
-variable "region_mapping" {
-  type        = map(string)
-  description = "Region Mapping: Full = Single CHAR, 4-CHAR"
-
-  # 28 Regions 
-
-  default = {
-    westus             = "weus"
-    westus2            = "wus2"
-    centralus          = "ceus"
-    eastus             = "eaus"
-    eastus2            = "eus2"
-    northcentralus     = "ncus"
-    southcentralus     = "scus"
-    westcentralus      = "wcus"
-    northeurope        = "noeu"
-    westeurope         = "weeu"
-    eastasia           = "eaas"
-    southeastasia      = "seas"
-    brazilsouth        = "brso"
-    japaneast          = "jpea"
-    japanwest          = "jpwe"
-    centralindia       = "cein"
-    southindia         = "soin"
-    westindia          = "wein"
-    uksouth2           = "uks2"
-    uknorth            = "ukno"
-    canadacentral      = "cace"
-    canadaeast         = "caea"
-    australiaeast      = "auea"
-    australiasoutheast = "ause"
-    uksouth            = "ukso"
-    ukwest             = "ukwe"
-    koreacentral       = "koce"
-    koreasouth         = "koso"
-  }
-}
 
 variable "tfstate_resource_id" {
   description = "The resource id of tfstate storage account"
@@ -49,11 +11,11 @@ locals {
   // Derive resource group name for deployer
   deployer                = try(var.deployer, {})
   deployer_environment    = try(local.deployer.environment, "")
-  deployer_location_short = try(var.region_mapping[local.deployer.region], "unkn")
   deployer_vnet           = try(local.deployer.vnet, "")
-  deployer_prefix         = upper(format("%s-%s-%s", local.deployer_environment, local.deployer_location_short, substr(local.deployer_vnet, 0, 7)))
+  
+  deployer_prefix         = module.sap_namegenerator.naming.prefix.DEPLOYER
   // If custom names are used for deployer, providing resource_group_name and msi_name will override the naming convention
-  deployer_rg_name = try(local.deployer.resource_group_name, format("%s-INFRASTRUCTURE", local.deployer_prefix))
+  deployer_rg_name = try(local.deployer.resource_group_name, format("%s%s", local.deployer_prefix, module.sap_namegenerator.naming.resource_suffixes.deployer_rg))
 
   // Retrieve the arm_id of deployer's Key Vault from deployer's terraform.tfstate
   deployer_key_vault_arm_id = try(data.terraform_remote_state.deployer.outputs.deployer_kv_user_arm_id, "")

--- a/deploy/terraform/run/sap_library/variables_local.tf
+++ b/deploy/terraform/run/sap_library/variables_local.tf
@@ -5,17 +5,10 @@ variable "tfstate_resource_id" {
 }
 
 locals {
-  // Sap library's environment
-  environment = upper(try(var.infrastructure.environment, ""))
-
-  // Derive resource group name for deployer
-  deployer                = try(var.deployer, {})
-  deployer_environment    = try(local.deployer.environment, "")
-  deployer_vnet           = try(local.deployer.vnet, "")
   
   deployer_prefix         = module.sap_namegenerator.naming.prefix.DEPLOYER
   // If custom names are used for deployer, providing resource_group_name and msi_name will override the naming convention
-  deployer_rg_name = try(local.deployer.resource_group_name, format("%s%s", local.deployer_prefix, module.sap_namegenerator.naming.resource_suffixes.deployer_rg))
+  deployer_rg_name = try(var.deployer.resource_group_name, format("%s%s", local.deployer_prefix, module.sap_namegenerator.naming.resource_suffixes.deployer_rg))
 
   // Retrieve the arm_id of deployer's Key Vault from deployer's terraform.tfstate
   deployer_key_vault_arm_id = try(data.terraform_remote_state.deployer.outputs.deployer_kv_user_arm_id, "")

--- a/deploy/terraform/terraform-units/modules/sap_namegenerator/keyvault.tf
+++ b/deploy/terraform/terraform-units/modules/sap_namegenerator/keyvault.tf
@@ -3,8 +3,8 @@ locals {
   sdu_private_keyvault_name = format("%s%s%s%sp%s", replace(local.env_verified, "/[^A-Za-z0-9]/", ""), local.location_short, replace(local.sap_vnet_verified, "/[^A-Za-z0-9]/", ""), var.sap_sid, local.random_id_verified)
   sdu_user_keyvault_name    = format("%s%s%s%su%s", replace(local.env_verified, "/[^A-Za-z0-9]/", ""), local.location_short, replace(local.sap_vnet_verified, "/[^A-Za-z0-9]/", ""), var.sap_sid, local.random_id_verified)
 
-  deployer_private_keyvault_name = format("%s%s%sprvt%s", replace(local.deployer_env_verified, "/[^A-Za-z0-9]/", ""), local.location_short, replace(local.dep_vnet_verified, "/[^A-Za-z0-9]/", ""), local.random_id_verified)
-  deployer_user_keyvault_name    = format("%s%s%suser%s", replace(local.deployer_env_verified, "/[^A-Za-z0-9]/", ""), local.location_short, replace(local.dep_vnet_verified, "/[^A-Za-z0-9]/", ""), local.random_id_verified)
+  deployer_private_keyvault_name = format("%s%s%sprvt%s", replace(local.deployer_env_verified, "/[^A-Za-z0-9]/", ""), local.deployer_location_short, local.dep_vnet_verified, local.random_id_verified)
+  deployer_user_keyvault_name    = format("%s%s%suser%s", replace(local.deployer_env_verified, "/[^A-Za-z0-9]/", ""), local.deployer_location_short, local.dep_vnet_verified, local.random_id_verified)
 
   landscape_private_keyvault_name = format("%s%s%sprvt%s", replace(local.landscape_env_verified, "/[^A-Za-z0-9]/", ""), local.location_short, replace(local.sap_vnet_verified, "/[^A-Za-z0-9]/", ""), local.random_id_verified)
   landscape_user_keyvault_name    = format("%s%s%suser%s", replace(local.landscape_env_verified, "/[^A-Za-z0-9]/", ""), local.location_short, replace(local.sap_vnet_verified, "/[^A-Za-z0-9]/", ""), local.random_id_verified)

--- a/deploy/terraform/terraform-units/modules/sap_namegenerator/resourcegroup.tf
+++ b/deploy/terraform/terraform-units/modules/sap_namegenerator/resourcegroup.tf
@@ -5,12 +5,12 @@ locals {
     upper(format("%s-%s-%s-%s", local.env_verified, local.location_short, local.sap_vnet_verified, var.sap_sid))
   )
 
-  deployer_name  = upper(format("%s-%s-%s", local.deployer_env_verified, local.location_short, local.dep_vnet_verified))
+  deployer_name  = upper(format("%s-%s-%s", local.deployer_env_verified, local.deployer_location_short, local.dep_vnet_verified))
   landscape_name = upper(format("%s-%s-%s", local.landscape_env_verified, local.location_short, local.sap_vnet_verified))
   library_name   = upper(format("%s-%s", local.library_env_verified, local.location_short))
 
   // Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only. The name must be unique.
-  deployer_storageaccount_name       = substr(replace(lower(format("%s%s%sdiag%s", local.deployer_env_verified, local.location_short, local.dep_vnet_verified, local.random_id_verified)), "/[^a-z0-9]/", ""), 0, var.azlimits.stgaccnt)
+  deployer_storageaccount_name       = substr(replace(lower(format("%s%s%sdiag%s", local.deployer_env_verified, local.deployer_location_short, local.dep_vnet_verified, local.random_id_verified)), "/[^a-z0-9]/", ""), 0, var.azlimits.stgaccnt)
   landscape_storageaccount_name      = substr(replace(lower(format("%s%s%sdiag%s", local.landscape_env_verified, local.location_short, local.sap_vnet_verified, local.random_id_verified)), "/[^a-z0-9]/", ""), 0, var.azlimits.stgaccnt)
   library_storageaccount_name        = substr(replace(lower(format("%s%ssaplib%s", local.library_env_verified, local.location_short, local.random_id_verified)), "/[^a-z0-9]/", ""), 0, var.azlimits.stgaccnt)
   sdu_storageaccount_name            = substr(replace(lower(format("%s%s%sdiag%s", local.env_verified, local.location_short, local.sap_vnet_verified, local.random_id_verified)), "/[^a-z0-9]/", ""), 0, var.azlimits.stgaccnt)

--- a/deploy/terraform/terraform-units/modules/sap_namegenerator/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_namegenerator/variables_local.tf
@@ -294,9 +294,17 @@ variable custom_prefix {
   default     = ""
 }
 
+variable deployer_location {
+  description = "Deployer Azure region"
+  default     = ""
+}
+
+
 locals {
 
   location_short = upper(try(var.region_mapping[var.location], "unkn"))
+
+  deployer_location_short = length(var.deployer_location) > 0 ? upper(try(var.region_mapping[var.deployer_location], "unkn")) : local.location_short
 
   // If no deployer environment provided use environment
   deployer_environment_temp = length(var.deployer_environment) > 0 ? var.deployer_environment : var.environment


### PR DESCRIPTION
## Problem
The are cases when the deployer is in a different environment from the sap library

## Solution
Add the support for multiple environment in the naming module, i.e deployer environment and sdu environment.

## Tests
<Please provide steps to test the PR>

## Notes
<Additional comments for the PR>