### PR TITLE
Add an indicator about enabling iscsi

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_landscape/iscsi.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/iscsi.tf
@@ -9,7 +9,7 @@
 
 // Creates iSCSI subnet of SAP VNET
 resource "azurerm_subnet" "iscsi" {
-  count                = local.iscsi_count == 0 ? 0 : (local.sub_iscsi_exists ? 0 : 1)
+  count                = local.enable_sub_iscsi ? (local.sub_iscsi_exists ? 0 : 1) : 0
   name                 = local.sub_iscsi_name
   resource_group_name  = local.vnet_sap_exists ? data.azurerm_virtual_network.vnet_sap[0].resource_group_name : azurerm_virtual_network.vnet_sap[0].resource_group_name
   virtual_network_name = local.vnet_sap_exists ? data.azurerm_virtual_network.vnet_sap[0].name : azurerm_virtual_network.vnet_sap[0].name
@@ -18,7 +18,7 @@ resource "azurerm_subnet" "iscsi" {
 
 // Imports data of existing SAP iSCSI subnet
 data "azurerm_subnet" "iscsi" {
-  count                = local.iscsi_count == 0 ? 0 : (local.sub_iscsi_exists ? 1 : 0)
+  count                = local.enable_sub_iscsi ? (local.sub_iscsi_exists ? 1 : 0) : 0
   name                 = split("/", local.sub_iscsi_arm_id)[10]
   resource_group_name  = split("/", local.sub_iscsi_arm_id)[4]
   virtual_network_name = split("/", local.sub_iscsi_arm_id)[8]
@@ -26,7 +26,7 @@ data "azurerm_subnet" "iscsi" {
 
 // Creates SAP iSCSI subnet nsg
 resource "azurerm_network_security_group" "iscsi" {
-  count               = local.iscsi_count == 0 ? 0 : (local.sub_iscsi_nsg_exists ? 0 : 1)
+  count               = local.enable_sub_iscsi ? (local.sub_iscsi_nsg_exists ? 0 : 1) : 0
   name                = local.sub_iscsi_nsg_name
   location            = local.rg_exists ? data.azurerm_resource_group.resource_group[0].location : azurerm_resource_group.resource_group[0].location
   resource_group_name = local.rg_exists ? data.azurerm_resource_group.resource_group[0].name : azurerm_resource_group.resource_group[0].name
@@ -34,7 +34,7 @@ resource "azurerm_network_security_group" "iscsi" {
 
 // Imports the SAP iSCSI subnet nsg data
 data "azurerm_network_security_group" "iscsi" {
-  count               = local.iscsi_count == 0 ? 0 : (local.sub_iscsi_nsg_exists ? 1 : 0)
+  count               = local.enable_sub_iscsi ? (local.sub_iscsi_nsg_exists ? 1 : 0) : 0
   name                = split("/", local.sub_iscsi_nsg_arm_id)[8]
   resource_group_name = split("/", local.sub_iscsi_nsg_arm_id)[4]
 }

--- a/deploy/terraform/terraform-units/modules/sap_landscape/key_vault_sap_landscape.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/key_vault_sap_landscape.tf
@@ -94,7 +94,7 @@ resource "azurerm_key_vault_secret" "iscsi_pk" {
 }
 
 resource "azurerm_key_vault_secret" "iscsi_username" {
-  count        = (local.enable_landscape_kv && ! local.iscsi_username_exist) ? 1 : 0
+  count        = (local.enable_landscape_kv && local.enable_iscsi && ! local.iscsi_username_exist) ? 1 : 0
   name         = local.iscsi_username_name
   value        = local.iscsi_auth_username
   key_vault_id = local.user_kv_exist ? local.user_key_vault_id : azurerm_key_vault.kv_user[0].id
@@ -139,7 +139,7 @@ data "azurerm_key_vault_secret" "iscsi_password" {
 }
 
 data "azurerm_key_vault_secret" "iscsi_username" {
-  count        = (local.enable_landscape_kv && local.iscsi_username_exist) ? 1 : 0
+  count        = (local.enable_landscape_kv && local.enable_iscsi && local.iscsi_username_exist) ? 1 : 0
   name         = local.iscsi_username_name
   key_vault_id = local.user_key_vault_id
 }


### PR DESCRIPTION
## Problem
<Please describe what problem this PR is trying to resolve>
1. When the iscsi is not provisioned, the username of iscsi shouldn't be stored in the KV of sap landscape.

2. When sub_iscsi is specified in input json, even if iscsi_count = 0, subnet of iscsi is supposed to be provisioned or imported. 
When sub_iscsi is specified in input json, iscsi_nsg should be created or imported.

## Solution
<Please elaborate the solution for the problem>
Add an indicator enable_iscsi
Add indicator enable_sub_iscsi

## Tests
<Please provide steps to test the PR>
see test pipeline

## Notes
<Additional comments for the PR>