### PR TITLE
[INFRASTRUCTURE] Update LoadBalance types to standard for all tiers

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/infrastructure.tf
@@ -5,7 +5,7 @@ Load balancer front IP address range: .4 - .9
 resource "azurerm_lb" "anydb" {
   count = local.enable_deployment ? 1 : 0
   name  = format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.db_alb)
-  sku   = local.zonal_deployment ? "Standard" : "Basic"
+  sku   = "Standard"
 
   resource_group_name = var.resource_group[0].name
   location            = var.resource_group[0].location

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/infrastructure.tf
@@ -44,7 +44,7 @@ resource "azurerm_lb" "scs" {
   name                = format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.scs_alb)
   resource_group_name = var.resource_group[0].name
   location            = var.resource_group[0].location
-  sku                 = local.scs_zonal_deployment ? "Standard" : "Basic"
+  sku                 = "Standard"
 
   frontend_ip_configuration {
     name      = format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.scs_alb_feip)
@@ -158,7 +158,7 @@ resource "azurerm_lb" "web" {
   name                = format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.web_alb)
   resource_group_name = var.resource_group[0].name
   location            = var.resource_group[0].location
-  sku                 = local.web_zonal_deployment ? "Standard" : "Basic"
+  sku                 = "Standard"
 
   frontend_ip_configuration {
     name      = format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.web_alb_feip)

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/infrastructure.tf
@@ -1,6 +1,6 @@
 // AVAILABILITY SET
 resource "azurerm_availability_set" "hdb" {
-  count = local.enable_deployment ? max(length(local.zones), 1) : 0
+  count = local.enable_deployment && !local.availabilitysets_exist  ? max(length(local.zones), 1) : 0
   name = local.zonal_deployment ? (
     format("%s%sz%s%s%s", local.prefix, var.naming.separator, local.zones[count.index], var.naming.separator, local.resource_suffixes.db_avset)) : (
     format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.db_avset)

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/infrastructure.tf
@@ -1,6 +1,6 @@
 // AVAILABILITY SET
 resource "azurerm_availability_set" "hdb" {
-  count = local.enable_deployment && !local.availabilitysets_exist  ? max(length(local.zones), 1) : 0
+  count = local.enable_deployment ? max(length(local.zones), 1) : 0
   name = local.zonal_deployment ? (
     format("%s%sz%s%s%s", local.prefix, var.naming.separator, local.zones[count.index], var.naming.separator, local.resource_suffixes.db_avset)) : (
     format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.db_avset)


### PR DESCRIPTION
## Problem
SAP should always use the Standard Load Balancer.

From documentation:
We recommend using Azure Standard Load Balancer for all SAP scenarios. If virtual machines in the backend pool require public outbound connectivity, or if they are used in an Azure zone deployment, the standard load balancers require additional configurations.

https://docs.microsoft.com/en-us/azure/architecture/reference-architectures/sap/sap-netweaver 

## Solution
Change the SKU to Standard

## Tests
<Please provide steps to test the PR>

## Notes
The PR will change the Load Balancer therefore the pipeline might fail