### PR TITLE
[INFRASTRUCTURE]Don't create Availability if deploying to an existing…

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/infrastructure.tf
@@ -1,6 +1,6 @@
 // AVAILABILITY SET
 resource "azurerm_availability_set" "hdb" {
-  count = local.enable_deployment ? max(length(local.zones), 1) : 0
+  count = local.enable_deployment && !local.availabilitysets_exist ? max(length(local.zones), 1) : 0
   name = local.zonal_deployment ? (
     format("%s%sz%s%s%s", local.prefix, var.naming.separator, local.zones[count.index], var.naming.separator, local.resource_suffixes.db_avset)) : (
     format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.db_avset)


### PR DESCRIPTION
## Problem
Currently the code deploys an availability set even if it is deployed to an existing one

## Solution
Add the check in the resource count

## Tests
<Please provide steps to test the PR>

## Notes
<Additional comments for the PR>