### PR TITLE
[INFRASTRUCTURE]Try reading the SPN KeyVault from override first

### DIFF
--- a/deploy/terraform/bootstrap/sap_library/saplibrary_full.json
+++ b/deploy/terraform/bootstrap/sap_library/saplibrary_full.json
@@ -10,6 +10,7 @@
     },
     "key_vault":{
         "kv_user_id": "",
-        "kv_prvt_id": ""
+        "kv_prvt_id": "",
+        "kv_spn_id": ""
     }
 }

--- a/deploy/terraform/bootstrap/sap_library/variables_global.tf
+++ b/deploy/terraform/bootstrap/sap_library/variables_global.tf
@@ -26,8 +26,3 @@ variable "key_vault" {
   default     = {}
 }
 
-variable "options" {
-  description = "Configuration options"
-  default     = {}
-}
-

--- a/deploy/terraform/bootstrap/sap_library/variables_global.tf
+++ b/deploy/terraform/bootstrap/sap_library/variables_global.tf
@@ -25,3 +25,9 @@ variable "key_vault" {
   description = "Import existing Azure Key Vaults"
   default     = {}
 }
+
+variable "options" {
+  description = "Configuration options"
+  default     = {}
+}
+

--- a/deploy/terraform/bootstrap/sap_library/variables_local.tf
+++ b/deploy/terraform/bootstrap/sap_library/variables_local.tf
@@ -51,7 +51,7 @@ locals {
   deployer_rg_name = try(local.deployer.resource_group_name, format("%s-INFRASTRUCTURE", local.deployer_prefix))
 
   // Retrieve the arm_id of deployer's Key Vault from deployer's terraform.tfstate
-  deployer_key_vault_arm_id = try(data.terraform_remote_state.deployer.outputs.deployer_kv_user_arm_id, "")
+  deployer_key_vault_arm_id = try(var.options.key_vault.kv_user_id, try(data.terraform_remote_state.deployer.outputs.deployer_kv_user_arm_id, ""))
 
   spn = {
     subscription_id = data.azurerm_key_vault_secret.subscription_id.value,

--- a/deploy/terraform/bootstrap/sap_library/variables_local.tf
+++ b/deploy/terraform/bootstrap/sap_library/variables_local.tf
@@ -51,7 +51,7 @@ locals {
   deployer_rg_name = try(local.deployer.resource_group_name, format("%s-INFRASTRUCTURE", local.deployer_prefix))
 
   // Retrieve the arm_id of deployer's Key Vault from deployer's terraform.tfstate
-  deployer_key_vault_arm_id = try(var.options.key_vault.kv_user_id, try(data.terraform_remote_state.deployer.outputs.deployer_kv_user_arm_id, ""))
+  deployer_key_vault_arm_id = try(var.key_vault.kv_spn_id, try(data.terraform_remote_state.deployer.outputs.deployer_kv_user_arm_id, ""))
 
   spn = {
     subscription_id = data.azurerm_key_vault_secret.subscription_id.value,

--- a/deploy/terraform/run/sap_landscape/saplandscape_full.json
+++ b/deploy/terraform/run/sap_landscape/saplandscape_full.json
@@ -31,7 +31,8 @@
         "kv_iscsi_username": "",
         "kv_iscsi_sshkey_prvt" : "",
         "kv_iscsi_sshkey_pub" : "",
-        "kv_iscsi_pwd": ""
+        "kv_iscsi_pwd": "",
+        "kv_spn_id": ""
     },
     "sshkey": {},
     "options": {}

--- a/deploy/terraform/run/sap_landscape/variables_local.tf
+++ b/deploy/terraform/run/sap_landscape/variables_local.tf
@@ -60,7 +60,7 @@ locals {
   deployer_tfstate_key         = try(var.deployer_tfstate_key, "")
 
   // Retrieve the arm_id of deployer's Key Vault from deployer's terraform.tfstate
-  deployer_key_vault_arm_id = try(var.options.key_vault.kv_user_id, try(data.terraform_remote_state.deployer.outputs.deployer_kv_user_arm_id, ""))
+  deployer_key_vault_arm_id = try(var.key_vault.kv_spn_id, try(data.terraform_remote_state.deployer.outputs.deployer_kv_user_arm_id, ""))
 
   spn = {
     subscription_id = data.azurerm_key_vault_secret.subscription_id.value,

--- a/deploy/terraform/run/sap_landscape/variables_local.tf
+++ b/deploy/terraform/run/sap_landscape/variables_local.tf
@@ -60,7 +60,7 @@ locals {
   deployer_tfstate_key         = try(var.deployer_tfstate_key, "")
 
   // Retrieve the arm_id of deployer's Key Vault from deployer's terraform.tfstate
-  deployer_key_vault_arm_id = try(data.terraform_remote_state.deployer.outputs.deployer_kv_user_arm_id, "")
+  deployer_key_vault_arm_id = try(var.options.key_vault.kv_user_id, try(data.terraform_remote_state.deployer.outputs.deployer_kv_user_arm_id, ""))
 
   spn = {
     subscription_id = data.azurerm_key_vault_secret.subscription_id.value,

--- a/deploy/terraform/run/sap_library/saplibrary_full.json
+++ b/deploy/terraform/run/sap_library/saplibrary_full.json
@@ -10,6 +10,7 @@
     },
     "key_vault":{
         "kv_user_id": "",
-        "kv_prvt_id": ""
+        "kv_prvt_id": "",
+        "kv_spn_id": ""
     }
 }

--- a/deploy/terraform/run/sap_library/variables_global.tf
+++ b/deploy/terraform/run/sap_library/variables_global.tf
@@ -19,11 +19,6 @@ variable "deployer" {
   default     = {}
 }
 
-variable "options" {
-  description = "Configuration options"
-  default     = {}
-}
-
 variable "key_vault" {
   description = "Import existing Azure Key Vaults"
   default     = {}

--- a/deploy/terraform/run/sap_library/variables_global.tf
+++ b/deploy/terraform/run/sap_library/variables_global.tf
@@ -18,6 +18,12 @@ variable "deployer" {
   description = "Details of deployer"
   default     = {}
 }
+
+variable "options" {
+  description = "Configuration options"
+  default     = {}
+}
+
 variable "key_vault" {
   description = "Import existing Azure Key Vaults"
   default     = {}

--- a/deploy/terraform/run/sap_library/variables_local.tf
+++ b/deploy/terraform/run/sap_library/variables_local.tf
@@ -56,7 +56,7 @@ locals {
   deployer_rg_name = try(local.deployer.resource_group_name, format("%s-INFRASTRUCTURE", local.deployer_prefix))
 
   // Retrieve the arm_id of deployer's Key Vault from deployer's terraform.tfstate
-  deployer_key_vault_arm_id = try(var.options.key_vault.kv_user_id, try(data.terraform_remote_state.deployer.outputs.deployer_kv_user_arm_id, ""))
+  deployer_key_vault_arm_id = try(var.key_vault.kv_spn_id, try(data.terraform_remote_state.deployer.outputs.deployer_kv_user_arm_id, ""))
 
   // Locate the tfstate storage account
   tfstate_resource_id          = try(var.tfstate_resource_id, "")

--- a/deploy/terraform/run/sap_library/variables_local.tf
+++ b/deploy/terraform/run/sap_library/variables_local.tf
@@ -56,7 +56,7 @@ locals {
   deployer_rg_name = try(local.deployer.resource_group_name, format("%s-INFRASTRUCTURE", local.deployer_prefix))
 
   // Retrieve the arm_id of deployer's Key Vault from deployer's terraform.tfstate
-  deployer_key_vault_arm_id = try(data.terraform_remote_state.deployer.outputs.deployer_kv_user_arm_id, "")
+  deployer_key_vault_arm_id = try(var.options.key_vault.kv_user_id, try(data.terraform_remote_state.deployer.outputs.deployer_kv_user_arm_id, ""))
 
   // Locate the tfstate storage account
   tfstate_resource_id          = try(var.tfstate_resource_id, "")


### PR DESCRIPTION
## Problem
Even though we provide an existing keyvault we still read the the SPN keyvault from the state file

## Solution
Try to read the override first and if that fails read the state file
deployer_key_vault_arm_id = try(var.options.key_vault.kv_user_id, try(data.terraform_remote_state.deployer.outputs.deployer_kv_user_arm_id, ""))

## Tests
<Please provide steps to test the PR>

## Notes
This will help in decoupling Deployer in the future