### PR TITLE
BoM Validation

### DIFF
--- a/documentation/ansible/system-design-deployment/examples/S4HANA_2020_ISS_v001/bom_with_errors.yml
+++ b/documentation/ansible/system-design-deployment/examples/S4HANA_2020_ISS_v001/bom_with_errors.yml
@@ -4,7 +4,7 @@ name: "S4HANA_2020_ISS_v001"
 target: "ABAP PLATFORM 2020"
 version: "001"
 
-defaults:
+default:
   target_location: "{{ target_media_location }}/download_basket"
 
 product_ids:
@@ -175,9 +175,9 @@ materials:
 
     # other components
 
-    - name: SAPCAR
-      version: 7.21
-      archive: SAPCAR_1324-80000935.EXE
+    - name:     SAPCAR
+      version:  7.21
+      archive:  SAPCAR_1324-80000935.EXE
       override_target_filename: SAPCAR.EXE
 
     - name: "Attribute Change Package 16 for EA-HR 608"
@@ -478,7 +478,7 @@ materials:
 
     - name: Download Basket Stack text
       file: MP_Stack_2001017452_20201030_.txt
-      override_target_location: "{{ target_media_location }}/config"
+      overide_target_location: "{{ target_media_location }}/config"
 
     - name: Download Basket Stack XML
       file: MP_Stack_2001017452_20201030_.xml

--- a/util/check_bom.sh
+++ b/util/check_bom.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# Usage
+#   cd /path/to/util
+#   ./check_bom.sh /some/other/path/to/bom.yml
+
+YAML_LINT=$(command -v yamllint) || echo "yamllint not found. To run linting, install yamllint and try again"
+ANSIBLE_LINT=$(command -v ansible-lint) || echo "ansible-lint not found. To run linting, install ansible-lint and try again"
+YAML_LINT_ERRORS=0
+ANSIBLE_LINT_ERRORS=0
+
+if [[ -n ${YAML_LINT} ]]; then
+  if ${YAML_LINT} $1; then
+    echo "... yamllint [ok]"
+  else
+    echo "... yamllint [errors]"
+    YAML_LINT_ERRORS=1
+  fi
+fi
+
+if [[ -n ${ANSIBLE_LINT} ]]; then
+  if ${ANSIBLE_LINT} $1; then
+    echo "... ansible-lint [ok]"
+  else
+    echo "... ansible-lint [errors]"
+    ANSIBLE_LINT_ERRORS=2
+  fi
+fi
+
+TMP_DIR=$(mktemp -d)
+mkfifo ${TMP_DIR}/capture
+cat ${TMP_DIR}/capture &
+
+VALIDATION_ERRORS=$(ansible-playbook --extra-vars "bom_name=$1" check_bom.yml 2>/dev/null |
+  sed -e 's/, *$//' -n -e '/^failed/,/^}/p' |
+  sed -n -e '/"msg":/s/^.*"msg": "\(.*\)"$/  - \1/p' |
+  tee ${TMP_DIR}/capture | wc -l)
+
+wait
+rm -rf "${TMP_DIR}"
+
+if [[ ${VALIDATION_ERRORS} -eq 0 ]]; then
+  echo "... bom structure [ok]"
+else
+  echo "... bom structure [errors]"
+  VALIDATION_ERRORS=4
+fi
+
+exit $(( ${YAML_LINT_ERRORS} + ${ANSIBLE_LINT_ERRORS} + ${VALIDATION_ERRORS} ))

--- a/util/check_bom.yml
+++ b/util/check_bom.yml
@@ -1,0 +1,108 @@
+---
+
+- hosts: localhost
+  vars:
+    target_media_location: /usr/sap/install
+
+  tasks:
+    - name: pre-checks
+      assert:
+        that:
+          - "{{ bom_name is defined }}"
+          - "{{ bom_name | trim | length != 0 }}"
+
+    - name: "Ensure {{ bom_name }} is available"
+      include_vars:
+        file: "{{ bom_name }}"
+        name: bom
+
+    - name: "Check bom dict"
+      include_tasks: "./validate_dict.yml"
+      vars:
+        reference: "bom"
+        dict: "{{ bom }}"
+        required: ['name', 'defaults', 'product_ids', 'materials']
+        optional: ['version', 'target']
+      ignore_errors: true
+
+    - name: "Check bom.defaults dict"
+      include_tasks: "./validate_dict.yml"
+      vars:
+        reference: "bom.defaults"
+        dict: "{{ bom.defaults }}"
+        required: ['target_location']
+        optional: []
+      when: bom.defaults is defined
+      ignore_errors: true
+
+    - name: "Check bom.product_ids dict"
+      include_tasks: "./validate_dict.yml"
+      vars:
+        reference: "bom.product_ids"
+        dict: "{{ bom.product_ids }}"
+        required: ['scs', 'db', 'pas', 'aas', 'web']
+        optional: []
+      when: bom.product_ids is defined
+      ignore_errors: true
+
+    - name: "Check bom.materials dict"
+      include_tasks: "./validate_dict.yml"
+      vars:
+        reference: "bom.materials"
+        dict: "{{ bom.materials }}"
+        required: ['media', 'templates', 'stackfiles']
+        optional: ['dependencies']
+      when: bom.materials is defined
+      ignore_errors: true
+
+    - name: "Check bom.materials.dependencies list"
+      include_tasks: "./validate_dict.yml"
+      vars:
+        reference: "bom.materials.dependencies"
+        dict: "{{ dict_item }}"
+        required: ['name']
+        optional: ['version']
+      when: bom.materials.dependencies is defined
+      loop: "{{ bom.materials.dependencies | flatten(levels=1) }}"
+      loop_control:
+        loop_var: dict_item
+      ignore_errors: true
+
+    - name: "Check bom.materials.templates list"
+      include_tasks: "./validate_dict.yml"
+      vars:
+        reference: "bom.materials.templates"
+        dict: "{{ dict_item }}"
+        required: ['name', 'file']
+        optional: ['version', 'override_target_location', 'override_target_filename']
+      when: bom.materials.templates is defined
+      loop: "{{ bom.materials.templates | flatten(levels=1) }}"
+      loop_control:
+        loop_var: dict_item
+      ignore_errors: true
+
+    - name: "Check bom.materials.stackfiles list"
+      include_tasks: "./validate_dict.yml"
+      vars:
+        reference: "bom.materials.stackfiles"
+        dict: "{{ dict_item }}"
+        required: ['name', 'file']
+        optional: ['version', 'override_target_location', 'override_target_filename']
+      when: bom.materials.stackfiles is defined
+      loop: "{{ bom.materials.stackfiles | flatten(levels=1) }}"
+      loop_control:
+        loop_var: dict_item
+      ignore_errors: true
+
+    - name: "Check bom.materials.media list"
+      include_tasks: "./validate_dict.yml"
+      vars:
+        reference: "bom.materials.media"
+        dict: "{{ dict_item }}"
+        required: ['name', 'archive']
+        optional: ['version', 'sapurl', 'override_target_location', 'override_target_filename']
+      when: bom.materials.media is defined
+      loop: "{{ bom.materials.media | flatten(levels=1) }}"
+      loop_control:
+        loop_var: dict_item
+      ignore_errors: true

--- a/util/validate_dict.yml
+++ b/util/validate_dict.yml
@@ -1,0 +1,31 @@
+---
+
+- name: "Determine list of dict keys"
+  set_fact:
+    dict_keys: "{{
+      dict |
+      dict2items |
+      flatten(levels=1) |
+      selectattr('key', 'defined') |
+      map(attribute='key') |
+      list
+      }}"
+    dict_name: "{{ ' (Check name: ' + dict.name + ')' if dict.name is defined }}"
+
+- name: "Check required keys"
+  assert:
+    that: "required_key in dict_keys"
+    fail_msg: "Expected to find key '{{ required_key }}' in '{{ reference }}'{{ dict_name }}"
+  loop: "{{ required }}"
+  loop_control:
+    loop_var: required_key
+  ignore_errors: true
+
+- name: "Check optional keys"
+  assert:
+    that: "key in required + optional"
+    fail_msg: "Unexpected key '{{ key }} in '{{ reference }}'{{ dict_name }}"
+  loop: "{{ dict_keys | flatten }}"
+  loop_control:
+    loop_var: key
+  ignore_errors: true


### PR DESCRIPTION
## Problem

Identifying errors with the BoM file is difficult and time-consuming.

## Solution

This PR:

- Adds `util/check_bom.sh`
- Adds `util/check_bom.yml` and `util/validate_dict.yml`
- Provides an error-free example `bom.yml` for testing
- Provides a `bom.yml` with errors for testing

The script and associated Ansible playbook validates a BoM: yaml linting, Ansible linting and BoM structure and keys.

## Prerequisites

For complete test coverage, you will need to ensure `yamllint` and `ansible-lint` are installed. For example:

- `sudo apt install -y yamllint`
- `sudo apt install -y ansible-lint`

Note that if these are not present, the script will warn you and linting will be skipped (BoM validation will still run).

## Tests

Switch to the `util` directory and execute the `check_bom.sh` passing the full location of the BoM file to be tested. Examples:

1. `./check_bom.sh ../documentation/ansible/system-design-deployment/examples/S4HANA_2020_ISS_v001/bom.yml`
   - [ ] Output looks like (no errors reported):

     ```text
     ... yamllint [ok]
     ... ansible-lint [ok]
     ... bom structure [ok]
     ```

1. `./check_bom.sh ../documentation/ansible/system-design-deployment/examples/S4HANA_2020_ISS_v001/bom_with_errors.yml`
   - [ ] Output looks like (errors reported):

     ```text
     ../documentation/ansible/system-design-deployment/examples/S4HANA_2020_ISS_v001/bom_with_errors.yml
       178:16    error    too many spaces after colon  (colons)
       179:16    error    too many spaces after colon  (colons)
       180:16    error    too many spaces after colon  (colons)
     
     ... yamllint [errors]
     ... ansible-lint [ok]
       - Expected to find key 'defaults' in 'bom' (Check name: S4HANA_2020_ISS_v001)
       - Unexpected key 'default in 'bom' (Check name: S4HANA_2020_ISS_v001)
       - Unexpected key 'overide_target_location in 'bom.materials.stackfiles' (Check name: Download Basket Stack text)
     ... bom structure [errors]
     ```
