### PR TITLE
[Beta2.3]Scaleout naming

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/variables_local.tf
@@ -224,12 +224,14 @@ dbnodes = local.anydb_ha ? (
         {
           name           = try("${dbnode.name}-0", format("%s%s%s%s", local.prefix, var.naming.separator, local.virtualmachine_names[idx], local.resource_suffixes.vm))
           computername   = try("${dbnode.name}-0", local.computer_names[idx], local.resource_suffixes.vm)
+          role           = try(dbnode.role, "db")
           admin_nic_ip   = lookup(dbnode, "admin_nic_ips", ["false", "false"])[0]
           db_nic_ip      = lookup(dbnode, "db_nic_ips", ["false", "false"])[0]
         },
         {
           name           = try("${dbnode.name}-1", format("%s%s%s%s", local.prefix, var.naming.separator, local.virtualmachine_names[idx + local.node_count], local.resource_suffixes.vm))
           computername   = try("${dbnode.name}-1", local.computer_names[idx + local.node_count])
+          role           = try(dbnode.role, "db")
           admin_nic_ip   = lookup(dbnode, "admin_nic_ips", ["false", "false"])[1]
           db_nic_ip      = lookup(dbnode, "db_nic_ips", ["false", "false"])[1]
         }
@@ -238,6 +240,7 @@ dbnodes = local.anydb_ha ? (
     flatten([for idx, dbnode in try(local.anydb.dbnodes, [{}]) : {
       name           = try("${dbnode.name}-0", format("%s%s%s%s", local.prefix, var.naming.separator, local.virtualmachine_names[idx], local.resource_suffixes.vm))
       computername   = try("${dbnode.name}-0", local.computer_names[idx], local.resource_suffixes.vm)
+      role           = try(dbnode.role, "db")
       admin_nic_ip   = lookup(dbnode, "admin_nic_ips", ["false", "false"])[0]
       db_nic_ip      = lookup(dbnode, "db_nic_ips", ["false", "false"])[0]
       }]

--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/variables_local.tf
@@ -217,24 +217,33 @@ locals {
     { loadbalancer = local.loadbalancer }
   )
 
-  dbnodes = flatten([[for idx, dbnode in try(local.anydb.dbnodes, [{}]) : {
-    name         = try("${dbnode.name}-0", format("%s%s%s%s", local.prefix, var.naming.separator, local.virtualmachine_names[idx], local.resource_suffixes.vm))
-    computername = try("${dbnode.name}-0", local.computer_names[idx], local.resource_suffixes.vm)
-    role         = try(dbnode.role, "worker"),
-    db_nic_ip    = lookup(dbnode, "db_nic_ips", [false, false])[0]
-    admin_nic_ip = lookup(dbnode, "admin_nic_ips", [false, false])[0]
-    }
-    ],
-    [for idx, dbnode in try(local.anydb.dbnodes, [{}]) : {
-      name         = try("${dbnode.name}-1", format("%s%s%s%s", local.prefix, var.naming.separator, local.virtualmachine_names[idx + local.node_count], local.resource_suffixes.vm))
-      computername = try("${dbnode.name}-1", local.computer_names[idx + local.node_count], local.resource_suffixes.vm)
-      role         = try(dbnode.role, "worker"),
-      db_nic_ip    = lookup(dbnode, "db_nic_ips", [false, false])[1],
-      admin_nic_ip = lookup(dbnode, "admin_nic_ips", [false, false])[1]
-      } if local.anydb_ha
-    ]
-    ]
+
+dbnodes = local.anydb_ha ? (
+    flatten([for idx, dbnode in try(local.anydb.dbnodes, [{}]) :
+      [
+        {
+          name           = try("${dbnode.name}-0", format("%s%s%s%s", local.prefix, var.naming.separator, local.virtualmachine_names[idx], local.resource_suffixes.vm))
+          computername   = try("${dbnode.name}-0", local.computer_names[idx], local.resource_suffixes.vm)
+          admin_nic_ip   = lookup(dbnode, "admin_nic_ips", ["false", "false"])[0]
+          db_nic_ip      = lookup(dbnode, "db_nic_ips", ["false", "false"])[0]
+        },
+        {
+          name           = try("${dbnode.name}-1", format("%s%s%s%s", local.prefix, var.naming.separator, local.virtualmachine_names[idx + local.node_count], local.resource_suffixes.vm))
+          computername   = try("${dbnode.name}-1", local.computer_names[idx + local.node_count])
+          admin_nic_ip   = lookup(dbnode, "admin_nic_ips", ["false", "false"])[1]
+          db_nic_ip      = lookup(dbnode, "db_nic_ips", ["false", "false"])[1]
+        }
+      ]
+    ])) : (
+    flatten([for idx, dbnode in try(local.anydb.dbnodes, [{}]) : {
+      name           = try("${dbnode.name}-0", format("%s%s%s%s", local.prefix, var.naming.separator, local.virtualmachine_names[idx], local.resource_suffixes.vm))
+      computername   = try("${dbnode.name}-0", local.computer_names[idx], local.resource_suffixes.vm)
+      admin_nic_ip   = lookup(dbnode, "admin_nic_ips", ["false", "false"])[0]
+      db_nic_ip      = lookup(dbnode, "db_nic_ips", ["false", "false"])[0]
+      }]
+    )
   )
+
 
   anydb_vms = [
     for idx, dbnode in local.dbnodes : {

--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/vm-anydb.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/vm-anydb.tf
@@ -16,7 +16,7 @@ resource "azurerm_network_interface" "anydb_db" {
 
     private_ip_address = local.use_DHCP ? (
       null) : (
-      try(local.anydb_vms[count.index].db_nic_ip, false) != false ? (
+      try(local.anydb_vms[count.index].db_nic_ip, "false") != "false" ? (
         local.anydb_vms[count.index].db_nic_ip) : (
         cidrhost(var.db_subnet.address_prefixes[0], tonumber(count.index) + local.anydb_ip_offsets.anydb_db_vm)
       )

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/variables_local.tf
@@ -161,26 +161,38 @@ locals {
   xsa        = try(local.hdb.xsa, { routing = "ports" })
   shine      = try(local.hdb.shine, { email = "shinedemo@microsoft.com" })
 
-  dbnodes = flatten([[for idx, dbnode in try(local.hdb.dbnodes, [{}]) : {
-    name           = try("${dbnode.name}-0", format("%s%s%s%s", local.prefix, var.naming.separator, local.virtualmachine_names[idx], local.resource_suffixes.vm))
-    computername   = try("${dbnode.name}-0", local.computer_names[idx], local.resource_suffixes.vm)
-    role           = try(dbnode.role, "worker")
-    admin_nic_ip   = lookup(dbnode, "admin_nic_ips", [false, false])[0]
-    db_nic_ip      = lookup(dbnode, "db_nic_ips", [false, false])[0]
-    storage_nic_ip = lookup(dbnode, "storage_nic_ips", [false, false])[0]
-    }
-    ],
-    [for idx, dbnode in try(local.hdb.dbnodes, [{}]) : {
-      name           = try("${dbnode.name}-1", format("%s%s%s%s", local.prefix, var.naming.separator, local.virtualmachine_names[idx + local.node_count], local.resource_suffixes.vm))
-      computername   = try("${dbnode.name}-1", local.computer_names[idx + local.node_count])
+dbnodes = local.hdb_ha ? (
+    flatten([for idx, dbnode in try(local.hdb.dbnodes, [{}]) :
+      [
+        {
+          name           = try("${dbnode.name}-0", format("%s%s%s%s", local.prefix, var.naming.separator, local.virtualmachine_names[idx], local.resource_suffixes.vm))
+          computername   = try("${dbnode.name}-0", local.computer_names[idx], local.resource_suffixes.vm)
+          role           = try(dbnode.role, "worker")
+          admin_nic_ip   = lookup(dbnode, "admin_nic_ips", [false, false])[0]
+          db_nic_ip      = lookup(dbnode, "db_nic_ips", [false, false])[0]
+          storage_nic_ip = lookup(dbnode, "storage_nic_ips", [false, false])[0]
+        },
+        {
+          name           = try("${dbnode.name}-1", format("%s%s%s%s", local.prefix, var.naming.separator, local.virtualmachine_names[idx + local.node_count], local.resource_suffixes.vm))
+          computername   = try("${dbnode.name}-1", local.computer_names[idx + local.node_count])
+          role           = try(dbnode.role, "worker")
+          admin_nic_ip   = lookup(dbnode, "admin_nic_ips", [false, false])[1]
+          db_nic_ip      = lookup(dbnode, "db_nic_ips", [false, false])[1]
+          storage_nic_ip = lookup(dbnode, "storage_nic_ips", [false, false])[1]
+        }
+      ]
+    ])) : (
+    flatten([for idx, dbnode in try(local.hdb.dbnodes, [{}]) : {
+      name           = try("${dbnode.name}-0", format("%s%s%s%s", local.prefix, var.naming.separator, local.virtualmachine_names[idx], local.resource_suffixes.vm))
+      computername   = try("${dbnode.name}-0", local.computer_names[idx], local.resource_suffixes.vm)
       role           = try(dbnode.role, "worker")
-      admin_nic_ip   = lookup(dbnode, "admin_nic_ips", [false, false])[1]
-      db_nic_ip      = lookup(dbnode, "db_nic_ips", [false, false])[1]
-      storage_nic_ip = lookup(dbnode, "storage_nic_ips", [false, false])[1]
-      } if local.hdb_ha
-    ]
-    ]
+      admin_nic_ip   = lookup(dbnode, "admin_nic_ips", [false, false])[0]
+      db_nic_ip      = lookup(dbnode, "db_nic_ips", [false, false])[0]
+      storage_nic_ip = lookup(dbnode, "storage_nic_ips", [false, false])[0]
+      }]
+    )
   )
+
 
   loadbalancer = try(local.hdb.loadbalancer, {})
 


### PR DESCRIPTION
## Problem
The current logic causes issues when deploying across multiple zones. In the current logic the server names are defined in two separate lists which get concatenated. If we have 3 servers then the HA name list will be

S1,S2,S3, S1HA, S2HS,S3HA. If we want to deploy across two Availability zones our code will put the first VM in the first zone, the second in the second and the end result will be that
Zone 1 have the servers S1, S3,S2HA and Zone 2 will have S2, S1HA, S3HA


## Solution
Instead of concatenating the names and the ha names the names need to be intertwined so that the example list from above will be S1, S1HA, S2, S2HA, S3, S3HA

## Tests
<Please provide steps to test the PR>

## Notes
<Additional comments for the PR>