### PR TITLE
Make the terraform generated password more complex

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_deployer/key_vault.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/key_vault.tf
@@ -158,7 +158,11 @@ resource "random_password" "deployer" {
     && ! local.pwd_exist
     && local.input_pwd == null
   ) ? 1 : 0
-  length           = 16
+  
+  length           = 32
+  min_upper        = 2
+  min_lower        = 2
+  min_numeric      = 2
   special          = true
   override_special = "_%@"
 }

--- a/deploy/terraform/terraform-units/modules/sap_landscape/key_vault_sap_landscape.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/key_vault_sap_landscape.tf
@@ -114,7 +114,11 @@ resource "random_password" "iscsi_password" {
     && local.enable_iscsi_auth_password
     && ! local.iscsi_pwd_exist
   && try(local.var_iscsi.authentication.password, null) == null) ? 1 : 0
-  length           = 16
+
+  length           = 32
+  min_upper        = 2
+  min_lower        = 2
+  min_numeric      = 2
   special          = true
   override_special = "_%@"
 }

--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/key_vault.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/key_vault.tf
@@ -10,7 +10,11 @@ resource "random_password" "password" {
   count = (
     local.enable_auth_password
   && try(local.anydb.authentication.password, null) == null) ? 1 : 0
-  length           = 16
+
+  length           = 32
+  min_upper        = 2
+  min_lower        = 2
+  min_numeric      = 2
   special          = true
   override_special = "_%@"
 }

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/key_vault.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/key_vault.tf
@@ -10,7 +10,11 @@ resource "random_password" "password" {
   count = (
     local.enable_auth_password
   && try(var.application.authentication.password, null) == null) ? 1 : 0
-  length           = 16
+
+  length           = 32
+  min_upper        = 2
+  min_lower        = 2
+  min_numeric      = 2
   special          = true
   override_special = "_%@"
 }

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/key_vault.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/key_vault.tf
@@ -10,9 +10,14 @@ resource "random_password" "password" {
   count = (
     local.enable_auth_password
   && try(local.hdb.authentication.password, null) == null) ? 1 : 0
-  length           = 16
+
+  length           = 32
+  min_upper        = 2
+  min_lower        = 2
+  min_numeric      = 2
   special          = true
   override_special = "_%@"
+
 }
 
 // Store the hdb logon username in KV when authentication type is password


### PR DESCRIPTION
## Problem
The current password is not complex enough
Error: creating Linux Virtual Machine "xxxx" (Resource Group "YYYYY"): compute.VirtualMachinesClient#CreateOrUpdate: Failure sending request: StatusCode=400 -- Original Error: Code="InvalidParameter" Message="The supplied password must be between 6-72 characters long and must satisfy at least 3 of password complexity requirements from the following:\r\n1) Contains an uppercase character\r\n2) Contains a lowercase character\r\n3) Contains a numeric digit\r\n4) Contains a special character\r\n5) Control characters are not allowed" Target="adminPassword"
## Solution
Add these settings
  length           = 32
  min_upper        = 2
  min_lower        = 2
  min_numeric      = 2

## Tests
<Please provide steps to test the PR>

## Notes
<Additional comments for the PR>