### PR TITLE
Reuse storage account from sap_landscape in sap_system

### DIFF
--- a/deploy/terraform/run/sap_landscape/output.tf
+++ b/deploy/terraform/run/sap_landscape/output.tf
@@ -26,9 +26,15 @@ output "iscsi_authentication_username" {
   value = try(module.sap_landscape.iscsi_authentication_username, "")
 }
 
-// Output for DNS
-output "dns_info_iscsi" {
-  value =  module.sap_landscape.dns_info_vms
+output "storageaccount_name" {
+  value = try(module.sap_landscape.storageaccount_name, "")
 }
 
+output "storageaccount_rg_name" {
+  value = try(module.sap_landscape.storageaccount_rg_name, "")
+}
 
+// Output for DNS
+output "dns_info_iscsi" {
+  value = module.sap_landscape.dns_info_vms
+}

--- a/deploy/terraform/terraform-units/modules/sap_landscape/outputs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/outputs.tf
@@ -46,6 +46,14 @@ output "iscsi_authentication_username" {
   value = local.iscsi_auth_username
 }
 
+output "storageaccount_name" {
+  value = azurerm_storage_account.storage_bootdiag.name
+}
+
+output "storageaccount_rg_name" {
+  value = azurerm_storage_account.storage_bootdiag.resource_group_name
+}
+
 // Output for DNS
 output "dns_info_vms" {
   value = local.iscsi_count > 0 ? zipmap(local.full_iscsiserver_names, azurerm_network_interface.iscsi[*].private_ip_address) : null

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/infrastructure.tf
@@ -68,14 +68,10 @@ data "azurerm_subnet" "storage" {
   virtual_network_name = split("/", local.sub_storage_arm_id)[8]
 }
 
-// Creates boot diagnostics storage account
-resource "azurerm_storage_account" "storage_bootdiag" {
-  name                      = local.storageaccount_name
-  resource_group_name       = local.rg_exists ? data.azurerm_resource_group.resource_group[0].name : azurerm_resource_group.resource_group[0].name
-  location                  = local.rg_exists ? data.azurerm_resource_group.resource_group[0].location : azurerm_resource_group.resource_group[0].location
-  account_replication_type  = "LRS"
-  account_tier              = "Standard"
-  enable_https_traffic_only = var.options.enable_secure_transfer == "" ? true : var.options.enable_secure_transfer
+// Import boot diagnostics storage account from sap_landscape
+data "azurerm_storage_account" "storage_bootdiag" {
+  name                = local.storageaccount_name
+  resource_group_name = local.storageaccount_rg_name
 }
 
 // PROXIMITY PLACEMENT GROUP

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/outputs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/outputs.tf
@@ -11,7 +11,7 @@ output "vnet_sap" {
 }
 
 output "storage_bootdiag" {
-  value = azurerm_storage_account.storage_bootdiag
+  value = data.azurerm_storage_account.storage_bootdiag
 }
 
 output "random_id" {

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/variables_local.tf
@@ -40,7 +40,6 @@ variable "custom_disk_sizes_filename" {
 locals {
   // Resources naming
   vnet_prefix                 = trimspace(var.naming.prefix.VNET)
-  storageaccount_name         = var.naming.storageaccount_names.SDU
   sid_keyvault_names          = var.naming.keyvault_names.SDU
   anchor_virtualmachine_names = var.naming.virtualmachine_names.ANCHOR_VMNAME
   anchor_computer_names       = var.naming.virtualmachine_names.ANCHOR_COMPUTERNAME
@@ -69,10 +68,12 @@ locals {
   deployer_tfstate = var.deployer_tfstate
 
   // Retrieve information about Sap Landscape from tfstate file
-  landscape_tfstate  = var.landscape_tfstate
-  kv_landscape_id    = try(local.landscape_tfstate.landscape_key_vault_user_arm_id, "")
-  secret_sid_pk_name = try(local.landscape_tfstate.sid_public_key_secret_name, "")
-  iscsi_private_ip   = try(local.landscape_tfstate.iscsi_private_ip, [])
+  landscape_tfstate      = var.landscape_tfstate
+  kv_landscape_id        = try(local.landscape_tfstate.landscape_key_vault_user_arm_id, "")
+  secret_sid_pk_name     = try(local.landscape_tfstate.sid_public_key_secret_name, "")
+  iscsi_private_ip       = try(local.landscape_tfstate.iscsi_private_ip, [])
+  storageaccount_name    = try(local.landscape_tfstate.storageaccount_name, "")
+  storageaccount_rg_name = try(local.landscape_tfstate.storageaccount_rg_name, "")
 
   //Filter the list of databases to only HANA platform entries
   databases = [

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/vm-anchor.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/vm-anchor.tf
@@ -60,7 +60,7 @@ resource "azurerm_linux_virtual_machine" "anchor" {
   }
 
   boot_diagnostics {
-    storage_account_uri = azurerm_storage_account.storage_bootdiag.primary_blob_endpoint
+    storage_account_uri = data.azurerm_storage_account.storage_bootdiag.primary_blob_endpoint
   }
 
   additional_capabilities {
@@ -106,7 +106,7 @@ resource "azurerm_windows_virtual_machine" "anchor" {
   }
 
   boot_diagnostics {
-    storage_account_uri = azurerm_storage_account.storage_bootdiag.primary_blob_endpoint
+    storage_account_uri = data.azurerm_storage_account.storage_bootdiag.primary_blob_endpoint
   }
 
   additional_capabilities {


### PR DESCRIPTION
## Problem
It is required to reuse the storage account for bootdiag in sap_system.

## Solution
Output bootdiag storage information from sap_landscape and import those in sap_system.

## Tests
pipeline test will fail since now new output is required.
Hence test with integration test:
https://dev.azure.com/azuresaphana/Azure-SAP-HANA/_build/results?buildId=17041&view=results

## Notes
<Additional comments for the PR>