### PR TITLE
Support deployment into existing resource group

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_deployer/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/infrastructure.tf
@@ -6,19 +6,23 @@ Description:
 
 // Create managed resource group for sap deployer with CanNotDelete lock
 resource "azurerm_resource_group" "deployer" {
-  count    = local.enable_deployers ? 1 : 0
+  count    = local.enable_deployers && ! local.rg_exists ? 1 : 0
   name     = local.rg_name
   location = local.region
 }
 
+data "azurerm_resource_group" "deployer" {
+  count = local.rg_exists ? 1 : 0
+  name  = local.rg_name
+}
 // TODO: Add management lock when this issue is addressed https://github.com/terraform-providers/terraform-provider-azurerm/issues/5473
 
 // Create/Import management vnet
 resource "azurerm_virtual_network" "vnet_mgmt" {
   count               = (local.enable_deployers && ! local.vnet_mgmt_exists) ? 1 : 0
   name                = local.vnet_mgmt_name
-  location            = azurerm_resource_group.deployer[0].location
-  resource_group_name = azurerm_resource_group.deployer[0].name
+  resource_group_name = local.rg_exists ? data.azurerm_resource_group.deployer[0].name : azurerm_resource_group.deployer[0].name
+  location            = local.rg_exists ? data.azurerm_resource_group.deployer[0].location : azurerm_resource_group.deployer[0].location
   address_space       = [local.vnet_mgmt_addr]
 }
 
@@ -48,8 +52,8 @@ data "azurerm_subnet" "subnet_mgmt" {
 resource "azurerm_storage_account" "deployer" {
   count                     = local.enable_deployers ? 1 : 0
   name                      = local.storageaccount_names
-  resource_group_name       = azurerm_resource_group.deployer[0].name
-  location                  = azurerm_resource_group.deployer[0].location
+  resource_group_name       = local.rg_exists ? data.azurerm_resource_group.deployer[0].name : azurerm_resource_group.deployer[0].name
+  location                  = local.rg_exists ? data.azurerm_resource_group.deployer[0].location : azurerm_resource_group.deployer[0].location
   account_replication_type  = "LRS"
   account_tier              = "Standard"
   enable_https_traffic_only = local.enable_secure_transfer

--- a/deploy/terraform/terraform-units/modules/sap_deployer/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/infrastructure.tf
@@ -12,7 +12,7 @@ resource "azurerm_resource_group" "deployer" {
 }
 
 data "azurerm_resource_group" "deployer" {
-  count = local.rg_exists ? 1 : 0
+  count = local.enable_deployers && local.rg_exists ? 1 : 0
   name  = local.rg_name
 }
 // TODO: Add management lock when this issue is addressed https://github.com/terraform-providers/terraform-provider-azurerm/issues/5473

--- a/deploy/terraform/terraform-units/modules/sap_deployer/key_vault.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/key_vault.tf
@@ -4,8 +4,8 @@ data "azurerm_client_config" "deployer" {}
 resource "azurerm_key_vault" "kv_prvt" {
   count                      = (local.enable_deployers && ! local.prvt_kv_exist) ? 1 : 0
   name                       = local.prvt_kv_name
-  location                   = azurerm_resource_group.deployer[0].location
-  resource_group_name        = azurerm_resource_group.deployer[0].name
+  resource_group_name        = local.rg_exists ? data.azurerm_resource_group.deployer[0].name : azurerm_resource_group.deployer[0].name
+  location                   = local.rg_exists ? data.azurerm_resource_group.deployer[0].location : azurerm_resource_group.deployer[0].location
   tenant_id                  = data.azurerm_client_config.deployer.tenant_id
   soft_delete_enabled        = true
   soft_delete_retention_days = 7
@@ -37,8 +37,8 @@ resource "azurerm_key_vault_access_policy" "kv_prvt_msi" {
 resource "azurerm_key_vault" "kv_user" {
   count                      = (local.enable_deployers && ! local.user_kv_exist) ? 1 : 0
   name                       = local.user_kv_name
-  location                   = azurerm_resource_group.deployer[0].location
-  resource_group_name        = azurerm_resource_group.deployer[0].name
+  resource_group_name        = local.rg_exists ? data.azurerm_resource_group.deployer[0].name : azurerm_resource_group.deployer[0].name
+  location                   = local.rg_exists ? data.azurerm_resource_group.deployer[0].location : azurerm_resource_group.deployer[0].location
   tenant_id                  = data.azurerm_client_config.deployer.tenant_id
   soft_delete_enabled        = true
   soft_delete_retention_days = 7
@@ -158,7 +158,11 @@ resource "random_password" "deployer" {
     && ! local.pwd_exist
     && local.input_pwd == null
   ) ? 1 : 0
-  length           = 16
+
+  length           = 32
+  min_upper        = 2
+  min_lower        = 2
+  min_numeric      = 2
   special          = true
   override_special = "_%@"
 }

--- a/deploy/terraform/terraform-units/modules/sap_deployer/key_vault.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/key_vault.tf
@@ -158,11 +158,7 @@ resource "random_password" "deployer" {
     && ! local.pwd_exist
     && local.input_pwd == null
   ) ? 1 : 0
-
-  length           = 32
-  min_upper        = 2
-  min_lower        = 2
-  min_numeric      = 2
+  length           = 16
   special          = true
   override_special = "_%@"
 }

--- a/deploy/terraform/terraform-units/modules/sap_deployer/nsg-mgmt.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/nsg-mgmt.tf
@@ -8,8 +8,8 @@ Description:
 resource "azurerm_network_security_group" "nsg_mgmt" {
   count               = local.enable_deployers && ! local.sub_mgmt_nsg_exists ? 1 : 0
   name                = local.sub_mgmt_nsg_name
-  location            = azurerm_resource_group.deployer[0].location
-  resource_group_name = azurerm_resource_group.deployer[0].name
+  resource_group_name = local.rg_exists ? data.azurerm_resource_group.deployer[0].name : azurerm_resource_group.deployer[0].name
+  location            = local.rg_exists ? data.azurerm_resource_group.deployer[0].location : azurerm_resource_group.deployer[0].location
 }
 
 data "azurerm_network_security_group" "nsg_mgmt" {

--- a/deploy/terraform/terraform-units/modules/sap_deployer/output.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/output.tf
@@ -6,7 +6,10 @@ Description:
 
 // Deployer resource group name
 output "deployer_rg_name" {
-  value = local.enable_deployers ? azurerm_resource_group.deployer[0].name : ""
+  value = local.enable_deployers ? (
+    local.rg_exists ? data.azurerm_resource_group.deployer[0].name : azurerm_resource_group.deployer[0].name) : (
+    ""
+  )
 }
 
 // Unique ID for deployer

--- a/deploy/terraform/terraform-units/modules/sap_deployer/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/variables_local.tf
@@ -20,9 +20,12 @@ locals {
   enable_deployer_public_ip = try(var.options.enable_deployer_public_ip, false)
 
   // Resource group and location
-  region  = try(var.infrastructure.region, "")
-  prefix  = try(var.infrastructure.resource_group.name, var.naming.prefix.DEPLOYER)
-  rg_name = try(var.infrastructure.resource_group.name, format("%s%s", local.prefix, local.resource_suffixes.deployer_rg))
+  region = try(var.infrastructure.region, "")
+  prefix = try(var.infrastructure.resource_group.name, var.naming.prefix.DEPLOYER)
+
+  rg_arm_id = try(var.infrastructure.resource_group.arm_id, "")
+  rg_exists = length(local.rg_arm_id) > 0 ? true : false
+  rg_name   = local.rg_exists ? try(split("/", local.rg_arm_id)[4], "") : try(var.infrastructure.resource_group.name, format("%s%s", local.prefix, local.resource_suffixes.deployer_rg))
 
   // Post fix for all deployed resources
   postfix = random_id.deployer.hex
@@ -31,7 +34,7 @@ locals {
   vnet_mgmt        = try(var.infrastructure.vnets.management, {})
   vnet_mgmt_arm_id = try(local.vnet_mgmt.arm_id, "")
   vnet_mgmt_exists = length(local.vnet_mgmt_arm_id) > 0 ? true : false
-  vnet_mgmt_name   = local.vnet_mgmt_exists ? split("/", local.vnet_mgmt_arm_id)[8] : try(local.vnet_mgmt.name, format("%s%s", local.prefix,local.resource_suffixes.vnet))
+  vnet_mgmt_name   = local.vnet_mgmt_exists ? split("/", local.vnet_mgmt_arm_id)[8] : try(local.vnet_mgmt.name, format("%s%s", local.prefix, local.resource_suffixes.vnet))
   vnet_mgmt_addr   = local.vnet_mgmt_exists ? "" : try(local.vnet_mgmt.address_space, "")
 
   // Management subnet
@@ -62,7 +65,7 @@ locals {
     try(deployer.authentication.type, "key") == "password" ? true : false
   ]), "true")
 
-  username = local.enable_deployers ? (local.username_exist ? data.azurerm_key_vault_secret.username[0].value : try(local.deployer_input[0].authentication.username, "azureadm")): "" 
+  username = local.enable_deployers ? (local.username_exist ? data.azurerm_key_vault_secret.username[0].value : try(local.deployer_input[0].authentication.username, "azureadm")) : ""
 
   // By default use generated password. Provide password under authentication overides it
   input_pwd_list = compact([


### PR DESCRIPTION
## Problem
Currently the code will always create the resource group for the deployer

## Solution
Add support for providing the arm_id for an existing resource group

## Tests
Provide the arm_id in the resource_group section in the infrastructure block

## Notes
<Additional comments for the PR>