### PR TITLE
[BUG] Support multiple disks for app tier

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-app.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-app.tf
@@ -215,7 +215,7 @@ resource "azurerm_windows_virtual_machine" "app" {
 # Creates managed data disk
 resource "azurerm_managed_disk" "app" {
   count                  = local.enable_deployment ? length(local.app_data_disks) : 0
-  name                   = format("%s%s%s%s", local.prefix, var.naming.separator, local.app_virtualmachine_names[count.index], local.app_data_disks[count.index].suffix)
+  name                   = format("%s%s%s%s", local.prefix, var.naming.separator, local.app_virtualmachine_names[local.app_data_disks[count.index].vm_index], local.app_data_disks[count.index].suffix)
   location               = var.resource_group[0].location
   resource_group_name    = var.resource_group[0].name
   create_option          = "Empty"

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-scs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-scs.tf
@@ -222,7 +222,7 @@ resource "azurerm_windows_virtual_machine" "scs" {
 # Creates managed data disk
 resource "azurerm_managed_disk" "scs" {
   count                  = local.enable_deployment ? length(local.scs_data_disks) : 0
-  name                   = format("%s%s%s%s", local.prefix, var.naming.separator, local.scs_virtualmachine_names[count.index], local.scs_data_disks[count.index].suffix)
+  name                   = format("%s%s%s%s", local.prefix, var.naming.separator, local.scs_virtualmachine_names[local.scs_data_disks[count.index].vm_index], local.scs_data_disks[count.index].suffix)
   location               = var.resource_group[0].location
   resource_group_name    = var.resource_group[0].name
   create_option          = "Empty"

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-webdisp.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-webdisp.tf
@@ -207,7 +207,7 @@ resource "azurerm_windows_virtual_machine" "web" {
 # Creates managed data disk
 resource "azurerm_managed_disk" "web" {
   count                  = local.enable_deployment ? length(local.web_data_disks) : 0
-  name                   = format("%s%s%s%s", local.prefix, var.naming.separator, local.web_virtualmachine_names[count.index], local.web_data_disks[count.index].suffix)
+  name                   = format("%s%s%s%s", local.prefix, var.naming.separator, local.web_virtualmachine_names[local.web_data_disks[count.index].vm_index], local.web_data_disks[count.index].suffix)
   location               = var.resource_group[0].location
   resource_group_name    = var.resource_group[0].name
   create_option          = "Empty"


### PR DESCRIPTION
## Problem
Currently the code naming the disks fails when there are more disks defined for the app tier servers than servers. The code was using the count.index and not the vm_index property

## Solution
Correct the faulty logic

## Tests
<Please provide steps to test the PR>

## Notes
<Additional comments for the PR>