### PR TITLE
Add more rules when pulling ssh key

### DIFF
--- a/.pipeline/templates/ansible/ansible-playbook-steps.yml
+++ b/.pipeline/templates/ansible/ansible-playbook-steps.yml
@@ -23,10 +23,10 @@ steps:
 
       echo "=== Retrieving SSH key pairs from sap_landscape KV ==="
       landscape_kv_name=$(az keyvault list --resource-group ${saplandscape_rg} | jq -r "'".[] | select(.name | contains(\\\"user\\\")).name"'")
-      sid_private_key_secret_name=$(az keyvault secret list --vault-name ${landscape_kv_name} | jq -r "'".[] | select(.name | contains(\\\"iscsi\\\") | not) | select(.name | contains(\\\"pub\\\") | not).name"'")
-      sid_public_key_secret_name=$(az keyvault secret list --vault-name ${landscape_kv_name} | jq -r "'".[] | select(.name | contains(\\\"iscsi\\\") | not) | select(.name | contains(\\\"pub\\\")).name"'")
-      iscsi_private_key_secret_name=$(az keyvault secret list --vault-name ${landscape_kv_name} | jq -r "'".[] | select(.name | contains(\\\"iscsi\\\")) | select(.name | contains(\\\"pub\\\") | not).name"'")
-      iscsi_public_key_secret_name=$(az keyvault secret list --vault-name ${landscape_kv_name} | jq -r "'".[] | select(.name | contains(\\\"iscsi\\\")) | select(.name | contains(\\\"pub\\\")).name"'")
+      sid_private_key_secret_name=$(az keyvault secret list --vault-name ${landscape_kv_name} | jq -r "'".[] | select(.name | contains(\\\"iscsi\\\") | not) | select(.name | contains(\\\"sshkey\\\")) | select(.name | contains(\\\"pub\\\") | not).name"'")
+      sid_public_key_secret_name=$(az keyvault secret list --vault-name ${landscape_kv_name} | jq -r "'".[] | select(.name | contains(\\\"iscsi\\\") | not) | select(.name | contains(\\\"sshkey\\\")) | select(.name | contains(\\\"pub\\\")).name"'")
+      iscsi_private_key_secret_name=$(az keyvault secret list --vault-name ${landscape_kv_name} | jq -r "'".[] | select(.name | contains(\\\"iscsi\\\")) | select(.name | contains(\\\"sshkey\\\")) | select(.name | contains(\\\"pub\\\") | not).name"'")
+      iscsi_public_key_secret_name=$(az keyvault secret list --vault-name ${landscape_kv_name} | jq -r "'".[] | select(.name | contains(\\\"iscsi\\\")) | select(.name | contains(\\\"sshkey\\\")) | select(.name | contains(\\\"pub\\\")).name"'")
 
       rm -f ${ws_dir}/sshkey
       az keyvault secret show --vault-name ${landscape_kv_name} --name ${sid_private_key_secret_name} | jq -r .value > ${ws_dir}/sshkey


### PR DESCRIPTION
## Problem
Current rule to pull sshkey for ansible playbook is not sufficient.

## Solution
Add more rules when pulling sshkey from kv.

## Tests
Before:
https://dev.azure.com/azuresaphana/Azure-SAP-HANA/_build/results?buildId=17798&view=logs&j=9f023c7a-31b1-56e6-342c-b6c6c5b3b1c2&t=dd481aef-2ee3-5e78-4fb1-7767504e9ae3

After:
https://dev.azure.com/azuresaphana/Azure-SAP-HANA/_build/results?buildId=17800&view=logs&j=93317a84-14f1-5d04-60ba-257c8e72aebb&t=d8607c4d-2959-5e0b-d023-c13804553548

## Notes
<Additional comments for the PR>