### PR TITLE
[HOTFIX] Revert change to use standard load balancer everywhere

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/infrastructure.tf
@@ -5,7 +5,7 @@ Load balancer front IP address range: .4 - .9
 resource "azurerm_lb" "anydb" {
   count = local.enable_deployment ? 1 : 0
   name  = format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.db_alb)
-  sku   = "Standard"
+  sku   = local.zonal_deployment ? "Standard" : "Basic"
 
   resource_group_name = var.resource_group[0].name
   location            = var.resource_group[0].location

--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/infrastructure.tf
@@ -42,21 +42,6 @@ resource "azurerm_lb_probe" "anydb" {
   number_of_probes    = 2
 }
 
-resource "azurerm_lb_rule" "anydb" {
-  count                          = local.enable_deployment ? 1 : 0
-  resource_group_name            = var.resource_group[0].name
-  loadbalancer_id                = azurerm_lb.anydb[0].id
-  name                           = format("%s%s%s%05d-%02d", local.prefix, var.naming.separator, local.resource_suffixes.db_alb_rule, 0, count.index)
-  protocol                       = "All"
-  frontend_port                  = 0
-  backend_port                   = 0
-  frontend_ip_configuration_name = format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.db_alb_feip)
-  backend_address_pool_id        = azurerm_lb_backend_address_pool.anydb[0].id
-  probe_id                       = azurerm_lb_probe.anydb[0].id
-  enable_floating_ip             = true
-}
-
-
 resource "azurerm_network_interface_backend_address_pool_association" "anydb" {
   count                   = local.enable_deployment ? local.db_server_count : 0
   network_interface_id    = azurerm_network_interface.anydb_db[count.index].id

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/infrastructure.tf
@@ -44,7 +44,7 @@ resource "azurerm_lb" "scs" {
   name                = format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.scs_alb)
   resource_group_name = var.resource_group[0].name
   location            = var.resource_group[0].location
-  sku                 = "Standard"
+  sku                 = local.scs_zonal_deployment ? "Standard" : "Basic"
 
   frontend_ip_configuration {
     name      = format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.scs_alb_feip)
@@ -158,7 +158,7 @@ resource "azurerm_lb" "web" {
   name                = format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.web_alb)
   resource_group_name = var.resource_group[0].name
   location            = var.resource_group[0].location
-  sku                 = "Standard"
+  sku                 = local.web_zonal_deployment ? "Standard" : "Basic"
 
   frontend_ip_configuration {
     name      = format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.web_alb_feip)

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/infrastructure.tf
@@ -88,13 +88,13 @@ resource "azurerm_lb_probe" "scs" {
 
 # Create the SCS Load Balancer Rules
 resource "azurerm_lb_rule" "scs" {
-  count                          = local.enable_deployment && local.scs_server_count > 0 ? 1 : 0
+  count                          = local.enable_deployment && local.scs_server_count > 0 ? length(local.lb_ports.scs) : 0
   resource_group_name            = var.resource_group[0].name
   loadbalancer_id                = azurerm_lb.scs[0].id
   name                           = format("%s%s%s%05d-%02d", local.prefix, var.naming.separator, local.resource_suffixes.scs_scs_rule, local.lb_ports.scs[count.index], count.index)
-  protocol                       = "All"
-  frontend_port                  = 0
-  backend_port                   = 0
+  protocol                       = "Tcp"
+  frontend_port                  = local.lb_ports.scs[count.index]
+  backend_port                   = local.lb_ports.scs[count.index]
   frontend_ip_configuration_name = format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.scs_alb_feip)
   backend_address_pool_id        = azurerm_lb_backend_address_pool.scs[0].id
   probe_id                       = azurerm_lb_probe.scs[0].id
@@ -103,13 +103,13 @@ resource "azurerm_lb_rule" "scs" {
 
 # Create the ERS Load balancer rules only in High Availability configurations
 resource "azurerm_lb_rule" "ers" {
-  count                          = local.enable_deployment && local.scs_server_count > 0 ? (local.scs_high_availability ? 1 : 0) : 0
+  count                          = local.enable_deployment && local.scs_server_count > 0 ? (local.scs_high_availability ? length(local.lb_ports.ers) : 0) : 0
   resource_group_name            = var.resource_group[0].name
   loadbalancer_id                = azurerm_lb.scs[0].id
   name                           = format("%s%s%s%05d-%02d", local.prefix, var.naming.separator, local.resource_suffixes.scs_ers_rule, local.lb_ports.ers[count.index], count.index)
-  protocol                       = "All"
-  frontend_port                  = 0
-  backend_port                   = 0
+  protocol                       = "Tcp"
+  frontend_port                  = local.lb_ports.ers[count.index]
+  backend_port                   = local.lb_ports.ers[count.index]
   frontend_ip_configuration_name = format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.scs_ers_feip)
   backend_address_pool_id        = azurerm_lb_backend_address_pool.scs[0].id
   probe_id                       = azurerm_lb_probe.scs[1].id
@@ -182,13 +182,13 @@ resource "azurerm_lb_backend_address_pool" "web" {
 
 # Create the Web dispatcher Load Balancer Rules
 resource "azurerm_lb_rule" "web" {
-  count                          = local.enable_deployment && local.webdispatcher_count > 0 ? 1 : 0
+  count                          = local.enable_deployment && local.webdispatcher_count > 0 ? length(local.lb_ports.web) : 0
   resource_group_name            = var.resource_group[0].name
   loadbalancer_id                = azurerm_lb.web[0].id
   name                           = format("%s%s%s%05d-%02d", local.prefix, var.naming.separator, local.resource_suffixes.web_alb_inrule, local.lb_ports.web[count.index], count.index)
-  protocol                       = "All"
-  frontend_port                  = 0
-  backend_port                   = 0
+  protocol                       = "Tcp"
+  frontend_port                  = local.lb_ports.web[count.index]
+  backend_port                   = local.lb_ports.web[count.index]
   frontend_ip_configuration_name = azurerm_lb.web[0].frontend_ip_configuration[0].name
   backend_address_pool_id        = azurerm_lb_backend_address_pool.web[0].id
   enable_floating_ip             = true

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/infrastructure.tf
@@ -71,13 +71,13 @@ resource "azurerm_network_interface_backend_address_pool_association" "hdb" {
 }
 
 resource "azurerm_lb_rule" "hdb" {
-  count                          = local.enable_deployment ? 1 : 0
+  count                          = local.enable_deployment ? length(local.loadbalancer_ports) : 0
   resource_group_name            = var.resource_group[0].name
   loadbalancer_id                = azurerm_lb.hdb[0].id
-  name                           = format("%s%s%s%05d-%02d", local.prefix, var.naming.separator, local.resource_suffixes.db_alb_rule, 0, count.index)
-  protocol                       = "All"
-  frontend_port                  = 0
-  backend_port                   = 0
+  name                           = format("%s%s%s%05d-%02d", local.prefix, var.naming.separator, local.resource_suffixes.db_alb_rule, local.loadbalancer_ports[count.index].port, count.index)
+  protocol                       = "Tcp"
+  frontend_port                  = local.loadbalancer_ports[count.index].port
+  backend_port                   = local.loadbalancer_ports[count.index].port
   frontend_ip_configuration_name = format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.db_alb_feip)
   backend_address_pool_id        = azurerm_lb_backend_address_pool.hdb[0].id
   probe_id                       = azurerm_lb_probe.hdb[0].id

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/infrastructure.tf
@@ -1,6 +1,6 @@
 // AVAILABILITY SET
 resource "azurerm_availability_set" "hdb" {
-  count = local.enable_deployment && !local.availabilitysets_exist ? max(length(local.zones), 1) : 0
+  count = local.enable_deployment && ! local.availabilitysets_exist ? max(length(local.zones), 1) : 0
   name = local.zonal_deployment ? (
     format("%s%sz%s%s%s", local.prefix, var.naming.separator, local.zones[count.index], var.naming.separator, local.resource_suffixes.db_avset)) : (
     format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.db_avset)
@@ -29,7 +29,7 @@ resource "azurerm_lb" "hdb" {
   name                = format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.db_alb)
   resource_group_name = var.resource_group[0].name
   location            = var.resource_group[0].location
-  sku                 = "Standard"
+  sku                 = local.zonal_deployment ? "Standard" : "Basic"
 
   frontend_ip_configuration {
     name                          = format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.db_alb_feip)

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/variables_local.tf
@@ -245,6 +245,30 @@ locals {
     hdb_storage_vm = 10
   }
 
+  // Ports used for specific HANA Versions
+  lb_ports = {
+    "1" = [
+      "30015",
+      "30017",
+    ]
+
+    "2" = [
+      "30013",
+      "30014",
+      "30015",
+      "30040",
+      "30041",
+      "30042",
+    ]
+  }
+
+  loadbalancer_ports = flatten([
+    for port in local.lb_ports[split(".", local.hdb_version)[0]] : {
+      sid  = local.sap_sid
+      port = tonumber(port) + (tonumber(local.hana_database.instance.instance_number) * 100)
+    }
+  ])
+
   db_sizing = local.enable_deployment ? lookup(local.sizes, local.hdb_size).storage : []
 
   // List of data disks to be created for HANA DB nodes


### PR DESCRIPTION
## Problem
When VMs without public IP addresses are placed in the backend pool of internal (no public IP address) Standard Azure load balancer, there is no outbound connectivity to public end points, unless additional configuration is done. (reference [link](https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/high-availability-guide-standard-load-balancer-outbound-connections))
This leads to the ansible playbook to fail (VM requires outbound connectivity to register with SUSE Cloud).

## Solution
Revert changes from PR #983 #1005 #1006.

## Tests
Now the VM has access to SUSE Cloud:
https://dev.azure.com/azuresaphana/Azure-SAP-HANA/_build/results?buildId=18011&view=logs&j=9f023c7a-31b1-56e6-342c-b6c6c5b3b1c2&t=dd481aef-2ee3-5e78-4fb1-7767504e9ae3

## Notes
@KimForss please plan on a discussion which options from the above link would customer prefer, or a design where we could support both options depends on the input variable. Then that can be implemented together with the supportability to use standard load balancer everywhere.