### PR TITLE
[HOTFIX] Outputs fail when scaling down an existing deployment

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/outputs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/outputs.tf
@@ -42,8 +42,8 @@ output "dns_info_vms" {
         slice(var.naming.virtualmachine_names.ANYDB_SECONDARY_DNSNAME, 0, local.db_server_count)
       )),
       compact(concat(
-        azurerm_network_interface.anydb_admin[*].private_ip_address,
-        azurerm_network_interface.anydb_db[*].private_ip_address
+        slice(azurerm_network_interface.anydb_admin[*].private_ip_address, 0, local.db_server_count),
+        slice(azurerm_network_interface.anydb_db[*].private_ip_address, 0, local.db_server_count)
       ))
     )
     ) : (

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/outputs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/outputs.tf
@@ -67,30 +67,33 @@ output "dns_info_vms" {
   value = local.enable_deployment ? (
     local.apptier_dual_nics ? (
       zipmap(
-        concat(local.full_appserver_names,
+        concat(
+          local.full_appserver_names,
           var.naming.virtualmachine_names.APP_SECONDARY_DNSNAME,
           local.full_scsserver_names,
           var.naming.virtualmachine_names.SCS_SECONDARY_DNSNAME,
           local.full_webserver_names,
           var.naming.virtualmachine_names.WEB_SECONDARY_DNSNAME
         ),
-        concat(azurerm_network_interface.app_admin[*].private_ip_address,
-          azurerm_network_interface.app[*].private_ip_address,
-          azurerm_network_interface.scs_admin[*].private_ip_address,
-          azurerm_network_interface.scs[*].private_ip_address,
-          azurerm_network_interface.web_admin[*].private_ip_address,
-          azurerm_network_interface.web[*].private_ip_address
+       concat(
+          slice(azurerm_network_interface.app_admin[*].private_ip_address, 0, local.application_server_count),
+          slice(azurerm_network_interface.app[*].private_ip_address, 0, local.application_server_count),
+          slice(azurerm_network_interface.scs_admin[*].private_ip_address, 0, local.scs_server_count),
+          slice(azurerm_network_interface.scs[*].private_ip_address, 0, local.scs_server_count),
+          slice(azurerm_network_interface.web_admin[*].private_ip_address, 0, local.webdispatcher_count),
+          slice(azurerm_network_interface.web[*].private_ip_address, 0, local.webdispatcher_count)
       ))) : (
       zipmap(
-        concat(local.full_appserver_names,
+        concat(
+          local.full_appserver_names,
           local.full_scsserver_names,
           local.full_webserver_names
         ),
-        concat(azurerm_network_interface.app[*].private_ip_address,
-          azurerm_network_interface.scs[*].private_ip_address,
-          azurerm_network_interface.web[*].private_ip_address
-      ))
-    )
+        concat(
+          slice(azurerm_network_interface.app[*].private_ip_address, 0, local.application_server_count),
+          slice(azurerm_network_interface.scs[*].private_ip_address, 0, local.scs_server_count),
+          slice(azurerm_network_interface.web[*].private_ip_address, 0, local.webdispatcher_count)      
+        )))
     ) : (
     null
   )

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/outputs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/outputs.tf
@@ -26,9 +26,14 @@ output "hana_database_info" {
 output "dns_info_vms" {
   value = local.enable_deployment ? (
     zipmap(
-      concat(local.hdb_vms[*].name, slice(var.naming.virtualmachine_names.HANA_SECONDARY_DNSNAME, 0, local.db_server_count)),
-      concat(azurerm_network_interface.nics_dbnodes_admin[*].private_ip_address, azurerm_network_interface.nics_dbnodes_db[*].private_ip_address)
-    )) : (
+      concat(
+        local.hdb_vms[*].name,
+        slice(var.naming.virtualmachine_names.HANA_SECONDARY_DNSNAME, 0, local.db_server_count)
+      ),
+      concat(
+        slice(azurerm_network_interface.nics_dbnodes_admin[*].private_ip_address, 0, local.db_server_count),
+        slice(azurerm_network_interface.nics_dbnodes_db[*].private_ip_address, 0, local.db_server_count)
+      )    )) : (
     null
   )
 }


### PR DESCRIPTION
## Problem
If we scale down the deployment (reduce the server count) the code fails

## Solution
Control the dimensions of the output slices by adding a server count to them

## Tests
Do a deployment with more than 2 app servers and then scale down the count to 1

## Notes
<Additional comments for the PR>