### PR TITLE
[HOTFIX] Support existing storage account (diagnosticslog)

### DIFF
--- a/deploy/terraform/run/sap_landscape/module.tf
+++ b/deploy/terraform/run/sap_landscape/module.tf
@@ -4,15 +4,16 @@
 */
 
 module "sap_landscape" {
-  source            = "../../terraform-units/modules/sap_landscape"
-  infrastructure    = var.infrastructure
-  options           = local.options
-  ssh-timeout       = var.ssh-timeout
-  sshkey            = var.sshkey
-  naming            = module.sap_namegenerator.naming
-  service_principal = local.service_principal
-  key_vault         = var.key_vault
-  deployer_tfstate  = data.terraform_remote_state.deployer.outputs
+  source                      = "../../terraform-units/modules/sap_landscape"
+  infrastructure              = var.infrastructure
+  options                     = local.options
+  ssh-timeout                 = var.ssh-timeout
+  sshkey                      = var.sshkey
+  naming                      = module.sap_namegenerator.naming
+  service_principal           = local.service_principal
+  key_vault                   = var.key_vault
+  deployer_tfstate            = data.terraform_remote_state.deployer.outputs
+  diagnostics_storage_account = var.diagnostics_storage_account
 }
 
 module "sap_namegenerator" {

--- a/deploy/terraform/run/sap_landscape/providers.tf
+++ b/deploy/terraform/run/sap_landscape/providers.tf
@@ -51,7 +51,7 @@ terraform {
       version = "~> 3.0.0"
     }
     azuread = {
-      source = "hashicorp/azuread"
+      source  = "hashicorp/azuread"
       version = "~> 1.0.0"
     }
     azurerm = {

--- a/deploy/terraform/run/sap_landscape/saplandscape_full.json
+++ b/deploy/terraform/run/sap_landscape/saplandscape_full.json
@@ -26,14 +26,17 @@
     "key_vault": {
         "kv_user_id": "",
         "kv_prvt_id": "",
-        "kv_sid_sshkey_prvt" : "",
-        "kv_sid_sshkey_pub" : "",
+        "kv_sid_sshkey_prvt": "",
+        "kv_sid_sshkey_pub": "",
         "kv_iscsi_username": "",
-        "kv_iscsi_sshkey_prvt" : "",
-        "kv_iscsi_sshkey_pub" : "",
+        "kv_iscsi_sshkey_prvt": "",
+        "kv_iscsi_sshkey_pub": "",
         "kv_iscsi_pwd": "",
         "kv_spn_id": ""
     },
     "sshkey": {},
-    "options": {}
+    "options": {},
+    "diagnostics_storage_account": {
+        "arm_id": ""
+    }
 }

--- a/deploy/terraform/run/sap_landscape/variables_global.tf
+++ b/deploy/terraform/run/sap_landscape/variables_global.tf
@@ -25,3 +25,10 @@ variable "key_vault" {
   description = "The user brings existing Azure Key Vaults"
   default     = ""
 }
+
+variable "diagnostics_storage_account" {
+  description = "Storage account information for diagnostics account"
+  default     = {
+    arm_id = ""
+  }
+}

--- a/deploy/terraform/run/sap_system/module.tf
+++ b/deploy/terraform/run/sap_system/module.tf
@@ -54,7 +54,7 @@ module "hdb_node" {
   sshkey                     = var.sshkey
   resource_group             = module.common_infrastructure.resource_group
   vnet_sap                   = module.common_infrastructure.vnet_sap
-  storage_bootdiag           = module.common_infrastructure.storage_bootdiag
+  storage_bootdiag_endpoint  = module.common_infrastructure.storage_bootdiag_endpoint
   ppg                        = module.common_infrastructure.ppg
   sid_kv_user_id             = module.common_infrastructure.sid_kv_user_id
   naming                     = module.sap_namegenerator.naming
@@ -79,7 +79,7 @@ module "app_tier" {
   sshkey                     = var.sshkey
   resource_group             = module.common_infrastructure.resource_group
   vnet_sap                   = module.common_infrastructure.vnet_sap
-  storage_bootdiag           = module.common_infrastructure.storage_bootdiag
+  storage_bootdiag_endpoint  = module.common_infrastructure.storage_bootdiag_endpoint
   ppg                        = module.common_infrastructure.ppg
   sid_kv_user_id             = module.common_infrastructure.sid_kv_user_id
   naming                     = module.sap_namegenerator.naming
@@ -103,7 +103,7 @@ module "anydb_node" {
   sshkey                     = var.sshkey
   resource_group             = module.common_infrastructure.resource_group
   vnet_sap                   = module.common_infrastructure.vnet_sap
-  storage_bootdiag           = module.common_infrastructure.storage_bootdiag
+  storage_bootdiag_endpoint  = module.common_infrastructure.storage_bootdiag_endpoint
   ppg                        = module.common_infrastructure.ppg
   sid_kv_user_id             = module.common_infrastructure.sid_kv_user_id
   naming                     = module.sap_namegenerator.naming

--- a/deploy/terraform/terraform-units/modules/sap_landscape/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/infrastructure.tf
@@ -55,10 +55,17 @@ resource "azurerm_virtual_network_peering" "peering_sap_management" {
 
 // Creates boot diagnostics storage account
 resource "azurerm_storage_account" "storage_bootdiag" {
+  count                     = length(var.diagnostics_storage_account.arm_id) > 0 ? 0 : 1
   name                      = local.storageaccount_name
   resource_group_name       = local.rg_exists ? data.azurerm_resource_group.resource_group[0].name : azurerm_resource_group.resource_group[0].name
   location                  = local.rg_exists ? data.azurerm_resource_group.resource_group[0].location : azurerm_resource_group.resource_group[0].location
   account_replication_type  = "LRS"
   account_tier              = "Standard"
   enable_https_traffic_only = var.options.enable_secure_transfer == "" ? true : var.options.enable_secure_transfer
+}
+
+data "azurerm_storage_account" "storage_bootdiag" {
+  count               = length(var.diagnostics_storage_account.arm_id) > 0 ? 1 : 0
+  name                = split("/", var.diagnostics_storage_account.arm_id)[8]
+  resource_group_name = split("/", var.diagnostics_storage_account.arm_id)[4]
 }

--- a/deploy/terraform/terraform-units/modules/sap_landscape/iscsi.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/iscsi.tf
@@ -102,8 +102,8 @@ resource "azurerm_linux_virtual_machine" "iscsi" {
 
   boot_diagnostics {
     storage_account_uri = length(var.diagnostics_storage_account.arm_id) > 0 ? (
-      azurerm_storage_account.storage_bootdiag[0].primary_blob_endpoint) : (
-      data.azurerm_storage_account.storage_bootdiag[0].primary_blob_endpoint
+      data.azurerm_storage_account.storage_bootdiag[0].primary_blob_endpoint) : (
+      azurerm_storage_account.storage_bootdiag[0].primary_blob_endpoint
     )
   }
 

--- a/deploy/terraform/terraform-units/modules/sap_landscape/iscsi.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/iscsi.tf
@@ -101,7 +101,10 @@ resource "azurerm_linux_virtual_machine" "iscsi" {
   }
 
   boot_diagnostics {
-    storage_account_uri = azurerm_storage_account.storage_bootdiag.primary_blob_endpoint
+    storage_account_uri = length(var.diagnostics_storage_account.arm_id) > 0 ? (
+      azurerm_storage_account.storage_bootdiag[0].primary_blob_endpoint) : (
+      data.azurerm_storage_account.storage_bootdiag[0].primary_blob_endpoint
+    )
   }
 
   tags = {

--- a/deploy/terraform/terraform-units/modules/sap_landscape/outputs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/outputs.tf
@@ -6,16 +6,15 @@ output "vnet_sap" {
   value = local.vnet_sap_exists ? data.azurerm_virtual_network.vnet_sap : azurerm_virtual_network.vnet_sap
 }
 
-output "storage_bootdiag" {
-  value = azurerm_storage_account.storage_bootdiag
-}
-
 output "random_id" {
   value = random_id.random_id.hex
 }
 
 output "nics_iscsi" {
-  value = local.iscsi_count > 0 ? azurerm_network_interface.iscsi[*] : []
+  value = local.iscsi_count > 0 ? (
+    azurerm_network_interface.iscsi[*]) : (
+    []
+  )
 }
 
 output "infrastructure_w_defaults" {
@@ -47,12 +46,27 @@ output "iscsi_authentication_username" {
 }
 
 output "storageaccount_name" {
-  value = azurerm_storage_account.storage_bootdiag.name
+  value = length(var.diagnostics_storage_account.arm_id) > 0 ? (
+    data.azurerm_storage_account.storage_bootdiag[0].name) : (
+    azurerm_storage_account.storage_bootdiag[0].name
+  )
 }
 
 output "storageaccount_rg_name" {
-  value = azurerm_storage_account.storage_bootdiag.resource_group_name
+  value = length(var.diagnostics_storage_account.arm_id) > 0 ? (
+    data.azurerm_storage_account.storage_bootdiag[0].resource_group_name) : (
+    azurerm_storage_account.storage_bootdiag[0].resource_group_name
+  )
 }
+
+
+output "storage_bootdiag_endpoint" {
+  value = length(var.diagnostics_storage_account.arm_id) > 0 ? (
+    data.azurerm_storage_account.storage_bootdiag[0].primary_blob_endpoint) : (
+    azurerm_storage_account.storage_bootdiag[0].primary_blob_endpoint
+  )
+}
+
 
 // Output for DNS
 output "dns_info_vms" {

--- a/deploy/terraform/terraform-units/modules/sap_landscape/variables_global.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/variables_global.tf
@@ -6,3 +6,7 @@ variable "key_vault" {
   description = "The user brings existing Azure Key Vaults"
   default     = ""
 }
+
+variable "diagnostics_storage_account" {
+  description = "Storage account information for diagnostics account"
+}

--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/variables_local.tf
@@ -10,7 +10,7 @@ variable "vnet_sap" {
   description = "Details of the SAP Vnet"
 }
 
-variable "storage_bootdiag" {
+variable "storage_bootdiag_endpoint" {
   description = "Details of the boot diagnostics storage account"
 }
 

--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/vm-anydb.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/vm-anydb.tf
@@ -120,7 +120,7 @@ resource "azurerm_linux_virtual_machine" "dbserver" {
   }
 
   boot_diagnostics {
-    storage_account_uri = var.storage_bootdiag.primary_blob_endpoint
+    storage_account_uri = var.storage_bootdiag_endpoint
   }
 
   tags = local.tags
@@ -187,7 +187,7 @@ resource "azurerm_windows_virtual_machine" "dbserver" {
   }
 
   boot_diagnostics {
-    storage_account_uri = var.storage_bootdiag.primary_blob_endpoint
+    storage_account_uri = var.storage_bootdiag_endpoint
   }
 
   tags = local.tags

--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/vm-observer.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/vm-observer.tf
@@ -74,7 +74,7 @@ resource "azurerm_linux_virtual_machine" "observer" {
   }
 
   boot_diagnostics {
-    storage_account_uri = var.storage_bootdiag.primary_blob_endpoint
+    storage_account_uri = var.storage_bootdiag_endpoint
   }
 
   tags = local.tags
@@ -127,7 +127,7 @@ resource "azurerm_windows_virtual_machine" "observer" {
   }
 
   boot_diagnostics {
-    storage_account_uri = var.storage_bootdiag.primary_blob_endpoint
+    storage_account_uri = var.storage_bootdiag_endpoint
   }
 
   tags = local.tags

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/variables_local.tf
@@ -14,7 +14,7 @@ variable "vnet_sap" {
   description = "Details of the SAP Vnet"
 }
 
-variable "storage_bootdiag" {
+variable "storage_bootdiag_endpoint" {
   description = "Details of the boot diagnostic storage device"
 }
 

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-app.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-app.tf
@@ -127,7 +127,7 @@ resource "azurerm_linux_virtual_machine" "app" {
   }
 
   boot_diagnostics {
-    storage_account_uri = var.storage_bootdiag.primary_blob_endpoint
+    storage_account_uri = var.storage_bootdiag_endpoint
   }
 
   tags = local.app_tags
@@ -205,7 +205,7 @@ resource "azurerm_windows_virtual_machine" "app" {
   }
 
   boot_diagnostics {
-    storage_account_uri = var.storage_bootdiag.primary_blob_endpoint
+    storage_account_uri = var.storage_bootdiag_endpoint
   }
 
   tags = local.app_tags

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-scs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-scs.tf
@@ -135,7 +135,7 @@ resource "azurerm_linux_virtual_machine" "scs" {
   }
 
   boot_diagnostics {
-    storage_account_uri = var.storage_bootdiag.primary_blob_endpoint
+    storage_account_uri = var.storage_bootdiag_endpoint
   }
 
   tags = local.scs_tags
@@ -213,7 +213,7 @@ resource "azurerm_windows_virtual_machine" "scs" {
   }
 
   boot_diagnostics {
-    storage_account_uri = var.storage_bootdiag.primary_blob_endpoint
+    storage_account_uri = var.storage_bootdiag_endpoint
   }
 
   tags = local.scs_tags

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-webdisp.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-webdisp.tf
@@ -121,7 +121,7 @@ resource "azurerm_linux_virtual_machine" "web" {
   }
 
   boot_diagnostics {
-    storage_account_uri = var.storage_bootdiag.primary_blob_endpoint
+    storage_account_uri = var.storage_bootdiag_endpoint
   }
 
   tags = local.web_tags
@@ -198,7 +198,7 @@ resource "azurerm_windows_virtual_machine" "web" {
   }
 
   boot_diagnostics {
-    storage_account_uri = var.storage_bootdiag.primary_blob_endpoint
+    storage_account_uri = var.storage_bootdiag_endpoint
   }
 
   tags = local.web_tags

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/outputs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/outputs.tf
@@ -10,8 +10,8 @@ output "vnet_sap" {
   value = local.vnet_sap
 }
 
-output "storage_bootdiag" {
-  value = data.azurerm_storage_account.storage_bootdiag
+output "storage_bootdiag_endpoint" {
+  value = data.azurerm_storage_account.storage_bootdiag.primary_blob_endpoint
 }
 
 output "random_id" {

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/variables_local.tf
@@ -10,7 +10,7 @@ variable "vnet_sap" {
   description = "Details of the SAP Vnet"
 }
 
-variable "storage_bootdiag" {
+variable "storage_bootdiag_endpoint" {
   description = "Details of the boot diagnostics storage account"
 }
 

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/vm-hdb.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/vm-hdb.tf
@@ -157,7 +157,7 @@ resource "azurerm_linux_virtual_machine" "vm_dbnode" {
   }
 
   boot_diagnostics {
-    storage_account_uri = var.storage_bootdiag.primary_blob_endpoint
+    storage_account_uri = var.storage_bootdiag_endpoint
   }
 
   tags = local.tags


### PR DESCRIPTION
## Problem
Currently there is no way to provide an existing storage account for the boot diagnostics log

## Solution
Add support for providing an existing storage account for the boot diagnostics log

## Tests
Normal deployment

## Notes
<Additional comments for the PR>