### PR TITLE
[HOTFIX] Changed the NIC order

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/vm-anydb.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/vm-anydb.tf
@@ -73,7 +73,7 @@ resource "azurerm_linux_virtual_machine" "dbserver" {
   zone = local.enable_ultradisk || local.db_server_count == local.db_zone_count ? local.zones[count.index % max(local.db_zone_count, 1)] : null
 
   network_interface_ids = local.anydb_dual_nics ? (
-    [azurerm_network_interface.anydb_admin[count.index].id, azurerm_network_interface.anydb_db[count.index].id]) : (
+    [azurerm_network_interface.anydb_db[count.index].id, azurerm_network_interface.anydb_admin[count.index].id]) : (
     [azurerm_network_interface.anydb_db[count.index].id]
   )
 
@@ -150,7 +150,7 @@ resource "azurerm_windows_virtual_machine" "dbserver" {
   zone = local.enable_ultradisk || local.db_server_count == local.db_zone_count ? local.zones[count.index % max(local.db_zone_count, 1)] : null
 
   network_interface_ids = local.anydb_dual_nics ? (
-    [azurerm_network_interface.anydb_admin[count.index].id, azurerm_network_interface.anydb_db[count.index].id]) : (
+    [azurerm_network_interface.anydb_db[count.index].id, azurerm_network_interface.anydb_admin[count.index].id]) : (
     [azurerm_network_interface.anydb_db[count.index].id]
   )
   size = local.anydb_vms[count.index].size

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-app.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-app.tf
@@ -70,7 +70,7 @@ resource "azurerm_linux_virtual_machine" "app" {
   null)
 
   network_interface_ids = local.apptier_dual_nics ? (
-    [azurerm_network_interface.app_admin[count.index].id, azurerm_network_interface.app[count.index].id]) : (
+    [azurerm_network_interface.app[count.index].id, azurerm_network_interface.app_admin[count.index].id]) : (
     [azurerm_network_interface.app[count.index].id]
   )
 
@@ -157,7 +157,7 @@ resource "azurerm_windows_virtual_machine" "app" {
   null)
 
   network_interface_ids = local.apptier_dual_nics ? (
-    [azurerm_network_interface.app_admin[count.index].id, azurerm_network_interface.app[count.index].id]) : (
+    [azurerm_network_interface.app[count.index].id, azurerm_network_interface.app_admin[count.index].id]) : (
     [azurerm_network_interface.app[count.index].id]
   )
 

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-scs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-scs.tf
@@ -78,7 +78,7 @@ resource "azurerm_linux_virtual_machine" "scs" {
   )
 
   network_interface_ids = local.apptier_dual_nics ? (
-    [azurerm_network_interface.scs_admin[count.index].id, azurerm_network_interface.scs[count.index].id]) : (
+    [azurerm_network_interface.scs[count.index].id, azurerm_network_interface.scs_admin[count.index].id]) : (
     [azurerm_network_interface.scs[count.index].id]
   )
 
@@ -165,7 +165,7 @@ resource "azurerm_windows_virtual_machine" "scs" {
   )
 
   network_interface_ids = local.apptier_dual_nics ? (
-    [azurerm_network_interface.scs_admin[count.index].id, azurerm_network_interface.scs[count.index].id]) : (
+    [azurerm_network_interface.scs[count.index].id, azurerm_network_interface.scs_admin[count.index].id]) : (
     [azurerm_network_interface.scs[count.index].id]
   )
 

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-webdisp.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-webdisp.tf
@@ -64,7 +64,7 @@ resource "azurerm_linux_virtual_machine" "web" {
   )
 
   network_interface_ids = local.apptier_dual_nics ? (
-    [azurerm_network_interface.web_admin[count.index].id, azurerm_network_interface.web[count.index].id]) : (
+    [azurerm_network_interface.web[count.index].id, azurerm_network_interface.web_admin[count.index].id]) : (
     [azurerm_network_interface.web[count.index].id]
   )
 
@@ -150,7 +150,7 @@ resource "azurerm_windows_virtual_machine" "web" {
   )
 
   network_interface_ids = local.apptier_dual_nics ? (
-    [azurerm_network_interface.web_admin[count.index].id, azurerm_network_interface.web[count.index].id]) : (
+    [azurerm_network_interface.web[count.index].id, azurerm_network_interface.web_admin[count.index].id]) : (
     [azurerm_network_interface.web[count.index].id]
   )
 

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/vm-hdb.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/vm-hdb.tf
@@ -108,11 +108,11 @@ resource "azurerm_linux_virtual_machine" "vm_dbnode" {
   zone = local.enable_ultradisk || local.db_server_count == local.db_zone_count ? local.zones[count.index % max(local.db_zone_count, 1)] : null
 
   network_interface_ids = local.enable_storage_subnet ? ([
-    azurerm_network_interface.nics_dbnodes_admin[count.index].id,
     azurerm_network_interface.nics_dbnodes_db[count.index].id,
-    azurerm_network_interface.nics_dbnodes_storage[count.index].id]) : ([
     azurerm_network_interface.nics_dbnodes_admin[count.index].id,
-    azurerm_network_interface.nics_dbnodes_db[count.index].id]
+    azurerm_network_interface.nics_dbnodes_storage[count.index].id]) : ([
+    azurerm_network_interface.nics_dbnodes_db[count.index].id,
+    azurerm_network_interface.nics_dbnodes_admin[count.index].id]
   )
   size                            = lookup(local.sizes, local.hdb_vms[count.index].size).compute.vm_size
   admin_username                  = var.sid_username


### PR DESCRIPTION
## Problem
In Linux only the primary network interface gets the default gateway configured.

## Solution
Add the app & db nic as the primary nic as the secondary NICs are all in the same subnet

## Tests
<Please provide steps to test the PR>

## Notes
<Additional comments for the PR>