### PR TITLE
Providing more options for app tier VM sizing AB#144

### DIFF
--- a/deploy/configs/app_sizes.json
+++ b/deploy/configs/app_sizes.json
@@ -23,6 +23,582 @@
           "write_accelerator": false
         }
       ]
+    },
+    "S_Dsv3": {
+      "compute": {
+        "vm_size": "Standard_D4s_v3",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "S_Esv3": {
+      "compute": {
+        "vm_size": "Standard_E4s_v3",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "S_Ddsv4": {
+      "compute": {
+        "vm_size": "Standard_D4ds_v4",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "S_Dasv4": {
+      "compute": {
+        "vm_size": "Standard_D4as_v4",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "S_Easv4": {
+      "compute": {
+        "vm_size": "Standard_E4as_v4",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "S_Edsv4": {
+      "compute": {
+        "vm_size": "Standard_E4ds_v4",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "M_Dsv3": {
+      "compute": {
+        "vm_size": "Standard_D8s_v3",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "M_Esv3": {
+      "compute": {
+        "vm_size": "Standard_E8s_v3",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "M_Ddsv4": {
+      "compute": {
+        "vm_size": "Standard_D8ds_v4",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "M_Dasv4": {
+      "compute": {
+        "vm_size": "Standard_D8as_v4",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "M_Easv4": {
+      "compute": {
+        "vm_size": "Standard_E8as_v4",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "M_Edsv4": {
+      "compute": {
+        "vm_size": "Standard_E8ds_v4",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "L_Dsv3": {
+      "compute": {
+        "vm_size": "Standard_D16s_v3",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "L_Esv3": {
+      "compute": {
+        "vm_size": "Standard_E16s_v3",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "L_Ddsv4": {
+      "compute": {
+        "vm_size": "Standard_D16ds_v4",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "L_Dasv4": {
+      "compute": {
+        "vm_size": "Standard_D16as_v4",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "L_Easv4": {
+      "compute": {
+        "vm_size": "Standard_E16as_v4",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "L_Edsv4": {
+      "compute": {
+        "vm_size": "Standard_E16ds_v4",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "XL_Dsv3": {
+      "compute": {
+        "vm_size": "Standard_D20s_v3",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "XL_Esv3": {
+      "compute": {
+        "vm_size": "Standard_E20s_v3",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "XL_Ddsv4": {
+      "compute": {
+        "vm_size": "Standard_D20ds_v4",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "XL_Dasv4": {
+      "compute": {
+        "vm_size": "Standard_D20as_v4",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "XL_Easv4": {
+      "compute": {
+        "vm_size": "Standard_E20as_v4",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "XL_Edsv4": {
+      "compute": {
+        "vm_size": "Standard_E20ds_v4",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
     }
   },
   "scs": {
@@ -49,6 +625,582 @@
           "write_accelerator": false
         }
       ]
+    },
+    "S_Dsv3": {
+      "compute": {
+        "vm_size": "Standard_D4s_v3",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "S_Esv3": {
+      "compute": {
+        "vm_size": "Standard_E4s_v3",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "S_Ddsv4": {
+      "compute": {
+        "vm_size": "Standard_D4ds_v4",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "S_Dasv4": {
+      "compute": {
+        "vm_size": "Standard_D4as_v4",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "S_Easv4": {
+      "compute": {
+        "vm_size": "Standard_E4as_v4",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "S_Edsv4": {
+      "compute": {
+        "vm_size": "Standard_E4ds_v4",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "M_Dsv3": {
+      "compute": {
+        "vm_size": "Standard_D8s_v3",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "M_Esv3": {
+      "compute": {
+        "vm_size": "Standard_E8s_v3",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "M_Ddsv4": {
+      "compute": {
+        "vm_size": "Standard_D8ds_v4",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "M_Dasv4": {
+      "compute": {
+        "vm_size": "Standard_D8as_v4",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "M_Easv4": {
+      "compute": {
+        "vm_size": "Standard_E8as_v4",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "M_Edsv4": {
+      "compute": {
+        "vm_size": "Standard_E8ds_v4",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "L_Dsv3": {
+      "compute": {
+        "vm_size": "Standard_D16s_v3",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "L_Esv3": {
+      "compute": {
+        "vm_size": "Standard_E16s_v3",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "L_Ddsv4": {
+      "compute": {
+        "vm_size": "Standard_D16ds_v4",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "L_Dasv4": {
+      "compute": {
+        "vm_size": "Standard_D16as_v4",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "L_Easv4": {
+      "compute": {
+        "vm_size": "Standard_E16as_v4",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "L_Edsv4": {
+      "compute": {
+        "vm_size": "Standard_E16ds_v4",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "XL_Dsv3": {
+      "compute": {
+        "vm_size": "Standard_D20s_v3",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "XL_Esv3": {
+      "compute": {
+        "vm_size": "Standard_E20s_v3",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "XL_Ddsv4": {
+      "compute": {
+        "vm_size": "Standard_D20ds_v4",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "XL_Dasv4": {
+      "compute": {
+        "vm_size": "Standard_D20as_v4",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "XL_Easv4": {
+      "compute": {
+        "vm_size": "Standard_E20as_v4",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "XL_Edsv4": {
+      "compute": {
+        "vm_size": "Standard_E20ds_v4",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
     }
   },
   "web": {
@@ -63,6 +1215,582 @@
           "name": "os",
           "disk_type": "Premium_LRS",
           "size_gb": 30,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "S_Dsv3": {
+      "compute": {
+        "vm_size": "Standard_D4s_v3",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "S_Esv3": {
+      "compute": {
+        "vm_size": "Standard_E4s_v3",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "S_Ddsv4": {
+      "compute": {
+        "vm_size": "Standard_D4ds_v4",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "S_Dasv4": {
+      "compute": {
+        "vm_size": "Standard_D4as_v4",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "S_Easv4": {
+      "compute": {
+        "vm_size": "Standard_E4as_v4",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "S_Edsv4": {
+      "compute": {
+        "vm_size": "Standard_E4ds_v4",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "M_Dsv3": {
+      "compute": {
+        "vm_size": "Standard_D8s_v3",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "M_Esv3": {
+      "compute": {
+        "vm_size": "Standard_E8s_v3",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "M_Ddsv4": {
+      "compute": {
+        "vm_size": "Standard_D8ds_v4",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "M_Dasv4": {
+      "compute": {
+        "vm_size": "Standard_D8as_v4",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "M_Easv4": {
+      "compute": {
+        "vm_size": "Standard_E8as_v4",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "M_Edsv4": {
+      "compute": {
+        "vm_size": "Standard_E8ds_v4",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "L_Dsv3": {
+      "compute": {
+        "vm_size": "Standard_D16s_v3",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "L_Esv3": {
+      "compute": {
+        "vm_size": "Standard_E16s_v3",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "L_Ddsv4": {
+      "compute": {
+        "vm_size": "Standard_D16ds_v4",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "L_Dasv4": {
+      "compute": {
+        "vm_size": "Standard_D16as_v4",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "L_Easv4": {
+      "compute": {
+        "vm_size": "Standard_E16as_v4",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "L_Edsv4": {
+      "compute": {
+        "vm_size": "Standard_E16ds_v4",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "XL_Dsv3": {
+      "compute": {
+        "vm_size": "Standard_D20s_v3",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "XL_Esv3": {
+      "compute": {
+        "vm_size": "Standard_E20s_v3",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "XL_Ddsv4": {
+      "compute": {
+        "vm_size": "Standard_D20ds_v4",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "XL_Dasv4": {
+      "compute": {
+        "vm_size": "Standard_D20as_v4",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "XL_Easv4": {
+      "compute": {
+        "vm_size": "Standard_E20as_v4",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
+          "caching": "ReadWrite",
+          "write_accelerator": false
+        },
+        {
+          "count": 1,
+          "name": "data",
+          "disk_type": "Premium_LRS",
+          "size_gb": 512,
+          "caching": "None",
+          "write_accelerator": false
+        }
+      ]
+    },
+    "XL_Edsv4": {
+      "compute": {
+        "vm_size": "Standard_E20ds_v4",
+        "accelerated_networking": false
+      },
+      "storage": [
+        {
+          "count": 1,
+          "name": "os",
+          "disk_type": "Premium_LRS",
+          "size_gb": 31,
           "caching": "ReadWrite",
           "write_accelerator": false
         },

--- a/deploy/configs/app_sizes.json
+++ b/deploy/configs/app_sizes.json
@@ -34,7 +34,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -58,7 +58,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -82,7 +82,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -106,7 +106,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -130,7 +130,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -154,7 +154,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -178,7 +178,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -202,7 +202,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -226,7 +226,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -250,7 +250,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -274,7 +274,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -298,7 +298,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -322,7 +322,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -346,7 +346,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -370,7 +370,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -394,7 +394,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -418,7 +418,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -442,7 +442,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -466,7 +466,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -490,7 +490,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -514,7 +514,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -538,7 +538,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -562,7 +562,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -586,7 +586,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -636,7 +636,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -660,7 +660,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -684,7 +684,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -708,7 +708,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -732,7 +732,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -756,7 +756,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -780,7 +780,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -804,7 +804,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -828,7 +828,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -852,7 +852,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -876,7 +876,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -900,7 +900,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -924,7 +924,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -948,7 +948,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -972,7 +972,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -996,7 +996,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -1020,7 +1020,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -1044,7 +1044,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -1068,7 +1068,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -1092,7 +1092,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -1116,7 +1116,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -1140,7 +1140,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -1164,7 +1164,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -1188,7 +1188,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -1238,7 +1238,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -1262,7 +1262,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -1286,7 +1286,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -1310,7 +1310,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -1334,7 +1334,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -1358,7 +1358,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -1382,7 +1382,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -1406,7 +1406,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -1430,7 +1430,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -1454,7 +1454,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -1478,7 +1478,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -1502,7 +1502,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -1526,7 +1526,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -1550,7 +1550,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -1574,7 +1574,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -1598,7 +1598,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -1622,7 +1622,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -1646,7 +1646,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -1670,7 +1670,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -1694,7 +1694,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -1718,7 +1718,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -1742,7 +1742,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -1766,7 +1766,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },
@@ -1790,7 +1790,7 @@
           "count": 1,
           "name": "os",
           "disk_type": "Premium_LRS",
-          "size_gb": 31,
+          "size_gb": 64,
           "caching": "ReadWrite",
           "write_accelerator": false
         },


### PR DESCRIPTION
## Problem
Currently the codebase on supports one VM SKU

## Solution
Add support for the following SKUs

- Dsv3-series
- Easv4-series
- Dasv4-series
- Esv3-series
- Ddsv4-series
- Edsv4-series

and the ability to specify the sizing for them.

S = 4 vCPU
M = 8 vCPU
L = 16 vCPU
XL = 20-32 vCPU

## Tests
Change the size in the application tier to S_Dsv3

## Notes
<Additional comments for the PR>