### PR TITLE
[HOTFIX] Add the ability to retain the NIC order from older deployments

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/variables_local.tf
@@ -18,7 +18,7 @@ variable "ppg" {
   description = "Details of the proximity placement group"
 }
 
-variable naming {
+variable "naming" {
   description = "Defines the names for the resources"
 }
 
@@ -79,6 +79,9 @@ locals {
 
   //Allowing changing the base for indexing, default is zero-based indexing, if customers want the first disk to start with 1 they would change this
   offset = try(var.options.resource_offset, 0)
+
+  //Allowing to keep the old nic order
+  legacy_order = try(var.options.legacy_order, false)
 
   // Zones
   zones            = try(local.anydb.zones, [])

--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/variables_local.tf
@@ -81,7 +81,7 @@ locals {
   offset = try(var.options.resource_offset, 0)
 
   //Allowing to keep the old nic order
-  legacy_order = try(var.options.legacy_order, false)
+  legacy_nic_order = try(var.options.legacy_nic_order, false)
 
   // Zones
   zones            = try(local.anydb.zones, [])

--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/vm-anydb.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/vm-anydb.tf
@@ -73,7 +73,7 @@ resource "azurerm_linux_virtual_machine" "dbserver" {
   zone = local.enable_ultradisk || local.db_server_count == local.db_zone_count ? local.zones[count.index % max(local.db_zone_count, 1)] : null
 
   network_interface_ids = local.anydb_dual_nics ? (
-    local.legacy_order ? (
+    local.legacy_nic_order ? (
       [azurerm_network_interface.anydb_admin[count.index].id, azurerm_network_interface.anydb_db[count.index].id]) : (
       [azurerm_network_interface.anydb_db[count.index].id, azurerm_network_interface.anydb_admin[count.index].id]
     )) : (
@@ -153,7 +153,7 @@ resource "azurerm_windows_virtual_machine" "dbserver" {
   zone = local.enable_ultradisk || local.db_server_count == local.db_zone_count ? local.zones[count.index % max(local.db_zone_count, 1)] : null
 
   network_interface_ids = local.anydb_dual_nics ? (
-    local.legacy_order ? (
+    local.legacy_nic_order ? (
       [azurerm_network_interface.anydb_admin[count.index].id, azurerm_network_interface.anydb_db[count.index].id]) : (
       [azurerm_network_interface.anydb_db[count.index].id, azurerm_network_interface.anydb_admin[count.index].id]
     )) : (

--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/vm-anydb.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/vm-anydb.tf
@@ -73,7 +73,10 @@ resource "azurerm_linux_virtual_machine" "dbserver" {
   zone = local.enable_ultradisk || local.db_server_count == local.db_zone_count ? local.zones[count.index % max(local.db_zone_count, 1)] : null
 
   network_interface_ids = local.anydb_dual_nics ? (
-    [azurerm_network_interface.anydb_db[count.index].id, azurerm_network_interface.anydb_admin[count.index].id]) : (
+    local.legacy_order ? (
+      [azurerm_network_interface.anydb_admin[count.index].id, azurerm_network_interface.anydb_db[count.index].id]) : (
+      [azurerm_network_interface.anydb_db[count.index].id, azurerm_network_interface.anydb_admin[count.index].id]
+    )) : (
     [azurerm_network_interface.anydb_db[count.index].id]
   )
 
@@ -105,7 +108,7 @@ resource "azurerm_linux_virtual_machine" "dbserver" {
 
   admin_username                  = var.sid_username
   admin_password                  = local.enable_auth_key ? null : var.sid_password
-  disable_password_authentication = ! local.enable_auth_password
+  disable_password_authentication = !local.enable_auth_password
 
   dynamic "admin_ssh_key" {
     for_each = range(local.enable_auth_password ? 0 : 1)
@@ -150,9 +153,13 @@ resource "azurerm_windows_virtual_machine" "dbserver" {
   zone = local.enable_ultradisk || local.db_server_count == local.db_zone_count ? local.zones[count.index % max(local.db_zone_count, 1)] : null
 
   network_interface_ids = local.anydb_dual_nics ? (
-    [azurerm_network_interface.anydb_db[count.index].id, azurerm_network_interface.anydb_admin[count.index].id]) : (
+    local.legacy_order ? (
+      [azurerm_network_interface.anydb_admin[count.index].id, azurerm_network_interface.anydb_db[count.index].id]) : (
+      [azurerm_network_interface.anydb_db[count.index].id, azurerm_network_interface.anydb_admin[count.index].id]
+    )) : (
     [azurerm_network_interface.anydb_db[count.index].id]
   )
+
   size = local.anydb_vms[count.index].size
 
   source_image_id = local.anydb_custom_image ? local.anydb_os.source_image_id : null

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/variables_local.tf
@@ -90,7 +90,7 @@ locals {
   offset = try(var.options.resource_offset, 0)
 
   //Allowing to keep the old nic order
-  legacy_order = try(var.options.legacy_order, false)
+  legacy_nic_order = try(var.options.legacy_nic_order, false)
 
   faultdomain_count = try(tonumber(compact(
     [for pair in local.faults :

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/variables_local.tf
@@ -22,7 +22,7 @@ variable "ppg" {
   description = "Details of the proximity placement group"
 }
 
-variable naming {
+variable "naming" {
   description = "Defines the names for the resources"
 }
 
@@ -89,6 +89,9 @@ locals {
   //Allowing changing the base for indexing, default is zero-based indexing, if customers want the first disk to start with 1 they would change this
   offset = try(var.options.resource_offset, 0)
 
+  //Allowing to keep the old nic order
+  legacy_order = try(var.options.legacy_order, false)
+
   faultdomain_count = try(tonumber(compact(
     [for pair in local.faults :
       upper(pair.Location) == upper(local.region) ? pair.MaximumFaultDomainCount : ""
@@ -135,7 +138,7 @@ locals {
     try(split("/", local.sub_app_arm_id)[10], "")) : (
     try(local.var_sub_app.name, format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.app_subnet))
   )
-  
+
   sub_app_prefix = local.sub_app_exists ? data.azurerm_subnet.subnet_sap_app[0].address_prefixes[0] : try(local.var_sub_app.prefix, "")
 
   // APP NSG
@@ -184,7 +187,6 @@ locals {
 
   firewall_service_tags = format("AzureCloud.%s", local.region)
 
-
   application_sid          = try(var.application.sid, "")
   enable_deployment        = try(var.application.enable_deployment, false)
   scs_instance_number      = try(var.application.scs_instance_number, "01")
@@ -224,7 +226,7 @@ locals {
   // OS image for all SCS VMs
   // If custom image is used, we do not overwrite os reference with default value
   // If no publisher or no custom image is specified use the custom image from the app if specified
-  scs_custom_image = try(var.application.scs_os.source_image_id, "") == "" && ! local.app_custom_image ? false : true
+  scs_custom_image = try(var.application.scs_os.source_image_id, "") == "" && !local.app_custom_image ? false : true
   scs_ostype       = try(var.application.scs_os.os_type, local.app_ostype)
 
   scs_os = {
@@ -247,7 +249,7 @@ locals {
   // OS image for all WebDispatcher VMs
   // If custom image is used, we do not overwrite os reference with default value
   // If no publisher or no custom image is specified use the custom image from the app if specified
-  web_custom_image = try(var.application.web_os.source_image_id, "") == "" && ! local.app_custom_image ? false : true
+  web_custom_image = try(var.application.web_os.source_image_id, "") == "" && !local.app_custom_image ? false : true
   web_ostype       = try(var.application.web_os.os_type, local.app_ostype)
 
   web_os = {

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-app.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-app.tf
@@ -70,13 +70,17 @@ resource "azurerm_linux_virtual_machine" "app" {
   null)
 
   network_interface_ids = local.apptier_dual_nics ? (
-    [azurerm_network_interface.app[count.index].id, azurerm_network_interface.app_admin[count.index].id]) : (
+    local.legacy_order ? (
+      [azurerm_network_interface.app_admin[count.index].id, azurerm_network_interface.app[count.index].id]) : (
+      [azurerm_network_interface.app[count.index].id, azurerm_network_interface.app_admin[count.index].id]
+    )
+    ) : (
     [azurerm_network_interface.app[count.index].id]
   )
 
   size                            = local.app_sizing.compute.vm_size
   admin_username                  = var.sid_username
-  disable_password_authentication = ! local.enable_auth_password
+  disable_password_authentication = !local.enable_auth_password
   admin_password                  = local.enable_auth_key ? null : var.sid_password
 
   dynamic "os_disk" {
@@ -157,7 +161,11 @@ resource "azurerm_windows_virtual_machine" "app" {
   null)
 
   network_interface_ids = local.apptier_dual_nics ? (
-    [azurerm_network_interface.app[count.index].id, azurerm_network_interface.app_admin[count.index].id]) : (
+    local.legacy_order ? (
+      [azurerm_network_interface.app_admin[count.index].id, azurerm_network_interface.app[count.index].id]) : (
+      [azurerm_network_interface.app[count.index].id, azurerm_network_interface.app_admin[count.index].id]
+    )
+    ) : (
     [azurerm_network_interface.app[count.index].id]
   )
 

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-app.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-app.tf
@@ -70,7 +70,7 @@ resource "azurerm_linux_virtual_machine" "app" {
   null)
 
   network_interface_ids = local.apptier_dual_nics ? (
-    local.legacy_order ? (
+    local.legacy_nic_order ? (
       [azurerm_network_interface.app_admin[count.index].id, azurerm_network_interface.app[count.index].id]) : (
       [azurerm_network_interface.app[count.index].id, azurerm_network_interface.app_admin[count.index].id]
     )
@@ -161,7 +161,7 @@ resource "azurerm_windows_virtual_machine" "app" {
   null)
 
   network_interface_ids = local.apptier_dual_nics ? (
-    local.legacy_order ? (
+    local.legacy_nic_order ? (
       [azurerm_network_interface.app_admin[count.index].id, azurerm_network_interface.app[count.index].id]) : (
       [azurerm_network_interface.app[count.index].id, azurerm_network_interface.app_admin[count.index].id]
     )

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-scs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-scs.tf
@@ -78,7 +78,7 @@ resource "azurerm_linux_virtual_machine" "scs" {
   )
 
   network_interface_ids = local.apptier_dual_nics ? (
-    local.legacy_order ? (
+    local.legacy_nic_order ? (
       [azurerm_network_interface.scs_admin[count.index].id, azurerm_network_interface.scs[count.index].id]) : (
       [azurerm_network_interface.scs[count.index].id, azurerm_network_interface.scs_admin[count.index].id]
     )
@@ -169,7 +169,7 @@ resource "azurerm_windows_virtual_machine" "scs" {
   )
 
   network_interface_ids = local.apptier_dual_nics ? (
-    local.legacy_order ? (
+    local.legacy_nic_order ? (
       [azurerm_network_interface.scs_admin[count.index].id, azurerm_network_interface.scs[count.index].id]) : (
       [azurerm_network_interface.scs[count.index].id, azurerm_network_interface.scs_admin[count.index].id]
     )

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-scs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-scs.tf
@@ -78,13 +78,17 @@ resource "azurerm_linux_virtual_machine" "scs" {
   )
 
   network_interface_ids = local.apptier_dual_nics ? (
-    [azurerm_network_interface.scs[count.index].id, azurerm_network_interface.scs_admin[count.index].id]) : (
+    local.legacy_order ? (
+      [azurerm_network_interface.scs_admin[count.index].id, azurerm_network_interface.scs[count.index].id]) : (
+      [azurerm_network_interface.scs[count.index].id, azurerm_network_interface.scs_admin[count.index].id]
+    )
+    ) : (
     [azurerm_network_interface.scs[count.index].id]
   )
 
   size                            = local.scs_sizing.compute.vm_size
   admin_username                  = var.sid_username
-  disable_password_authentication = ! local.enable_auth_password
+  disable_password_authentication = !local.enable_auth_password
   admin_password                  = local.enable_auth_key ? null : var.sid_password
 
   dynamic "os_disk" {
@@ -165,9 +169,14 @@ resource "azurerm_windows_virtual_machine" "scs" {
   )
 
   network_interface_ids = local.apptier_dual_nics ? (
-    [azurerm_network_interface.scs[count.index].id, azurerm_network_interface.scs_admin[count.index].id]) : (
+    local.legacy_order ? (
+      [azurerm_network_interface.scs_admin[count.index].id, azurerm_network_interface.scs[count.index].id]) : (
+      [azurerm_network_interface.scs[count.index].id, azurerm_network_interface.scs_admin[count.index].id]
+    )
+    ) : (
     [azurerm_network_interface.scs[count.index].id]
   )
+
 
   size           = local.scs_sizing.compute.vm_size
   admin_username = var.sid_username

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-webdisp.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-webdisp.tf
@@ -64,7 +64,7 @@ resource "azurerm_linux_virtual_machine" "web" {
   )
 
   network_interface_ids = local.apptier_dual_nics ? (
-    local.legacy_order ? (
+    local.legacy_nic_order ? (
       [azurerm_network_interface.web_admin[count.index].id, azurerm_network_interface.web[count.index].id]) : (
       [azurerm_network_interface.web[count.index].id, azurerm_network_interface.web_admin[count.index].id]
     )
@@ -154,7 +154,7 @@ resource "azurerm_windows_virtual_machine" "web" {
   )
 
   network_interface_ids = local.apptier_dual_nics ? (
-    local.legacy_order ? (
+    local.legacy_nic_order ? (
       [azurerm_network_interface.web_admin[count.index].id, azurerm_network_interface.web[count.index].id]) : (
       [azurerm_network_interface.web[count.index].id, azurerm_network_interface.web_admin[count.index].id]
     )

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-webdisp.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-webdisp.tf
@@ -64,13 +64,17 @@ resource "azurerm_linux_virtual_machine" "web" {
   )
 
   network_interface_ids = local.apptier_dual_nics ? (
-    [azurerm_network_interface.web[count.index].id, azurerm_network_interface.web_admin[count.index].id]) : (
+    local.legacy_order ? (
+      [azurerm_network_interface.web_admin[count.index].id, azurerm_network_interface.web[count.index].id]) : (
+      [azurerm_network_interface.web[count.index].id, azurerm_network_interface.web_admin[count.index].id]
+    )
+    ) : (
     [azurerm_network_interface.web[count.index].id]
   )
 
   size                            = local.web_sizing.compute.vm_size
   admin_username                  = var.sid_username
-  disable_password_authentication = ! local.enable_auth_password
+  disable_password_authentication = !local.enable_auth_password
   admin_password                  = local.enable_auth_key ? null : var.sid_password
 
   dynamic "os_disk" {
@@ -150,7 +154,11 @@ resource "azurerm_windows_virtual_machine" "web" {
   )
 
   network_interface_ids = local.apptier_dual_nics ? (
-    [azurerm_network_interface.web[count.index].id, azurerm_network_interface.web_admin[count.index].id]) : (
+    local.legacy_order ? (
+      [azurerm_network_interface.web_admin[count.index].id, azurerm_network_interface.web[count.index].id]) : (
+      [azurerm_network_interface.web[count.index].id, azurerm_network_interface.web_admin[count.index].id]
+    )
+    ) : (
     [azurerm_network_interface.web[count.index].id]
   )
 


### PR DESCRIPTION
## Problem
Changing the NIC order is a service impacting event, however the new NIC order is preferable to the old one

## Solution
Add a parameter in the option block "legacy_nic_order" when set to true retains the old order. Default is false

## Tests
<Please provide steps to test the PR>

## Notes
<Additional comments for the PR>