### PR TITLE
Use the value of ARM_SUBSCRIPTION_ID as sub id

### DIFF
--- a/deploy/scripts/installer.sh
+++ b/deploy/scripts/installer.sh
@@ -151,7 +151,7 @@ else
         ARM_SUBSCRIPTION_ID=$(echo "${temp}" | cut -d= -f2 | tr -d \" | xargs)
     fi
     
-    STATE_SUBSCRIPTION=ARM_SUBSCRIPTION_ID
+    STATE_SUBSCRIPTION=${ARM_SUBSCRIPTION_ID}
     
     temp=$(grep -m1 "tfstate_resource_id" "${system_config_information}")
     if [ ! -z "${temp}" ]


### PR DESCRIPTION
When initialising the STATE_SUBSCRIPTION, use the value of the
ARM_SUBSCRIPTION_ID variable, rather than the variable name, as the
subscription id.

Fixes #1100