### PR TITLE
Update Installer.sh to populate the stdout.az

### DIFF
--- a/deploy/scripts/installer.sh
+++ b/deploy/scripts/installer.sh
@@ -209,7 +209,7 @@ if [ ! -n "${ARM_SUBSCRIPTION_ID}" ]; then
 fi
 
 # Checking for valid az session
-
+az account show > stdout.az 2>&1
 temp=$(grep "az login" stdout.az)
 if [ -n "${temp}" ]; then
     echo ""


### PR DESCRIPTION
added missing, az account show on line#212

## Problem
We validate the existence of a session by checking if az cli command for show accounts works. However, it seems that the line may have been removed causing most of scripts throw an error: ```grep: stdout.az: No such file or directory``` 

## Solution
add the line which creates the stdout.az to the scripts

## Tests


## Notes
