### PR TITLE
Update remover.sh to handle sap_deployer removal

### DIFF
--- a/deploy/scripts/remover.sh
+++ b/deploy/scripts/remover.sh
@@ -197,7 +197,7 @@ if [ ! -n "${DEPLOYMENT_REPO_PATH}" ]; then
 fi
 
 # Checking for valid az session
-
+az account show > stdout.az 2>&1
 temp=$(grep "az login" stdout.az)
 if [ -n "${temp}" ]; then
     echo ""
@@ -270,7 +270,17 @@ echo "#                                                                         
 echo "#########################################################################################"
 echo ""
  
-terraform -chdir="${terraform_module_directory}" destroy -var-file="${var_file}" $tfstate_parameter $landscape_tfstate_key_parameter $deployer_tfstate_key_parameter 
+if [ $deployment_system == sap_deployer ]
+then
+    terraform -chdir="${terraform_module_directory}" destroy -var-file="${var_file}" \
+                $landscape_tfstate_key_parameter \
+                $deployer_tfstate_key_parameter
+else
+    terraform -chdir="${terraform_module_directory}" destroy -var-file="${var_file}" \
+                $tfstate_parameter \
+                $landscape_tfstate_key_parameter \
+                $deployer_tfstate_key_parameter
+fi
 
 if [ $deployment_system == sap_deployer ]
 then


### PR DESCRIPTION
## Problem
remover.sh fails to delete the deployer resources as the module does not have tf_state_resource_id variable. This is essentially not available during bootstrap as the deployer is the first component which is created.

## Solution
The sap_deployer module does not implement the tf_state_resource_id parameter as the deployer state is migrated to azurerm backend after initial provisioning. To prevent this from failing when removing the deployer, we add an IF conditional to control the parameters passed to ```terraform destroy``` command.

Also, fixed a minor issue with az cli session checking logic. When checking for a valid az session, we missed redirecting the output to a file. It just throws an error to screen saying stdout.az not found.

## Tests
When you run the following from the folder containing your deployer json configuration, it should successfully remove the deployer environment.

```bash
$DEPLOYMENT_REPO_PATH/deploy/scripts/remover.sh -p <deployer.json> -t sap_deployer
```

## Notes
🚨 test with caution