### PR TITLE
Fix some ansible issues for roles-os/1.5-disk-setup

### DIFF
--- a/deploy/ansible/roles-os/1.5-disk-setup/tasks/main.yml
+++ b/deploy/ansible/roles-os/1.5-disk-setup/tasks/main.yml
@@ -14,7 +14,7 @@
 
 # -------------------------------------+---------------------------------------8
 #
-# <Comment Header> 
+# <Comment Header>
 #
 # -------------------------------------+---------------------------------------8
 
@@ -52,7 +52,7 @@
   ansible.builtin.ping:
 
 - debug:
-  msg: System {{ inventory_hostname }} has uuid {{ ansible_product_uuid }}
+    msg: System {{ inventory_hostname }} has uuid {{ ansible_product_uuid }}
 
   # Get all the unique disk types from sap-parameters
 # Translate this to JINJA later
@@ -66,49 +66,49 @@
 
 - name: Prepare the disk list
   set_fact:
-    alldisks: "{{ alldisks|default([]) +  [ { 'type': item.type, 'vg' : 'vg_'+ item.type, 'pvs' :  '/dev/disk/azure/scsi1/lun' + item.LUN } ] }}"
+    alldisks: "{{ alldisks|default([]) +  [ { 'type': item.type, 'vg' : 'vg_' ~ item.type, 'pvs' :  '/dev/disk/azure/scsi1/lun' ~ item.LUN } ] }}"
     cacheable: yes
   loop: "{{ disks }}"
   when: item.host == inventory_hostname
 
 - name: Store the data pvs valuas into a list
   set_fact:
-    pvs_data: "{{ (pvs_data|default([]) +  [ '/dev/disk/azure/scsi1/lun' + item.LUN ]) | list}}"
+    pvs_data: "{{ (pvs_data|default([]) +  [ '/dev/disk/azure/scsi1/lun' ~ item.LUN ]) | list}}"
     cacheable: yes
   loop: "{{ disks }}"
   when: item.type == 'data' and item.host == inventory_hostname
-  
+
 - name: Convert the data pvs list to a string
   set_fact:
-    pvs_data_str: "{{ pvs_data | join(',') }}"    
+    pvs_data_str: "{{ pvs_data | default([]) | join(',') }}"
     cacheable: yes
 
 # Log volume
 
 - name: Store the log pvs valuas into a list
   set_fact:
-    pvs_log: "{{ (pvs_log|default([]) +  [ '/dev/disk/azure/scsi1/lun' + item.LUN ]) | list}}"
+    pvs_log: "{{ (pvs_log|default([]) +  [ '/dev/disk/azure/scsi1/lun' ~ item.LUN ]) | list}}"
     cacheable: yes
   loop: "{{ disks }}"
   when: item.type == 'log' and item.host == inventory_hostname
-  
+
 - name: Convert the log pvs list to a string
   set_fact:
-    pvs_log_str: "{{ pvs_log | join(',') }}"    
+    pvs_log_str: "{{ pvs_log | default([]) | join(',') }}"
     cacheable: yes
 
 # SAP volume
 
 - name: Store the sap pvs valuas into a list
   set_fact:
-    pvs_sap: "{{ (pvs_sap|default([]) +  [ '/dev/disk/azure/scsi1/lun' + item.LUN ]) | list}}"
+    pvs_sap: "{{ (pvs_sap|default([]) +  [ '/dev/disk/azure/scsi1/lun' ~ item.LUN ]) | list}}"
     cacheable: yes
   loop: "{{ disks }}"
   when: item.type == 'sap' and item.host == inventory_hostname
-  
+
 - name: Convert the sap pvs list to a string
   set_fact:
-    pvs_sap_str: "{{ pvs_sap | join(',') }}"    
+    pvs_sap_str: "{{ pvs_sap | default([]) | join(',') }}"
     cacheable: yes
 
 - name: Create the consolidated variable
@@ -121,5 +121,7 @@
 - lvg:
     vg:     "{{ item.vg }}"
     pvs:    "{{ item.pvs }}"
-    
+
   loop: "{{ LVM_data }}"
+  when:
+    - item.pvs | bool


### PR DESCRIPTION
When I ran the OS setup playbooks this morning using the latest version of the `alfa` branch I hit some error which I fixed up as follows:

  * Indent the msg argument to the debug action
  * Use `~` rather than `+` when combining facts with facts, or
    facts with strings to avoid type incompatibility issues; the
    Jinja2 `~` concatenation operator automatically converts it's
    arguments to strings.
  * Ensure that references to conditionally initialised `pvs_data`,
    `pvs_log` and `pvs_sap` use `default([])` when generating the
    comma joined string from the list, so that an empty string is
    generated rather than an error.
  * Add a condition check for item.pvs being empty (using `| bool`
    yields False for an empty string) when creating VGs so as to
    avoid errors for disk groups that had no items defined in the
    terraform outputs.

Also removed training whitespaces present in the file.