### PR TITLE
Ansible OS roles changes - packages, sudo, timezone

### DIFF
--- a/deploy/ansible/roles-os/1.0-sudoers/tasks/main.yaml
+++ b/deploy/ansible/roles-os/1.0-sudoers/tasks/main.yaml
@@ -1,0 +1,22 @@
+# -----------------------------------------------------------------------------
+#
+# Task: 1.0  - Enable logging for sudo
+#
+# -----------------------------------------------------------------------------
+
+- name: 1.0 - Enable logging for sudo operations
+  blockinfile:
+    path: /etc/sudoers
+    state: present
+    insertafter: 'EOF'
+    validate: visudo -cf %s
+    block: |
+      Defaults logfile="/var/log/sudo.log"
+      Defaults iolog_dir="/var/log/sudo/${user}"
+      Defaults log_input
+#      Additional option to also logo outputs instead of inputs only      
+#      Defaults log_input, log_output
+
+# /*----------------------------------------------------------------------------8
+# |                                    END                                      |
+# +------------------------------------4---------------------------------------*/

--- a/deploy/ansible/roles-os/1.4-packages/tasks/main.yaml
+++ b/deploy/ansible/roles-os/1.4-packages/tasks/main.yaml
@@ -1,15 +1,8 @@
 # /*----------------------------------------------------------------------------8
 # |                                                                            |
-# |                            Package Installation                             |
+# |               Task: 1.4       - Package Installation for OS                |
 # |                                                                            |
 # +------------------------------------4--------------------------------------*/
----
-# -------------------------------------+---------------------------------------8
-#
-# Task: 1.4       - Package Installation for OS
-#
-# TODO: split between OS and sap playbooks
-
 
 - name:             1.4 - Import package list
   include_vars:     os-packages.yaml
@@ -18,18 +11,8 @@
   package:
     name:           "{{ item }}" 
     state:          present
-  loop:             "{{ packages[ansible_os_family|lower] }}"
+  loop:             "{{ packages[ansible_os_family|lower + ansible_distribution_major_version] }}"
 
-# -------------------------------------+---------------------------------------8
-
-
-
-# - name:             "1.4 - Installing OS packages: {{ ansible_os_family|upper }}-{{ ansible_distribution_major_version }}"
-#   include_tasks:    1.4.yaml
-#   when:             ansible_os_family|upper == "REDHAT" or
-#                     ansible_os_family|upper == "SUSE"
-
-...
 # /*----------------------------------------------------------------------------8
 # |                                    END                                      |
-# +------------------------------------4--------------------------------------*/
+# +------------------------------------4---------------------------------------*/

--- a/deploy/ansible/roles-os/1.4-packages/vars/os-packages.yaml
+++ b/deploy/ansible/roles-os/1.4-packages/vars/os-packages.yaml
@@ -1,7 +1,5 @@
----
-
 packages:
-    redhat:
+    redhat7:
       - "@base"
       - gtk2
       - libicu
@@ -29,18 +27,55 @@ packages:
       - net-tools
       - bind-utils
       - chrony
-      - ntp
       - gdisk
       - sg3_utils
       - lvm2
-      - ntpdate
       - numad
       - cifs-utils
 
-    suse: 
+    redhat8:
+      - "@base"
+      - gtk2
+      - libicu
+      - sudo
+      - tcsh
+      - libssh2
+      - expect
+      - cairo
+      - graphviz
+      - iptraf-ng
+      - krb5-workstation
+      - krb5-libs
+      - libpng12
+      - nfs-utils
+      - lm_sensors
+      - rsyslog
+      - openssl
+      - PackageKit-gtk3-module
+      - libcanberra-gtk2
+      - libtool-ltdl
+      - xorg-x11-xauth 
+      - numactl
+      - xfsprogs
+      - net-tools
+      - bind-utils
+      - chrony
+      - gdisk
+      - sg3_utils
+      - lvm2
+      - numad
+      - cifs-utils      
+
+    suse12: 
       - libyui-qt-pkg7
       - glibc
       - systemd
       - tuned
-      - ntp
       - numad
+
+    suse15: 
+      - libyui-qt-pkg11
+      - glibc
+      - systemd
+      - tuned
+      - numad     

--- a/deploy/ansible/roles-os/1.6-timezone/tasks/main.yaml
+++ b/deploy/ansible/roles-os/1.6-timezone/tasks/main.yaml
@@ -1,0 +1,13 @@
+# -----------------------------------------------------------------------------
+#
+# Task: 1.6  - Setting OS timezone
+#
+# -----------------------------------------------------------------------------
+
+- name:             1.6 - Setting OS timezone
+  timezone:
+    name:           America/Los_Angeles               # ToDo: use per system setting from SAP SID yaml, central setting here, override ifExists from central yaml
+
+# /*----------------------------------------------------------------------------8
+# |                                    END                                      |
+# +------------------------------------4---------------------------------------*/

--- a/deploy/ansible/roles-sap-os/2.1-sap-packages/tasks/main.yaml
+++ b/deploy/ansible/roles-sap-os/2.1-sap-packages/tasks/main.yaml
@@ -7,23 +7,16 @@
 # -------------------------------------+---------------------------------------8
 #
 # Task: 2.1       - Package Installation for SAP
-#
-# TODO: split between OS and sap playbooks
-
 
 - name:             2.1 - Import package list
   include_vars:     sap-packages.yaml
 
-- name:             "2.1 - Install OS packages fro SAP: {{ ansible_os_family|upper }}-{{ ansible_distribution_major_version }}"
+- name:             "2.1 - Install OS packages for SAP: {{ ansible_os_family|upper }}-{{ ansible_distribution_major_version }}"
   package:
     name:           "{{ item }}" 
     state:          present
   loop:             "{{ packages[ansible_os_family|lower] }}"
 
-# -------------------------------------+---------------------------------------8
-
-
-...
 # /*----------------------------------------------------------------------------8
 # |                                    END                                      |
 # +------------------------------------4--------------------------------------*/

--- a/deploy/ansible/roles-sap-os/2.1-sap-packages/vars/sap-packages.yaml
+++ b/deploy/ansible/roles-sap-os/2.1-sap-packages/vars/sap-packages.yaml
@@ -2,14 +2,17 @@
 
 packages:
     redhat:
-      - tuned-profiles-sap-hana
-      - compat-sap-c++-5                # TODO:
-      - compat-sap-c++-9                # TODO:
-      - libatomic                       # TODO:
+      - tuned-profiles-sap*
+      - compat-sap-c++-*                
+      - libatomic                     
+      - uuidd
+      - csh
 
     suse: 
       - sapconf
       - saptune
-      - libgcc_s1                       # TODO:
-      - libstdc++6                      # TODO:
-      - libatomic1                      # TODO:
+      - libgcc_s1  
+      - libstdc++6 
+      - libatomic1 
+      - uuidd
+


### PR DESCRIPTION
Ansible OS packages
- 1.0 sudoers - new, sets logging for sudo
- 1.4 packages - removed ntp*
                        - changed to OS-major version as RHEL8/SLES15 have differences (e.g. xulrunner is no longer deliverd for RHEL8)
- 1.6 timezone - simple role that adds static/global timezone
- 2.1 SAP OS packages - added uuidd
                                     - changed package list to include placeholders (compat-sap-*) for all 5 versions and more in future      