### PR TITLE
Update Ansible swap space configuration

### DIFF
--- a/deploy/ansible/roles-os/1.1-swap/tasks/configure.yaml
+++ b/deploy/ansible/roles-os/1.1-swap/tasks/configure.yaml
@@ -1,11 +1,23 @@
 ---
 
-- name:         "Ensure Resource disk is mounted"
+- name:         "Ensure /mnt/resource directory exists"
+  file:
+    path:       "/mnt/resource"
+    state:      directory
+    mode:       "0755"
+
+- name:         "validate /mnt/resource directory exists"
+  stat:
+    path:       "/mnt/resource"
+  register:   swapfsdata
+
+- name:         "Ensure Resource disk is formatted if it is not formatted"
   lineinfile:
     state:      present
     dest:       /etc/waagent.conf
     regexp:     'ResourceDisk.Format='
     line:       'ResourceDisk.Format=y'
+  when: swapfsdata.stat.exists and swapfsdata.stat.isdir
 
 - name:         "Ensure swap is enabled"
   lineinfile:
@@ -13,13 +25,15 @@
     dest:       /etc/waagent.conf
     regexp:     'ResourceDisk.EnableSwap='
     line:       'ResourceDisk.EnableSwap=y'
+  when: swapfsdata.stat.exists and swapfsdata.stat.isdir
 
 - name:         "Ensure swapfile size"
   lineinfile:
     state:      present
     dest:       /etc/waagent.conf
     regexp:     'ResourceDisk.SwapSizeMB='
-    line:       'ResourceDisk.SwapSizeMB={{ item.swap_size_mb }}'
+    line:       'ResourceDisk.SwapSizeMB={{ item.swap_size_mb | default(2052) }}'
+  when: swapfsdata.stat.exists and swapfsdata.stat.isdir
 
 - name:         "Ensure waagent is restarted"
   service:

--- a/deploy/ansible/roles-os/1.1-swap/tasks/main.yaml
+++ b/deploy/ansible/roles-os/1.1-swap/tasks/main.yaml
@@ -13,6 +13,7 @@
 # TODO: 20210127 Review
 #       1) This could be written to be more efficient
 #       2) waagent config should not run on Baremetal
+#          -Update: I have assumed that the tier for Baremetal is going to be named "HLI"
 
 - name: Ensure variables are available
   include_vars:
@@ -20,6 +21,6 @@
 
 - include_tasks: configure.yaml
   loop: "{{ sap_swap }}"
-  when: item.tier == "all" or item.tier == tier
+  when: (item.tier != "HLI") and (item.tier == "all" or item.tier == tier)
 
 ...


### PR DESCRIPTION
## Problem
Re-write old ansible swap configuration 

## Solution
##Update Ansible swap space configuration
- updated the swap configuration section
    - create  directory /mnt/resource if not exists
    - validate if the directory /mnt/resource is available
    - if /mnt/resource is available
        - make changes to waagent.conf file to accommodate swap settings
        - restart waagent service

## Tests
1. Run ```${DEPLOYMENT_REPO_PATH}deploy/ansible/test_menu.sh```
2. On-prompt: ```Please select playbook: ```, select 1
3. If you want to manually validate, you should be able to ```ssh``` into the configured VM to the following:
   - check swap space ( ```free -m``` ) and 
   - restart time for waagent service ( ```systemctl status waagent | grep "Active:" ``` )


## Notes
⚠️ **I have assumed that the tier for Baremetal is going to be named "HLI"**