### PR TITLE
Avoid quoting argument entries that could be empty strings

### DIFF
--- a/deploy/scripts/install_deployer.sh
+++ b/deploy/scripts/install_deployer.sh
@@ -260,7 +260,7 @@ echo "#                                                                         
 echo "#########################################################################################"
 echo ""
 
-terraform -chdir="${terraform_module_directory}"  apply "${approve}" -var-file="${var_file}" 2>error.log
+terraform -chdir="${terraform_module_directory}"  apply ${approve} -var-file="${var_file}" 2>error.log
 str1=$(grep "Error: " error.log)
 if [ -n "${str1}" ]
 then

--- a/deploy/scripts/installer.sh
+++ b/deploy/scripts/installer.sh
@@ -649,7 +649,7 @@ if [ $ok_to_proceed ]; then
     allParams=$(printf " -var-file=%s %s %s %s %s" "${var_file}" "${extra_vars}" "${tfstate_parameter}" "${landscape_tfstate_key_parameter}" "${deployer_tfstate_key_parameter}")
 
     
-    terraform -chdir="${terraform_module_directory}" apply "${approve}" $allParams  2>error.log
+    terraform -chdir="${terraform_module_directory}" apply ${approve} $allParams  2>error.log
  
     str1=$(grep "Error: " error.log)
     if [ -n "${str1}" ]


### PR DESCRIPTION
When constructing argument lists for shell command lines avoid quoting
any entries that may be empty as otherwise you can create an empty
argument, i.e. '', in the argument list that likely will not be handled
appropriately.