### PR TITLE
Call get-sshkey.sh appropriately

### DIFF
--- a/deploy/ansible/test_menu.sh
+++ b/deploy/ansible/test_menu.sh
@@ -33,7 +33,7 @@
 
 export           ANSIBLE_HOST_KEY_CHECKING=False
 
-./get-sshkey.sh
+bash ${DEPLOYMENT_REPO_PATH}deploy/ansible/get-sshkey.sh
 
 PS3='Please select playbook: '
 options=(                           \


### PR DESCRIPTION
When running the test_menu.sh script from the ansible_config_files
directory in a SYSTEM area for the first time the SSH keys won't
exist, and you need get-sshkey.sh to retrieve them. However the
test_menu.sh script is not specifying the correct path to find the
get-sshkey.sh script, and the script itself is not marked as being
executable so we need to fix test_menu.sh use bash to call it with
the correct path.