### PR TITLE
Re-work 1.4-packages to add tier and state fields

### DIFF
--- a/deploy/ansible/playbook_01_os_base_config.yaml
+++ b/deploy/ansible/playbook_01_os_base_config.yaml
@@ -37,6 +37,10 @@
 #
 # -------------------------------------+---------------------------------------8
 
+  # Specify the active tier for this playbook run
+  - set_fact:
+      tier:     os
+
   - include_role:
       name:     roles-os/1.1-swap
 

--- a/deploy/ansible/roles-os/1.4-packages/defaults/main.yml
+++ b/deploy/ansible/roles-os/1.4-packages/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+# TODO: Maybe move these to a group_vars/all/distro file so that they
+# can be shared by all playbooks/tasks automatically, and extend with
+# standardised versions of all similar patterns used in the playbooks.
+distro_name: "{{ ansible_os_family|upper }}-{{ ansible_distribution_major_version }}"
+distro_id: "{{ ansible_os_family|lower ~ ansible_distribution_major_version }}"

--- a/deploy/ansible/roles-os/1.4-packages/tasks/main.yaml
+++ b/deploy/ansible/roles-os/1.4-packages/tasks/main.yaml
@@ -1,4 +1,5 @@
-# /*----------------------------------------------------------------------------8
+---
+# /*---------------------------------------------------------------------------8
 # |                                                                            |
 # |               Task: 1.4       - Package Installation for OS                |
 # |                                                                            |
@@ -7,11 +8,36 @@
 - name:             1.4 - Import package list
   include_vars:     os-packages.yaml
 
-- name:             "1.4 - Install OS packages: {{ ansible_os_family|upper }}-{{ ansible_distribution_major_version }}"
+# Analyse the package list for this distribution selecting only those
+# packages assigned to the active tier or 'all'.
+- name:             Determine packages appropriate for tier
+  set_fact:
+    packages_for_tier: "{{ packages[distro_id] |
+                           selectattr('tier', 'in', ['all', tier]) |
+                           list }}"
+
+# Print list of matching packages if verbosity it 1 or greater
+- debug:
+    var: packages_for_tier
+    verbosity: 1
+
+# Extract the list of package names whose state match the specified value and
+# pass them as the argument to the name parameter; this is the recommended
+# approach as it only calls the underlying distro specific package manager
+# once per state value.
+# TODO: Do we want to remap 'present' to 'latest' to install latest version
+# for packages that may not be up-to-date?
+- name:             "1.4 - Update OS packages: {{ distro_name }}"
   package:
-    name:           "{{ item }}" 
-    state:          present
-  loop:             "{{ packages[ansible_os_family|lower + ansible_distribution_major_version] }}"
+    name:           "{{ packages_for_tier |
+                        selectattr('state', 'equalto', item.state) |
+                        map(attribute='package') |
+                        list }}"
+    state:          "{{ item.state }}"
+  loop:
+    - { state: 'present' }  # First install required packages
+    - { state: 'absent' }   # Then remove packages that we don't want
+
 
 # /*----------------------------------------------------------------------------8
 # |                                    END                                      |

--- a/deploy/ansible/roles-os/1.4-packages/vars/os-packages.yaml
+++ b/deploy/ansible/roles-os/1.4-packages/vars/os-packages.yaml
@@ -1,81 +1,95 @@
+---
+# /*---------------------------------------------------------------------------8
+# |                                                                            |
+# |               Task: 1.4       - Package lists per OS                       |
+# |                                                                            |
+# +------------------------------------4--------------------------------------*/
+
+# For each supported 'distro_id' we want a list of dictionary entries that
+# specify the associated tier (or 'all' to always match), the package name,
+# and whether we want the package to be installed (present) or removed
+# (absent). See the definition of 'distro_id' to determine what to use when
+# creating an entry for a new distribution.
 packages:
     redhat7:
-      - "@base"
-      - gtk2
-      - libicu
-      - xulrunner
-      - sudo
-      - tcsh
-      - libssh2
-      - expect
-      - cairo
-      - graphviz
-      - iptraf-ng
-      - krb5-workstation
-      - krb5-libs
-      - libpng12
-      - nfs-utils
-      - lm_sensors
-      - rsyslog
-      - openssl
-      - PackageKit-gtk3-module
-      - libcanberra-gtk2
-      - libtool-ltdl
-      - xorg-x11-xauth 
-      - numactl
-      - xfsprogs
-      - net-tools
-      - bind-utils
-      - chrony
-      - gdisk
-      - sg3_utils
-      - lvm2
-      - numad
-      - cifs-utils
+      - { tier: 'os', package: '@base',                  state: 'present' }
+      - { tier: 'os', package: 'gtk2',                   state: 'present' }
+      - { tier: 'os', package: 'libicu',                 state: 'present' }
+      - { tier: 'os', package: 'xulrunner',              state: 'present' }
+      - { tier: 'os', package: 'sudo',                   state: 'present' }
+      - { tier: 'os', package: 'tcsh',                   state: 'present' }
+      - { tier: 'os', package: 'libssh2',                state: 'present' }
+      - { tier: 'os', package: 'expect',                 state: 'present' }
+      - { tier: 'os', package: 'cairo',                  state: 'present' }
+      - { tier: 'os', package: 'graphviz',               state: 'present' }
+      - { tier: 'os', package: 'iptraf-ng',              state: 'present' }
+      - { tier: 'os', package: 'krb5-workstation',       state: 'present' }
+      - { tier: 'os', package: 'krb5-libs',              state: 'present' }
+      - { tier: 'os', package: 'libpng12',               state: 'present' }
+      - { tier: 'os', package: 'nfs-utils',              state: 'present' }
+      - { tier: 'os', package: 'lm_sensors',             state: 'present' }
+      - { tier: 'os', package: 'rsyslog',                state: 'present' }
+      - { tier: 'os', package: 'openssl',                state: 'present' }
+      - { tier: 'os', package: 'PackageKit-gtk3-module', state: 'present' }
+      - { tier: 'os', package: 'libcanberra-gtk2',       state: 'present' }
+      - { tier: 'os', package: 'libtool-ltdl',           state: 'present' }
+      - { tier: 'os', package: 'xorg-x11-xauth',         state: 'present' }
+      - { tier: 'os', package: 'numactl',                state: 'present' }
+      - { tier: 'os', package: 'xfsprogs',               state: 'present' }
+      - { tier: 'os', package: 'net-tools',              state: 'present' }
+      - { tier: 'os', package: 'bind-utils',             state: 'present' }
+      - { tier: 'os', package: 'chrony',                 state: 'present' }
+      - { tier: 'os', package: 'gdisk',                  state: 'present' }
+      - { tier: 'os', package: 'sg3_utils',              state: 'present' }
+      - { tier: 'os', package: 'lvm2',                   state: 'present' }
+      - { tier: 'os', package: 'numad',                  state: 'present' }
+      - { tier: 'os', package: 'cifs-utils',             state: 'present' }
 
     redhat8:
-      - "@base"
-      - gtk2
-      - libicu
-      - sudo
-      - tcsh
-      - libssh2
-      - expect
-      - cairo
-      - graphviz
-      - iptraf-ng
-      - krb5-workstation
-      - krb5-libs
-      - libpng12
-      - nfs-utils
-      - lm_sensors
-      - rsyslog
-      - openssl
-      - PackageKit-gtk3-module
-      - libcanberra-gtk2
-      - libtool-ltdl
-      - xorg-x11-xauth 
-      - numactl
-      - xfsprogs
-      - net-tools
-      - bind-utils
-      - chrony
-      - gdisk
-      - sg3_utils
-      - lvm2
-      - numad
-      - cifs-utils      
+      - { tier: 'os', package: '@base',                  state: 'present' }
+      - { tier: 'os', package: 'gtk2',                   state: 'present' }
+      - { tier: 'os', package: 'libicu',                 state: 'present' }
+      - { tier: 'os', package: 'sudo',                   state: 'present' }
+      - { tier: 'os', package: 'tcsh',                   state: 'present' }
+      - { tier: 'os', package: 'libssh2',                state: 'present' }
+      - { tier: 'os', package: 'expect',                 state: 'present' }
+      - { tier: 'os', package: 'cairo',                  state: 'present' }
+      - { tier: 'os', package: 'graphviz',               state: 'present' }
+      - { tier: 'os', package: 'iptraf-ng',              state: 'present' }
+      - { tier: 'os', package: 'krb5-workstation',       state: 'present' }
+      - { tier: 'os', package: 'krb5-libs',              state: 'present' }
+      - { tier: 'os', package: 'libpng12',               state: 'present' }
+      - { tier: 'os', package: 'nfs-utils',              state: 'present' }
+      - { tier: 'os', package: 'lm_sensors',             state: 'present' }
+      - { tier: 'os', package: 'rsyslog',                state: 'present' }
+      - { tier: 'os', package: 'openssl',                state: 'present' }
+      - { tier: 'os', package: 'PackageKit-gtk3-module', state: 'present' }
+      - { tier: 'os', package: 'libcanberra-gtk2',       state: 'present' }
+      - { tier: 'os', package: 'libtool-ltdl',           state: 'present' }
+      - { tier: 'os', package: 'xorg-x11-xauth',         state: 'present' }
+      - { tier: 'os', package: 'numactl',                state: 'present' }
+      - { tier: 'os', package: 'xfsprogs',               state: 'present' }
+      - { tier: 'os', package: 'net-tools',              state: 'present' }
+      - { tier: 'os', package: 'bind-utils',             state: 'present' }
+      - { tier: 'os', package: 'chrony',                 state: 'present' }
+      - { tier: 'os', package: 'gdisk',                  state: 'present' }
+      - { tier: 'os', package: 'sg3_utils',              state: 'present' }
+      - { tier: 'os', package: 'lvm2',                   state: 'present' }
+      - { tier: 'os', package: 'numad',                  state: 'present' }
+      - { tier: 'os', package: 'cifs-utils',             state: 'present' }
 
-    suse12: 
-      - libyui-qt-pkg7
-      - glibc
-      - systemd
-      - tuned
-      - numad
+    suse12:
+      - { tier: 'os', package: 'libyui-qt-pkg7', state: 'present' }
+      - { tier: 'os', package: 'glibc',          state: 'present' }
+      - { tier: 'os', package: 'systemd',        state: 'present' }
+      - { tier: 'os', package: 'tuned',          state: 'present' }
+      - { tier: 'os', package: 'numad',          state: 'present' }
+      - { tier: 'os', package: 'ntp',            state: 'absent' }
 
-    suse15: 
-      - libyui-qt-pkg11
-      - glibc
-      - systemd
-      - tuned
-      - numad     
+    suse15:
+      - { tier: 'os', package: 'libyui-qt-pkg11', state: 'present' }
+      - { tier: 'os', package: 'glibc',           state: 'present' }
+      - { tier: 'os', package: 'systemd',         state: 'present' }
+      - { tier: 'os', package: 'tuned',           state: 'present' }
+      - { tier: 'os', package: 'numad',           state: 'present' }
+      - { tier: 'os', package: 'ntp',             state: 'absent' }

--- a/deploy/ansible/test_menu.sh
+++ b/deploy/ansible/test_menu.sh
@@ -76,11 +76,12 @@ do
 #       1) Make SID in inventory file name a parameter.
 #       2) Convert file extension to yaml.
 #       3) Find more secure way to handle the ssh private key so it is not exposed.
-        ansible-playbook                                                                                                \
+        ansible-playbook                                                                  \
           --inventory   X00_hosts.yaml                                                    \
           --user        azureadm                                                          \
           --private-key sshkey                                                            \
           --extra-vars="@sap-parameters.yaml"                                             \
+	  "${@}"                                                                          \
           ~/Azure_SAP_Automated_Deployment/sap-hana/deploy/ansible/${playbook}
           break
 done


### PR DESCRIPTION
By updating the package list specification to specify the target tier as
well as the desired state (present or absent) this allows us to specify
both packages we want installed, as well as packages we want removed,
for a given target tier. Note that an 'all' tier entry will always be
considered a match for the active target tier.

When calling the package module we extract the matching list of packages
for a given state into a list to be passed as the name parameter per the
recommended calling pattern; this minimises the calls to the underlying
package manager.

Add definitions for 'distro_name' and 'distro_id' to the 1.4-packages
role defaults to make it easier to read the code.
NOTE: This is an example of the sort of definitions that it is useful
to include in a group_vars/all file, making then available to every
playbook, role, and task without having to specify them or explicitly
include them.

Add target tier specification to the top level playbook associated with
the roles-os roles.

Add support to test_menu.sh to pass any arguments specified when running
it as additional arguments when calling ansible-playbook. For example
this allows verbosity control for the running ansible playbook.
