### PR TITLE
Generate an ansible.cfg in ansible_config_files.

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_system/output_files/ansible.cfg.tmpl
+++ b/deploy/terraform/terraform-units/modules/sap_system/output_files/ansible.cfg.tmpl
@@ -1,0 +1,19 @@
+[defaults]
+# Ref: https://docs.ansible.com/ansible/2.9/reference_appendices/interpreter_discovery.html
+# Silence warnings about Python interpreter discovery
+interpreter_python = auto_silent
+
+# Ref: https://docs.ansible.com/ansible/2.9/plugins/callback/default.html
+# Don't show skipped tasks
+display_skipped_hosts = no
+
+# Ref: https://docs.ansible.com/ansible/2.9/reference_appendices/config.html#default-callback-whitelist
+# Show per-task profiling info and also a summary of longest
+# running tasks at end of playbook run
+callback_whitelist = profile_tasks
+
+[callback_profile_tasks]
+# Ref: https://docs.ansible.com/ansible/2.9/plugins/callback/profile_tasks.html
+# Commented out defaults below
+#task_output_limit = 20
+#sort_order = descending

--- a/deploy/terraform/terraform-units/modules/sap_system/output_files/inventory.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/output_files/inventory.tf
@@ -213,3 +213,10 @@ resource "azurerm_storage_blob" "hosts_yaml" {
   source                 = local_file.ansible_inventory_new_yml.filename
 }
 
+resource "local_file" "ansible_cfg" {
+  content = templatefile(format("%s/ansible.cfg.tmpl", path.module), {})
+  filename             = format("%s/ansible_config_files/ansible.cfg", path.cwd)
+  file_permission      = "0660"
+  directory_permission = "0770"
+}
+


### PR DESCRIPTION
Add support to the terraform ansible_config_files setup to generate
an ansible.cfg file that:

  * silences the Python interpreter discovery warning by setting
    `interpreter_python` to forward compatible `auto_silent` mode.

  * enables the profile_tasks callback, which generates profile data
    for tasks, and a table at the end of the run showing the longest
    running tasks.

  * disables showing task entries for skipped tasks.

These settings are a good staring point for both "quietening" the
rather verbose output from ansible playbook runs as well as showing
useful timing information. You can even quieten the outpit for "Ok"
tasks, i.e. ones for which no changes were made to further reduce
output.

Per https://docs.ansible.com/ansible/2.9/reference_appendices/config.html
the ansible-playbook command will look for Ansible config settings
in the following locations:
  * a file specified by the env var 'ANSIBLE_CONFIG'
  * a file called 'ansible.cfg' in the current directory
  * a file called '.ansible.cfg' in the user's home directory
  * /etc/ansible/ansible.cfg

Since we will be running the ansible-playbook commands (either
directly, or via utility scripts like 'test_menu.sh') from the
generated 'ansible_config_files' directory, it seems to make sense to
generate an 'ansible.cfg' file in that directory.