### PR TITLE
Further cleanup of jq related issues.

### DIFF
--- a/deploy/scripts/deploy_utils.sh
+++ b/deploy/scripts/deploy_utils.sh
@@ -75,3 +75,26 @@ function init() {
     
     
 }
+
+function error_msg {
+    echo "Error!!! ${@}"
+}
+
+function fail_if_null {
+    local var_name="${1}"
+
+    # return immeditaely if no action required
+    if [ "${!var_name}" != "null" ]; then
+        return
+    fi
+
+    shift 1
+
+    if (( $# > 0 )); then
+        error_msg "${@}"
+    else
+        error_msg "Got a null value for '${var_name}'"
+    fi
+
+    exit 1
+}

--- a/deploy/scripts/install_deployer.sh
+++ b/deploy/scripts/install_deployer.sh
@@ -98,8 +98,8 @@ fi
 
 
 # Read environment
-environment=$(cat "${parameterfile}" | jq .infrastructure.environment | tr -d \")
-region=$(cat "${parameterfile}" | jq .infrastructure.region | tr -d \")
+environment=$(jq --raw-output .infrastructure.environment "${parameterfile}")
+region=$(jq --raw-output .infrastructure.region "${parameterfile}")
 key=$(echo "${parameterfile}" | cut -d. -f1)
 
 if [ ! -n "${environment}" ]

--- a/deploy/scripts/prepare_region.sh
+++ b/deploy/scripts/prepare_region.sh
@@ -179,8 +179,8 @@ if [ ! -n "${az}" ]; then
 fi
 
 # Helper variables
-environment=$(jq .infrastructure.environment "${deployer_parameter_file}" | tr -d \")
-region=$(jq .infrastructure.region "${deployer_parameter_file}" | tr -d \")
+environment=$(jq --raw-output .infrastructure.environment "${deployer_parameter_file}")
+region=$(jq --raw-output .infrastructure.region "${deployer_parameter_file}")
 
 if [ ! -n "${environment}" ]
 then
@@ -358,7 +358,7 @@ then
     allParams=$(printf " -p %s %s" "${deployer_file_parametername}" "${approveparam}")
                 
     "${DEPLOYMENT_REPO_PATH}"deploy/scripts/install_deployer.sh $allParams
-    if [ $? -eq 255 ]
+    if (( $? > 0 ))
     then
         exit $?
     fi
@@ -408,7 +408,7 @@ then
             allParams=$(printf " -e %s -r %s -v %s --spn_secret %s " "${environment}" "${region}" "${keyvault}" "${spn_secret}" )
             
             "${DEPLOYMENT_REPO_PATH}"deploy/scripts/set_secrets.sh $allParams
-            if [ $? -eq 255 ]
+            if (( $? > 0 ))
             then
                 exit $?
             fi
@@ -420,7 +420,7 @@ then
                 allParams="${env_param}""${keyvault_param}""${region_param}"
                 
                 "${DEPLOYMENT_REPO_PATH}"deploy/scripts/set_secrets.sh $allParams
-                if [ $? -eq 255 ]
+                if (( $? > 0 ))
                 then
                     exit $?
                 fi
@@ -428,7 +428,10 @@ then
         fi
         
         if [ -f post_deployment.sh ]; then
-            "./post_deployment.sh"
+            ./post_deployment.sh
+            if (( $? > 0 )); then
+                exit $?
+            fi
         fi
         cd "${curdir}" || exit
         step=2
@@ -470,7 +473,7 @@ then
     allParams=$(printf " -p %s -d %s %s" "${library_file_parametername}" "${relative_path}" "${approveparam}")
     
     "${DEPLOYMENT_REPO_PATH}"deploy/scripts/install_library.sh $allParams
-    if [ $? -eq 255 ]
+    if (( $? > 0 ))
     then
         exit $?
     fi
@@ -513,7 +516,7 @@ then
     allParams=$(printf " -p %s -t sap_deployer %s" "${deployer_file_parametername}" "${approveparam}")
     
     "${DEPLOYMENT_REPO_PATH}"deploy/scripts/installer.sh $allParams
-    if [ $? -eq 255 ]
+    if (( $? > 0 ))
     then
         exit $?
     fi
@@ -541,7 +544,7 @@ then
     allParams=$(printf " -p %s -t sap_library %s" "${library_file_parametername}" "${approveparam}")
 
     "${DEPLOYMENT_REPO_PATH}"deploy/scripts/installer.sh $allParams
-    if [ $? -eq 255 ]
+    if (( $? > 0 ))
     then
         exit $?
     fi

--- a/deploy/scripts/remove_region.sh
+++ b/deploy/scripts/remove_region.sh
@@ -147,8 +147,8 @@ if [ ! -n "${az}" ]; then
 fi
 
 # Helper variables
-environment=$(jq .infrastructure.environment "${deployer_parameter_file}" | tr -d \")
-region=$(jq .infrastructure.region "${deployer_parameter_file}" | tr -d \")
+environment=$(jq --raw-output .infrastructure.environment "${deployer_parameter_file}")
+region=$(jq --raw-output .infrastructure.region "${deployer_parameter_file}")
 key=$(echo "${deployer_parameter_file}" | cut -d. -f1)
 
 if [ ! -n "${environment}" ]

--- a/deploy/scripts/remover.sh
+++ b/deploy/scripts/remover.sh
@@ -134,8 +134,8 @@ if [ ! -n "${deployment_system}" ]; then
 fi
 
 # Read environment
-environment=$(jq .infrastructure.environment "${parameterfile}" | tr -d \")
-region=$( jq .infrastructure.region "${parameterfile}" | tr -d \")
+environment=$(jq --raw-output .infrastructure.environment "${parameterfile}")
+region=$(jq --raw-output .infrastructure.region "${parameterfile}")
 
 if [ ! -n "${environment}" ]; then
     echo "#########################################################################################"


### PR DESCRIPTION
deploy_utils.sh
===============
Add fail_if_null() function that can be used to fail if a specified
variable that was initialised with the result of a jq query has the
value 'null', which happens when you query an non-existent entry.

Add error_msg() function that can be used to report error messages
in a consistent fashion.

TODO:
  * Moved colourised message support into deploy_utils.sh and have
    error_msg() output errors in red.

validate.sh
===========
The validate.sh script's usage of jq doesn't correctly handle the
case where we get a 'null' back when attempting to lookup an invalid
reference.

Additionally in a number of cases the checks for values being set in
the config files appear to have been mistakenly inverted, checking for
retrieve values being an empty, rather than non-empty, string. This
seems to have "worked" previously due to the the 'null' value being
returned, and thus the inverted check appeared to do the right thing.

Additionally I added support for tracking if errors occurred during
the validating checking, allowing the validate.sh command to exit
with a non-zero exit status indicating failure.  The error() function
makes this easy to manage as well as printing the error message in
bold red text.

The new heading() function prints headings in cyan with a following
line of '-' characters in a consistent fashion, with consistent
formatting/layout.

Fixed a whitespace issue in the indentation of the displayed subnet
address range for the deployer.

TODO:
  * Convert the repeated pattern of code for the subnet processing
    when validating sap_system config files into a routine.
  * Convert the output echo commands to use printf commands with
    format strings the handle the whitespace indentation.

prepare_region.sh
=================
Updates jq queries to use --raw-output and removes post processing
that is no longer required.

Also catch any non-zero exit status, rather than specifically 255,
when calling other scripts and exit out immediately with that exit
status.

install_deployer.sh, remove_region.sh, remover.sh
====================================================================
Updates jq queries to use --raw-output and removes post processing
that is no longer required.

install_library.sh
============
Leverages fail_if_null() to fail when jq queries result in a 'null'
value.

Also updates jq queries to use --raw-output and removes the post
processing that is no longer required.

installer.sh
============
Ensire that if we get a 'null' back when checking for .deployer.use
that we treat it as a false.

Leverages fail_if_null() to fail when jq queries result in a 'null'
value.

Also updates jq queries to use --raw-output and removes the post
processing that is no longer required.

Also quotes all jq query strings that contain shell pattern match
characters to avoid potential for side effects.

install_workloadzone.sh
=======================
Simplifies and logically fixes some if conditions to simply check
for values being empty or non-empty value, rather than a negated
non-empty or empty value, respectively. In some cases we were
checking if a value was non-empty, and if so dynamically retrieved
the correct value again.

Leverages fail_if_null() to fail when jq queries result in a 'null'
value.

Also updates jq queries to use --raw-output and removes the post
processing that is no longer required.

Also quotes all jq query strings that contain shell pattern match
characters to avoid potential for side effects.deploy_utils.sh
===============
Add fail_if_null() function that can be used to fail if a specified
variable that was initialised with the result of a jq query has the
value 'null', which happens when you query an non-existent entry.

Add error_msg() function that can be used to report error messages
in a consistent fashion.

TODO:
  * Moved colourised message support into deploy_utils.sh and have
    error_msg() output errors in red.

validate.sh
===========
The validate.sh script's usage of jq doesn't correctly handle the
case where we get a 'null' back when attempting to lookup an invalid
reference.

Additionally in a number of cases the checks for values being set in
the config files appear to have been mistakenly inverted, checking for
retrieve values being an empty, rather than non-empty, string. This
seems to have "worked" previously due to the the 'null' value being
returned, and thus the inverted check appeared to do the right thing.

Additionally I added support for tracking if errors occurred during
the validating checking, allowing the validate.sh command to exit
with a non-zero exit status indicating failure.  The error() function
makes this easy to manage as well as printing the error message in
bold red text.

The new heading() function prints headings in cyan with a following
line of '-' characters in a consistent fashion, with consistent
formatting/layout.

Fixed a whitespace issue in the indentation of the displayed subnet
address range for the deployer.

TODO:
  * Convert the repeated pattern of code for the subnet processing
    when validating sap_system config files into a routine.
  * Convert the output echo commands to use printf commands with
    format strings the handle the whitespace indentation.

install_deployer.sh, prepare_region.sh, remove_region.sh, remover.sh
====================================================================
Updates jq queries to use --raw-output and removes post processing
that is no longer required.

install_library.sh
============
Leverages fail_if_null() to fail when jq queries result in a 'null'
value.

Also updates jq queries to use --raw-output and removes the post
processing that is no longer required.

installer.sh
============
Leverages fail_if_null() to fail when jq queries result in a 'null'
value.

Also updates jq queries to use --raw-output and removes the post
processing that is no longer required.

Also quotes all jq query strings that contain shell pattern match
characters to avoid potential for side effects.

install_workloadzone.sh
=======================
Simplifies and logically fixes some if conditions to simply check
for values being empty or non-empty value, rather than a negated
non-empty or empty value, respectively. In some cases we were
checking if a value was non-empty, and if so dynamically retrieved
the correct value again.

Leverages fail_if_null() to fail when jq queries result in a 'null'
value.

Also updates jq queries to use --raw-output and removes the post
processing that is no longer required.

Also quotes all jq query strings that contain shell pattern match
characters to avoid potential for side effects.