### PR TITLE
Don't report zypper lr repo check command as changed.

### DIFF
--- a/deploy/ansible/roles-os/1.3-repository/tasks/main.yml
+++ b/deploy/ansible/roles-os/1.3-repository/tasks/main.yml
@@ -40,6 +40,10 @@
     # If there are no repos configured zypper lr will fail with rc == 6
     - name:     Check that zypper repos are registered
       command:    zypper lr
+      # command/shell actions always report changed even if they are
+      # not making any changes; we know this command action doesn't
+      # change anything so ensure it doesn't report as changed.
+      changed_when: false
       args:
         warn: false  # quieten warning about using zypper directly
 


### PR DESCRIPTION
Since we are running this command to detect if repos are registered,
and know that it makes no changes, we configure it not to report as
changed, which is the default for command/shell actions.