### PR TITLE
Fix some typos I spotted while trying to use remover.sh

### DIFF
--- a/deploy/scripts/prepare_region.sh
+++ b/deploy/scripts/prepare_region.sh
@@ -274,7 +274,7 @@ if [ ! -n "$ARM_SUBSCRIPTION_ID" ]; then
     echo "#########################################################################################"
     exit 65                                                                                           #data format error
 else
-    if [ "{$arm_config_stored}" != 0 ]
+    if [ "${arm_config_stored}" != 0 ]
     then
         echo "Storing the configuration"
         save_config_var "ARM_SUBSCRIPTION_ID" "${deployer_config_information}"

--- a/deploy/scripts/remover.sh
+++ b/deploy/scripts/remover.sh
@@ -250,7 +250,7 @@ fi
 
 export TF_DATA_DIR="${parameterfile_dirname}"/.terraform
 
-terraform_module_directory="{DEPLOYMENT_REPO_PATH}"/deploy/terraform/run/"${deployment_system}"/
+terraform_module_directory="${DEPLOYMENT_REPO_PATH}"/deploy/terraform/run/"${deployment_system}"/
 
 if [ ! -d "${terraform_module_directory}" ]; then
     printf -v val %-40.40s "$deployment_system"


### PR DESCRIPTION
The remover.sh script was failing due to a missing $ before a variable
dereference.