### PR TITLE
Add further ansible.cfg settings

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_system/output_files/ansible.cfg.tmpl
+++ b/deploy/terraform/terraform-units/modules/sap_system/output_files/ansible.cfg.tmpl
@@ -1,4 +1,7 @@
 [defaults]
+inventory = ${inventory}
+private_key_file = ${private_key_file}
+
 # Ref: https://docs.ansible.com/ansible/2.9/reference_appendices/interpreter_discovery.html
 # Silence warnings about Python interpreter discovery
 interpreter_python = auto_silent

--- a/deploy/terraform/terraform-units/modules/sap_system/output_files/ansible_inventory_new.yml.tmpl
+++ b/deploy/terraform/terraform-units/modules/sap_system/output_files/ansible_inventory_new.yml.tmpl
@@ -4,6 +4,7 @@ ${sid}_DB:
 %{~ for idx,ips_dbnode in ips_dbnodes }
     ${dbnodes[idx].name}:
       ansible_host        : ${ips_dbnode}
+      ansible_user        : ${ansible_user}
       ansible_connection  : ${dbconnection} 
       connection_type     : ${dbconnectiontype} 
 %{~ endfor }
@@ -15,6 +16,7 @@ ${sid}_SCS:
 %{~ for idx,ip_scs in ips_scs }
     ${scsservers[idx]}:
       ansible_host        : ${ip_scs}
+      ansible_user        : ${ansible_user}
       ansible_connection  : ${scsconnection} 
       connection_type     : ${scsconnectiontype} 
 %{~ endfor }
@@ -26,6 +28,7 @@ ${sid}_ERS:
 %{~ for idx,ip_ers in ips_ers }
     ${ersservers[idx]}:
       ansible_host        : ${ip_ers}
+      ansible_user        : ${ansible_user}
       ansible_connection  : ${ersconnection} 
       connection_type     : ${ersconnectiontype} 
 %{~ endfor }
@@ -38,6 +41,7 @@ ${sid}_PAS:
 %{~ for idx,ip_pas in ips_pas }
     ${passervers[idx]}:
       ansible_host        : ${ip_pas}
+      ansible_user        : ${ansible_user}
       ansible_connection  : ${scsconnection} 
       connection_type     : ${scsconnectiontype} 
 
@@ -50,6 +54,7 @@ ${sid}_APP:
 %{~ for idx,ip_app in ips_app }
     ${appservers[idx]}:
       ansible_host        : ${ip_app}
+      ansible_user        : ${ansible_user}
       ansible_connection  : ${appconnection} 
       connection_type     : ${appconnectiontype} 
 
@@ -62,6 +67,7 @@ ${sid}_WEB:
 %{~ for idx,ip_web in ips_web }
     ${webservers[idx]}:
       ansible_host        : ${ip_web}
+      ansible_user        : ${ansible_user}
       ansible_connection  : ${webconnection} 
       connection_type     : ${webconnectiontype} 
 

--- a/deploy/terraform/terraform-units/modules/sap_system/output_files/inventory.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/output_files/inventory.tf
@@ -181,6 +181,7 @@ resource "local_file" "ansible_inventory_new_yml" {
     scsconnectiontype = var.application.auth_type
     ersconnectiontype = var.application.auth_type
     dbconnectiontype  = length(local.hdb_vms) > 0 ? local.hdb_vms[0].auth_type : local.anydb_vms[0].auth_type
+    ansible_user      = local.ansible_user
     }
   )
   filename             = format("%s/ansible_config_files/%s_hosts.yaml", path.cwd, var.hdb_sid)
@@ -214,9 +215,12 @@ resource "azurerm_storage_blob" "hosts_yaml" {
 }
 
 resource "local_file" "ansible_cfg" {
-  content = templatefile(format("%s/ansible.cfg.tmpl", path.module), {})
+  content = templatefile(format("%s/ansible.cfg.tmpl", path.module), {
+    inventory        = local_file.ansible_inventory_new_yml.filename
+    private_key_file = "sshkey",
+    }
+  )
   filename             = format("%s/ansible_config_files/ansible.cfg", path.cwd)
   file_permission      = "0660"
   directory_permission = "0770"
 }
-

--- a/deploy/terraform/terraform-units/modules/sap_system/output_files/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/output_files/variables_local.tf
@@ -117,12 +117,19 @@ variable "scs_ha" {
   default = false
 }
 
+variable "ansible_user" {
+  description = "The ansible remote user account to use"
+  default = "azureadm"
+}
+
 
 locals {
 
   tfstate_resource_id          = try(var.tfstate_resource_id, "")
   tfstate_storage_account_name = split("/", local.tfstate_resource_id)[8]
   ansible_container_name       = try(var.naming.resource_suffixes.ansible, "ansible")
+  # Need to figure out how to leverage common_infrasture's local.sid_auth_username
+  ansible_user                 = try(var.ansible_user, "azureadm")
 
   kv_name = split("/", var.sid_kv_user_id)[8]
 


### PR DESCRIPTION
Configure the default inventory, private_key_file and remote_user
settings so that is not necessary to specify them when running the
ansible-playbook (or ansible) command.

Note that while the private_key_file name will be specified, the
actual file will still need to be downloaded separately.