### PR TITLE
Ensure ~/bin/terraform is preferred terraform command

### DIFF
--- a/documentation/SAP_Automation_on_Azure/Software_Documentation/workshops/manual-infrastructure-deployment/01-bootstrap-deployer.md
+++ b/documentation/SAP_Automation_on_Azure/Software_Documentation/workshops/manual-infrastructure-deployment/01-bootstrap-deployer.md
@@ -80,6 +80,7 @@
      mkdir -p ~/bin; cd $_
      wget  https://releases.hashicorp.com/terraform/0.14.7/terraform_0.14.7_linux_amd64.zip
      unzip terraform_0.14.7_linux_amd64.zip
+     hash terraform
      ```
 
 4. Repository


### PR DESCRIPTION
If you have just created the ~/bin directory, and installed terraform
under it, but there was previously a terraform in a different PATH
directory, you may still end up using that other terraform unless you
force an update of the command hash table.