### PR TITLE
Use cloud-init config to disable growpart

### DIFF
--- a/deploy/terraform/run/sap_system/module.tf
+++ b/deploy/terraform/run/sap_system/module.tf
@@ -47,6 +47,7 @@ module "common_infrastructure" {
   authentication             = var.authentication
   terraform_template_version = var.terraform_template_version
   deployment                 = var.deployment
+
 }
 
 // Create HANA database nodes
@@ -77,6 +78,8 @@ module "hdb_node" {
   db_asg_id                  = module.common_infrastructure.db_asg_id
   terraform_template_version = var.terraform_template_version
   deployment                 = var.deployment
+  cloudinit_disable_growpart = module.common_infrastructure.cloudinit_disable_growpart
+
 }
 
 // Create Application Tier nodes
@@ -108,6 +111,7 @@ module "app_tier" {
   landscape_tfstate          = data.terraform_remote_state.landscape.outputs
   terraform_template_version = var.terraform_template_version
   deployment                 = var.deployment
+  cloudinit_disable_growpart = module.common_infrastructure.cloudinit_disable_growpart
 
 }
 
@@ -138,6 +142,7 @@ module "anydb_node" {
   db_asg_id                  = module.common_infrastructure.db_asg_id
   terraform_template_version = var.terraform_template_version
   deployment                 = var.deployment
+  cloudinit_disable_growpart = module.common_infrastructure.cloudinit_disable_growpart
 
 }
 

--- a/deploy/terraform/terraform-units/modules/sap_landscape/iscsi.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/iscsi.tf
@@ -86,6 +86,8 @@ resource "azurerm_linux_virtual_machine" "iscsi" {
   admin_password                  = local.iscsi_auth_password
   disable_password_authentication = local.enable_iscsi_auth_key
 
+  custom_data = var.cloudinit_disable_growpart
+
   os_disk {
     name                 = format("%s%s%s%s", local.prefix, var.naming.separator, local.virtualmachine_names[count.index], local.resource_suffixes.osdisk)
     caching              = "ReadWrite"

--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/variables_local.tf
@@ -67,6 +67,10 @@ variable "terraform_template_version" {
   description = "The version of Terraform templates that were identified in the state file"
 }
 
+variable "cloudinit_disable_growpart" {
+  description = "A cloud-init config that disables automatic growpart expansion of root partition"
+}
+
 
 locals {
   // Imports database sizing information

--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/vm-anydb.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/vm-anydb.tf
@@ -81,6 +81,8 @@ resource "azurerm_linux_virtual_machine" "dbserver" {
     }
   }
 
+  custom_data = var.cloudinit_disable_growpart
+
   dynamic "os_disk" {
     iterator = disk
     for_each = range(length(local.os_disk))

--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/vm-observer.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/vm-observer.tf
@@ -62,6 +62,8 @@ resource "azurerm_linux_virtual_machine" "observer" {
   ]
   size = local.observer_size
 
+  custom_data = var.cloudinit_disable_growpart
+
   os_disk {
     name                   = format("%s%s%s%s", local.prefix, var.naming.separator, local.observer_virtualmachine_names[count.index], local.resource_suffixes.osdisk)
     caching                = "ReadWrite"

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/variables_local.tf
@@ -80,6 +80,10 @@ variable "terraform_template_version" {
   description = "The version of Terraform templates that were identified in the state file"
 }
 
+variable "cloudinit_disable_growpart" {
+  description = "A cloud-init config that disables automatic growpart expansion of root partition"
+}
+
 
 locals {
   // Imports Disk sizing sizing information

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-app.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-app.tf
@@ -96,6 +96,7 @@ resource "azurerm_linux_virtual_machine" "app" {
     }
   }
 
+  custom_data = var.cloudinit_disable_growpart
 
   dynamic "os_disk" {
     iterator = disk

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-scs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-scs.tf
@@ -103,6 +103,9 @@ resource "azurerm_linux_virtual_machine" "scs" {
       public_key = var.sdu_public_key
     }
   }
+
+  custom_data = var.cloudinit_disable_growpart
+
   dynamic "os_disk" {
     iterator = disk
     for_each = flatten(

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-webdisp.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-webdisp.tf
@@ -90,6 +90,7 @@ resource "azurerm_linux_virtual_machine" "web" {
     }
   }
 
+  custom_data = var.cloudinit_disable_growpart
 
   dynamic "os_disk" {
     iterator = disk

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/infrastructure.tf
@@ -132,3 +132,16 @@ resource "azurerm_application_security_group" "db" {
   location = local.nsg_asg_with_vnet ? (local.vnet_sap_resource_group_location) : (local.rg_exists ? data.azurerm_resource_group.resource_group[0].location : azurerm_resource_group.resource_group[0].location)
 }
 
+// Define a cloud-init config that disables the automatic expansion
+// of the root partition.
+data "template_cloudinit_config" "disable_growpart" {
+  gzip          = true
+  base64_encode = true
+
+  # Main cloud-config configuration file.
+  part {
+    content_type = "text/cloud-config"
+    content      = "growpart: {'mode': 'off'}"
+  }
+}
+

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/outputs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/outputs.tf
@@ -91,3 +91,7 @@ output "db_asg_id" {
 output "use_local_credentials" {
   value = local.use_local_credentials
 }
+
+output "cloudinit_disable_growpart" {
+  value = local.cloudinit_disable_growpart
+}

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/variables_local.tf
@@ -382,3 +382,8 @@ locals {
   service_principal = try(var.service_principal, {})
 
 }
+
+locals {
+  // 'Cg==` is empty string, base64 encoded.
+  cloudinit_disable_growpart = try(data.template_cloudinit_config.disable_growpart.rendered, "Cg==")
+}

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/vm-anchor.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/vm-anchor.tf
@@ -47,6 +47,7 @@ resource "azurerm_linux_virtual_machine" "anchor" {
     }
   }
 
+  custom_data = local.cloudinit_disable_growpart
 
   os_disk {
     name                   = format("%s%s%s%s", local.prefix, var.naming.separator, local.anchor_virtualmachine_names[count.index], local.resource_suffixes.osdisk)

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/variables_local.tf
@@ -74,6 +74,10 @@ variable "terraform_template_version" {
   description = "The version of Terraform templates that were identified in the state file"
 }
 
+variable "cloudinit_disable_growpart" {
+  description = "A cloud-init config that disables automatic growpart expansion of root partition"
+}
+
 
 locals {
   // Resources naming

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/vm-hdb.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/vm-hdb.tf
@@ -138,6 +138,8 @@ resource "azurerm_linux_virtual_machine" "vm_dbnode" {
 
   size = local.hdb_vms[count.index].size
 
+  custom_data = var.cloudinit_disable_growpart
+
   dynamic "os_disk" {
     iterator = disk
     for_each = range(length(local.os_disk))


### PR DESCRIPTION
By defining a cloud-init config that disables running growpart to
expand the root file system we have the option to manage how the
extra space on the OS disk is utilised later.

Currently this is required for SUSE distro images which leverage
cloud-init to handle this automation root filesystem expansion.

A new cloudinit_disable_growpart variable is defined in the
common_infrastructure whose value can be used as the custom_data
attribute when defining a Linux VM. The other relevant modules
have been updated to leverage this variable when being initialised.

All Linux VM definitions, except for the Deployer, have had the
custom_data attribute added to them that leverages this new
cloudinit_disable_growpart value.