### PR TITLE
Add get-sshkey.yaml playbook and update test_menu.sh to use it

### DIFF
--- a/deploy/ansible/get-sshkey.yaml
+++ b/deploy/ansible/get-sshkey.yaml
@@ -1,0 +1,51 @@
+---
+
+# Targets the first node in the all nodes list, but we don't actually
+# run any commands on the node; we just need to reference a node that
+# is specified by the inventory file for the inventory_dir reference
+# to be a valid fact.
+- hosts: all[0]
+  gather_facts: false
+  tags:
+  - always
+  tasks:
+  - name: Load the SAP parameters
+    include_vars: "{{ inventory_dir }}/sap-parameters.yaml"
+
+  - name: Construct SSH key secret name
+    set_fact:
+      secret_name: "{{ secret_prefix }}-sid-sshkey"
+
+  - name: Retrieve SSH Key secret details (locally)
+    command: >-
+      az keyvault secret show
+        --vault-name {{ kv_uri }}
+        --name {{ secret_name }}
+    changed_when: false
+    delegate_to: localhost
+    register: keyvault_secret_show
+    no_log: true
+
+  - name: Extract SSH Key content from secret details
+    set_fact:
+      sshkey_content: >-
+        {{ (keyvault_secret_show.stdout | from_json).value }}
+    no_log: true
+
+  - name: Determine SSH key file name
+    set_fact:
+      sshkey_file: "{{ lookup('env', 'ANSIBLE_PRIVATE_KEY_FILE') | default('sshkey', True) }}"
+
+  - name: Determine SSH key file path
+    set_fact:
+      sshkey_path: >-
+        {{ sshkey_file is abs |
+           ternary(sshkey_file,
+                   (inventory_dir, sshkey_file) | join('/')) }}
+
+  - name: Write out SSH Key content as sshkey file (locally)
+    copy:
+      dest: "{{ sshkey_path }}"
+      content: "{{ sshkey_content }}"
+      mode: "0600"
+    delegate_to: localhost

--- a/deploy/terraform/terraform-units/modules/sap_system/output_files/ansible.cfg.tmpl
+++ b/deploy/terraform/terraform-units/modules/sap_system/output_files/ansible.cfg.tmpl
@@ -1,4 +1,5 @@
 [defaults]
+host_key_checking = false
 inventory = ${inventory}
 private_key_file = ${private_key_file}
 


### PR DESCRIPTION
get-sshkey.yaml
===============
The get-sshkey.yaml playbook runs against the system inventory,
targeting the first member of the all group, but running all it's
actions delegated to localhost; this is required for the ansible
inventory_dir fact to be correctly defined. Currently it uses the
az CLI tool to retrieve the sshkey file content from the key vault
as we don't have all of the required data available to us in the
ansible runtime environment to be able to use the relevent ansible
action modules to access the key vault "natively".

The get-sshkey.yaml playbook is intended to be run as the first
playbook by the ansible-playbook command, before any other others,
to ensure that the sshkey is downloaded and available before we
run any actions that require a functioning SSH connection to a
node.

Note also that we leverage the no_log settings on relevant actions
within the get-sshkey.yaml playbook to avoid any possible "leaks"
of the SSH key content when running with verbosity enabled or if
errors occurs.

test_menu.sh
============
Updated the test_menu.sh to include the get-sshkey.yaml playbook
before the other playbooks when running ansible-playbook.

Added explicit Ansible configuration settings, specified using the
appropriate environment variables, matching those settings that are 
configured in the generated ansible.cfg.

Also eliminated some duplication when specifying and processing the
selections, and added options to run all of the playbooks, or all
of the remaining playbooks after the basic install set of playbooks.

ansible.cfg.tmpl
================
Updated to add the host_key_checking setting to match the Ansible
config settings that are being set in test_menu.sh.
