### PR TITLE
Fix playbook_01 tags enablement

### DIFF
--- a/deploy/ansible/playbook_01_os_base_config.yaml
+++ b/deploy/ansible/playbook_01_os_base_config.yaml
@@ -38,48 +38,57 @@
   - set_fact:
       tier:     os
 
-  - include_role:
-      name:     roles-os/1.0-sudoers
+  - block:
+      - include_role:
+          name:     roles-os/1.0-sudoers
     tags:
       - 1.0-sudoers
 
-  - include_role:
-      name:     roles-os/1.1-swap
+  - block:
+      - include_role:
+          name:     roles-os/1.1-swap
     tags:
       - 1.1-swap
 
-  - include_role:
-      name:     roles-os/1.2-hostname
+  - block:
+      - include_role:
+          name:     roles-os/1.2-hostname
     tags:
       - 1.2-hostname
 
-  - include_role:
-      name:     roles-os/1.5-disk-setup
+  - block:
+      - include_role:
+          name:     roles-os/1.5-disk-setup
     tags:
       - 1.5-disk-setup
 
-  - include_role:
-      name:     roles-os/1.3-repository
+  - block:
+      - include_role:
+          name:     roles-os/1.3-repository
     tags:
       - 1.3-repository
 
-  - include_role:
-      name:     roles-os/1.4-packages
+  - block:
+      - include_role:
+          name:     roles-os/1.4-packages
     tags:
       - 1.4-packages
 
-  - include_role:
-      name:     roles-os/1.7-chrony
+  - block:
+      - include_role:
+          name:     roles-os/1.7-chrony
     tags:
       - 1.7-chrony
 
-  - include_role:
-      name:     roles-os/1.11-accounts
+  - block:
+      - include_role:
+          name:     roles-os/1.11-accounts
     tags:
       - 1.11-accounts
 
-  - include_role:
-      name:     roles-os/1.20-prometheus
+  - block:
+      - include_role:
+          name:     roles-os/1.20-prometheus
     tags:
       - 1.20-prometheus
     when:   prometheus


### PR DESCRIPTION
Previous change just added tags to the include_role actions, but this
approach only works for import_role. For include_role the tags apply
to the include_role statement itself, and not to the included tasks
so unless they also have the same tags configured, or are tagged with
always, they won't be run.
    
To get the desired effect, namely run only the tasks associated with
the included role when the associated task is specified, we need to
specify both a tags list for the include_role, and dynamically apply
the same tags to the included tasks using the apply mechanism. Or
you can wrap the include_role in a block action, with associated
tags, which will apply to both the include_role action and any tasks
that it includes.