### PR TITLE
Ensure SLE 15 SP2 deployments works correctly

### DIFF
--- a/deploy/ansible/roles-os/1.4-packages/vars/os-packages.yaml
+++ b/deploy/ansible/roles-os/1.4-packages/vars/os-packages.yaml
@@ -95,3 +95,8 @@ packages:
       - { tier: 'os', package: 'tuned',           state: 'present' }
       - { tier: 'os', package: 'numad',           state: 'present' }
       - { tier: 'os', package: 'ntp',             state: 'absent' }
+
+      # TODO(rtamalin): Ensure SLE 15 SP2 uses /usr/bin/python3 rather
+      # than /usr/bin/python.
+      # Required to enable ansible to use /usr/bin/python on SLE 15 SP2
+      - { tier: 'os', package: 'python2-rpm',             state: 'present' }


### PR DESCRIPTION
When managing SLE 15 SP2 based images the Ansible automatic Python
interpreter detection process is selecting the /usr/bin/python
interpreter, which is a Python2 version, but the images don't have
all the packages installed for the Python2 stream that are required
to fully support Ansible packaging related operations.

We really should be using the Python3 environment which is already
setup correctly on the SLE 15 SP2 images.

NOTE: It is possible to select the desired Python interpreter using
the ansible_python_interpreter setting, and that would probably be
the better fix in the long run, and would allow this change to be
dropped.