### PR TITLE
Ensure correct IP address used for HDB inventory entries

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_system/output_files/inventory.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/output_files/inventory.tf
@@ -124,7 +124,7 @@ resource "local_file" "ansible_inventory_yml" {
 */
 resource "local_file" "ansible_inventory_new_yml" {
   content = templatefile(format("%s%s", path.module, "/ansible_inventory_new.yml.tmpl"), {
-    ips_dbnodes = length(local.hdb_vms) > 0 ? local.ips_dbnodes_admin : local.ips_anydbnodes,
+    ips_dbnodes = length(local.hdb_vms) > 0 ? local.ips_dbnodes_db : local.ips_anydbnodes,
     dbnodes     = length(local.hdb_vms) > 0 ? local.hdb_vms : local.anydb_vms
     ips_scs = length(local.ips_scs) > 0 ? (
       length(local.ips_scs) > 1 ? (


### PR DESCRIPTION
In recent testing I attempted to bring up a HDB node backed by a RHEL
for SAP Apps image, but was unable to talk to the node using Ansible
via the IP address specified in the terraform generated inventory.

After discussing with the team it was identified that the inventory
was being generated with the "admin" subnet IP address for the HDB
nodes, rather than the correct DB subnet address; this patch corrects
that error.