### PR TITLE
Improve Terraform driven initial deployer setup

### DIFF
--- a/deploy/ansible/test_menu.sh
+++ b/deploy/ansible/test_menu.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+export PATH=/opt/terraform/bin:/opt/ansible/bin:${PATH}
+
 cmd_dir="$(dirname "$(readlink -e "${BASH_SOURCE[0]}")")"
 
 
@@ -53,6 +55,7 @@ sap_sid="$(awk '$1 == "sap_sid:" {print $2}' ${sap_params_file})"
 export           ANSIBLE_HOST_KEY_CHECKING=False
 export           ANSIBLE_INVENTORY="${sap_sid}_hosts.yaml"
 export           ANSIBLE_PRIVATE_KEY_FILE=sshkey
+export           ANSIBLE_COLLECTIONS_PATHS=/opt/ansible/collections${ANSIBLE_COLLECTIONS_PATHS:+${ANSIBLE_COLLECTIONS_PATHS}}
 
 # We really should be determining the user dynamically, or requiring
 # that it be specified in the inventory settings (currently true)

--- a/deploy/ansible/validator_test_menu.sh
+++ b/deploy/ansible/validator_test_menu.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+export PATH=/opt/terraform/bin:/opt/ansible/bin:${PATH}
+
 cmd_dir="$(dirname "$(readlink -e "${BASH_SOURCE[0]}")")"
 
 
@@ -46,6 +48,7 @@ fi
 # entry associated with the specific setting.
 #
 export           ANSIBLE_HOST_KEY_CHECKING=False
+export           ANSIBLE_COLLECTIONS_PATHS=/opt/ansible/collections${ANSIBLE_COLLECTIONS_PATHS:+${ANSIBLE_COLLECTIONS_PATHS}}
 
 # We really should be determining the user dynamically, or requiring
 # that it be specified in the inventory settings (currently true)

--- a/deploy/scripts/deploy_utils.sh
+++ b/deploy/scripts/deploy_utils.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+export PATH=/opt/terraform/bin:/opt/ansible/bin:${PATH}
+
 #########################################################################
 # Helper utilities
 #

--- a/deploy/scripts/validate.sh
+++ b/deploy/scripts/validate.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+export PATH=/opt/terraform/bin:/opt/ansible/bin:${PATH}
+
 exit_status=0
 
 #colors for terminal

--- a/deploy/terraform/terraform-units/modules/sap_deployer/configure-deployer.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/configure-deployer.tf
@@ -19,84 +19,32 @@ resource "null_resource" "prepare-deployer" {
     timeout     = var.ssh-timeout
   }
 
+  provisioner "file" {
+    content = templatefile(format("%s/templates/configure_deployer.sh.tmpl", path.module), {
+      tfversion       = "0.14.7",
+      rg_name         = local.rg_name,
+      client_id       = azurerm_user_assigned_identity.deployer.client_id,
+      subscription_id = data.azurerm_subscription.primary.subscription_id,
+      tenant_id       = data.azurerm_subscription.primary.tenant_id
+      }
+    )
+    destination = "/tmp/configure_deployer.sh"
+  }
+
   provisioner "remote-exec" {
     inline = local.deployers[count.index].os.source_image_id != "" ? [] : [
       //
-      // Prepare folder structure
+      // Set useful shell options
       //
-      "mkdir -p $HOME/Azure_SAP_Automated_Deployment/WORKSPACES/LOCAL/${local.rg_name}",
-      "mkdir $HOME/Azure_SAP_Automated_Deployment/WORKSPACES/LIBRARY",
-      "mkdir $HOME/Azure_SAP_Automated_Deployment/WORKSPACES/SYSTEM",
-      "mkdir $HOME/Azure_SAP_Automated_Deployment/WORKSPACES/LANDSCAPE",
-      "mkdir $HOME/Azure_SAP_Automated_Deployment/WORKSPACES/DEPLOYER",
+      "set -o xtrace",
+      "set -o verbose",
+      "set -o errexit",
+      
       //
-      // Clones project repository
+      // Make configure_deployer.sh executable and run it
       //
-      "git clone https://github.com/Azure/sap-hana.git $HOME/Azure_SAP_Automated_Deployment/sap-hana",
-      //
-      // Install terraform for all users
-      //
-      "sudo apt-get install unzip",
-      "tfversion=",
-      "tfdir=0.14.7",
-      "sudo mkdir -p /opt/terraform/terraform_0.14.7",
-      "sudo mkdir -p /opt/terraform/bin/",
-      "sudo wget -P /opt/terraform/terraform_0.14.7 https://releases.hashicorp.com/terraform/0.14.7/terraform_0.14.7_linux_amd64.zip",
-      "sudo unzip /opt/terraform/terraform_0.14.7/terraform_0.14.7_linux_amd64.zip -d /opt/terraform/terraform_0.14.7/",
-      "sudo ln -s /opt/terraform/terraform_0.14.7/terraform /opt/terraform/bin/terraform",
-      "sudo sh -c \"echo export PATH=$PATH:/opt/terraform/bin > /etc/profile.d/deploy_server.sh\"",
-      //
-      // Set env for MSI
-      //
-      "sudo sh -c \"echo export ARM_USE_MSI=true >> /etc/profile.d/deploy_server.sh\"",
-      "sudo sh -c \"echo export ARM_MSI_ENDPOINT=\"http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01\" >> /etc/profile.d/deploy_server.sh\"",
-      "sudo sh -c \"echo export ARM_CLIENT_ID=${azurerm_user_assigned_identity.deployer.client_id} >> /etc/profile.d/deploy_server.sh\"",
-      "sudo sh -c \"echo export ARM_SUBSCRIPTION_ID=${data.azurerm_subscription.primary.subscription_id} >> /etc/profile.d/deploy_server.sh\"",
-      "sudo sh -c \"echo export ARM_TENANT_ID=${data.azurerm_subscription.primary.tenant_id} >> /etc/profile.d/deploy_server.sh\"",
-      "sudo sh -c \"echo export DEPLOYMENT_REPO_PATH=$HOME/Azure_SAP_Automated_Deployment/sap-hana >> /etc/profile.d/deploy_server.sh\"",
-      "sudo sh -c \"echo az login --identity --output none >> /etc/profile.d/deploy_server.sh\"",
-      //
-      // Set env for ansible
-      //
-      "sudo sh -c \"echo export ANSIBLE_HOST_KEY_CHECKING=False >> /etc/profile.d/deploy_server.sh\"",
-      //
-      // Install az cli
-      //
-      "curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash",
-      "sudo apt update",
-      //
-      // install jq
-      //
-      "sudo apt -y install jq",
-      "sudo pip3 pip install setuptools-rust",
-      //
-      // Install pip
-      //
-      "sudo apt -y install python3-pip",
-      "sudo pip3 install --upgrade pip",
-      "sudo pip3 pip install msal",
-      //
-      // Installs Ansible
-      //
-      "sudo pip3 install \"ansible>=2.9,<2.10\"",
-      "sudo pip3 install ansible[azure]",
-      "sudo -H wget -nv -q https://raw.githubusercontent.com/ansible-collections/azure/dev/requirements-azure.txt",
-      "sudo -H pip3 install -r requirements-azure.txt",
-      "sudo -H ansible-galaxy collection install azure.azcollection --force",
-      //
-      // Install pywinrm
-      //
-      "sudo pip3 install \"pywinrm>=0.3.0\"",
-      //
-      // Install yamllint
-      //
-      "sudo pip3 install yamllint",
-      //
-      // Install ansible-lint
-      //
-      "sudo pip3 install ansible-lint \"ansible>=2.9,<2.10\"",
-      "sudo pip3 install argcomplete",
-      "sudo activate-global-python-argcomplete"
+      "chmod +x /tmp/configure_deployer.sh",
+      "/tmp/configure_deployer.sh"
     ]
   }
 }

--- a/deploy/terraform/terraform-units/modules/sap_deployer/templates/configure_deployer.sh.tmpl
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/templates/configure_deployer.sh.tmpl
@@ -1,0 +1,395 @@
+#!/bin/bash
+
+#
+# configure_deployer.sh
+#
+# This script is intended to perform all the necessary initial
+# setup of a node so that it can act as a deployer for use with
+# Azure SAP Automated Deployment.
+#
+# As part of doing so it will:
+#
+#   * Installs the specifed version of terraform so that it
+#     is available for all users.
+#
+#   * Installs the Azure CLI using the provided installer
+#     script, making it available for all users.
+#
+#   * Create a Python virtualenv, which can be used by all
+#     users, with the specified Ansible version and related
+#     tools, and associated Python dependencies, installed.
+#
+#   * Create a /etc/profile.d file that will setup a users
+#     interactive session appropriately to use these tools.
+#
+# This script does not modify the system's Python environment,
+# instead using a Python virtualenv to host the installed Python
+# packages, meaning that standard system updates can be safely
+# installed.
+#
+# The script can be run again to re-install/update the required
+# tools if needed. Note that doing so will re-generate the
+# /etc/profile.d file, so any local changes will be lost.
+#
+
+#
+# Setup some useful shell options
+#
+
+# Print expanded commands as they are about to be executed
+set -o xtrace
+
+# Print shell input lines as they are read in
+set -o verbose
+
+# Fail if any command exits with a non-zero exit status
+set -o errexit
+
+# Ensure that the exit status of a pipeline command is non-zero if any
+# stage of the pipefile has a non-zero exit status.
+set -o pipefail
+
+# Fail if attempting to access and unset variable or parameter
+set -o nounset
+
+#
+# Terraform templated settings
+#
+rg_name="${rg_name}"
+tfversion="${tfversion}"
+client_id="${client_id}"
+subscription_id="${subscription_id}"
+tenant_id="${tenant_id}"
+
+#
+# Ansible Version settings
+#
+ansible_version="$${ansible_version:-2.9}"
+ansible_major="$${ansible_version%%.*}"
+ansible_minor=$(echo "$${ansible_version}." | cut -d . -f 2)
+
+#
+# Utility Functions
+#
+distro_name=""
+distro_version=""
+distro_name_version=""
+error()
+{
+    echo 1>&2 "ERROR: $${@}"
+}
+
+get_distro_name()
+{
+    typeset -g distro_name
+
+    if [[ -z "$${distro_name:-}" ]]; then
+        distro_name="$(. /etc/os-release; echo "$${ID,,}")"
+    fi
+
+    echo "$${distro_name}"
+}
+
+get_distro_version()
+{
+    typeset -g distro_version
+
+    if [[ -z "$${distro_version:-}" ]]; then
+        distro_version="$(. /etc/os-release; echo "$${VERSION_ID,,}")"
+    fi
+
+    echo "$${distro_version}"
+}
+
+get_distro_name_version()
+{
+    typeset -g distro_name_version
+
+    if [[ -z "$${distro_name_version:-}" ]]; then
+        distro_name_version="$(get_distro_name)_$(get_distro_version)"
+    fi
+
+    echo "$${distro_name_version}"
+}
+
+#
+# Package Management Functions
+#
+pkg_mgr_init()
+{
+    typeset -g pkg_mgr
+
+    case "$(get_distro_name)" in
+    (ubuntu|debian)
+        pkg_mgr="apt-get"
+        ;;
+    (sles|opensuse*)
+        pkg_mgr="zypper"
+        ;;
+    (*)
+        error "Unsupported distibution: '$${distro_name}'"
+        exit 1
+        ;;
+    esac
+}
+
+pkg_mgr_refresh()
+{
+    typeset -g pkg_mgr pkg_mgr_refreshed
+
+    if [[ -z "$${pkg_mgr:-}" ]]; then
+        pkg_mgr_init
+    fi
+
+    if [[ -n "$${pkg_mgr_refreshed:-}" ]]; then
+        return
+    fi
+
+    case "$${pkg_mgr}" in
+    (apt-get)
+        sudo $${pkg_mgr} update --quiet
+        ;;
+    (zypper)
+        sudo $${pkg_mgr} --gpg-auto-import-keys --quiet refresh 
+        ;;
+    esac
+
+    pkg_mgr_refreshed=true
+}
+
+pkg_mgr_install()
+{
+    typeset -g pkg_mgr
+
+    pkg_mgr_refresh
+
+    case "$${pkg_mgr}" in
+    (apt-get)
+        sudo env DEBIAN_FRONTEND=noninteractive $${pkg_mgr} --quiet --yes install "$${@}"
+        ;;
+    (zypper)
+        sudo $${pkg_mgr} --gpg-auto-import-keys --quiet --non-interactive install --no-confirm "$${@}"
+        ;;
+    esac
+}
+
+#
+# Directories and paths
+#
+
+# Ansible installation directories
+ansible_base=/opt/ansible
+ansible_bin=$${ansible_base}/bin
+ansible_venv=$${ansible_base}/venv/$${ansible_version}
+ansible_venv_bin=$${ansible_venv}/bin
+ansible_collections=$${ansible_base}/collections
+ansible_pip3=$${ansible_venv_bin}/pip3
+
+# Azure SAP Automated Deployment directories
+asad_home="$${HOME}/Azure_SAP_Automated_Deployment"
+asad_ws="$${asad_home}/WORKSPACES"
+asad_repo="https://github.com/Azure/sap-hana.git"
+asad_dir="$${asad_home}/$(basename $${asad_repo} .git)"
+
+# Terraform installation directories
+tf_base=/opt/terraform
+tf_dir=$${tf_base}/terraform_$${tfversion}
+tf_bin=$${tf_base}/bin
+tf_zip=terraform_$${tfversion}_linux_amd64.zip
+
+
+#
+# Main body of script
+#
+
+# Check for supported distro
+case "$(get_distro_name_version)" in
+(sles_12*)
+    error "Unsupported distro: $${distro_name_version} doesn't provide virtualenv in standard repos."
+    exit 1
+    ;;
+(ubuntu*|sles*)
+    echo "$${distro_name_version} is supported."
+    ;;
+(*)
+    error "Unsupported distro: $${distro_name_version} not currently supported."
+    exit 1
+    ;;
+esac
+
+# List of required packages whose names are common to all supported distros
+required_pkgs=(
+    jq
+    unzip
+)
+
+# Include distro version agnostic packages into required packages list
+case "$(get_distro_name)" in
+(ubuntu|sles)
+    required_pkgs+=(
+        python3-pip
+        python3-virtualenv
+    )
+    ;;
+esac
+
+# Include distro version specific packages into required packages list
+case "$(get_distro_name_version)" in
+(ubuntu_18.04)
+    required_pkgs+=(
+        virtualenv
+    )
+    ;;
+esac
+
+# Ensure our package metadata cache is up to date
+pkg_mgr_refresh
+
+# Install required packages as determined above
+pkg_mgr_install "$${required_pkgs[@]}"
+
+# Prepare Azure SAP Automated Deployment folder structure
+mkdir -p \
+    $${asad_ws}/LOCAL/$${rg_name} \
+    $${asad_ws}/LIBRARY \
+    $${asad_ws}/SYSTEM \
+    $${asad_ws}/LANDSCAPE \
+    $${asad_ws}/DEPLOYER
+
+#
+# Clone Azure SAP Automated Deployment project repository
+#
+if [[ ! -d "$${asad_dir}" ]]; then
+    git clone "$${asad_repo}" "$${asad_dir}"
+fi
+
+#
+# Install terraform for all users
+#
+sudo mkdir -p \
+    $${tf_dir} \
+    $${tf_bin}
+wget -nv -O /tmp/$${tf_zip} https://releases.hashicorp.com/terraform/$${tfversion}/$${tf_zip}
+sudo unzip -o /tmp/$${tf_zip} -d $${tf_dir}
+sudo ln -vfs ../$(dirname $${tf_dir})/terraform $${tf_bin}/terraform
+
+#
+# Install az cli using provided scripting
+#
+curl -sL https://aka.ms/InstallAzureCLI | sudo bash
+
+#
+# Install latest Ansible revision of specified version for all users.
+#
+sudo mkdir -p \
+    $${ansible_bin} \
+    $${ansible_collections}
+    
+# Create a Python3 based venv into which we will install Ansible.
+if [[ ! -e "$${ansible_venv_bin}/activate" ]]; then
+    sudo rm -rf $${ansible_venv}
+    sudo virtualenv --python python3 $${ansible_venv}
+fi
+
+# Fail if pip3 doesn't exist in the venv
+if [[ ! -x "$${ansible_venv_bin}/pip3" ]]; then
+    echo "Using the wrong pip3: '$${found_pip3}' != '$${ansible_venv_bin}/pip3'"
+    exit 1
+fi
+
+# Ensure that standard tools are up to date
+sudo $${ansible_venv_bin}/pip3 install --upgrade \
+    pip \
+    wheel \
+    setuptools
+
+# Install latest MicroSoft Authentication Library
+# TODO(rtamalin): Do we need this? In particular do we expect to integrated
+# Rust based tools with the Python/Ansible envs that we are using?
+sudo $${ansible_venv_bin}/pip3 install \
+    setuptools-rust
+
+# Install latest revision of target Ansible version, along with additional
+# useful/supporting Python packages such as ansible-lint, yamllint,
+# argcomplete, pywinrm.
+sudo $${ansible_venv_bin}/pip3 install \
+    "ansible>=$${ansible_major}.$${ansible_minor},<$${ansible_major}.$((ansible_minor + 1))" \
+    ansible-lint \
+    argcomplete \
+    'pywinrm>=0.3.0' \
+    yamllint \
+    msal
+
+# Install Ansible collections under the ANSIBLE_COLLECTIONS_PATHS for all users.
+sudo mkdir -p $${ansible_collections}
+sudo -H $${ansible_venv_bin}/ansible-galaxy collection install azure.azcollection --force --collections-path $${ansible_collections}
+
+# Install the Python requirements associated with the Ansible Azure collection
+# that was just installed into the Ansible venv.
+azure_azcollection_version=$(jq -r '.collection_info.version' $${ansible_collections}/ansible_collections/azure/azcollection/MANIFEST.json)
+wget -nv -O /tmp/requirements-azure.txt https://raw.githubusercontent.com/ansible-collections/azure/v$${azure_azcollection_version}/requirements-azure.txt
+sudo $${ansible_venv_bin}/pip3 install \
+    -r /tmp/requirements-azure.txt
+
+# Create symlinks for all relevant commands that were installed in the Ansible
+# venv's bin so that they are available in the /opt/ansible/bin directory, which
+# will be added to the system PATH. This ensures that we expose only those tools
+# that we need from the Ansible venv bin directory without superceding standard
+# system versions of the commands that are also found there, e.g. python3.
+ansible_venv_commands=(
+    # Ansible 2.9 command set
+    ansible
+    ansible-config
+    ansible-connection
+    ansible-console
+    ansible-doc
+    ansible-galaxy
+    ansible-inventory
+    ansible-playbook
+    ansible-pull
+    ansible-test
+    ansible-vault
+
+    # ansible-lint
+    ansible-lint
+
+    # argcomplete
+    activate-global-python-argcomplete
+
+    # yamllint
+    yamllint
+)
+
+relative_path="$(realpath --relative-to $${ansible_bin} $${ansible_venv_bin})"
+for vcmd in "$${ansible_venv_commands[@]}"
+do
+    sudo ln -vfs $${relative_path}/$${vcmd} $${ansible_bin}/$${vcmd}
+done
+
+# Ensure that Python argcomplete is enabled for all users interactive shell sessions
+sudo $${ansible_bin}/activate-global-python-argcomplete
+
+#
+# Create /etc/profile.d script to setup environment for interactive sessions
+#
+echo '# Configure environment settings for deployer interactive sessions' | sudo tee /etc/profile.d/deploy_server.sh
+
+# Add new /opt bin directories to start of PATH to ensure the versions we installed
+# are preferred over any installed standard system versions.
+echo export "PATH=$${ansible_bin}:$${tf_bin}:"'$${PATH}' | sudo tee -a /etc/profile.d/deploy_server.sh
+
+# Set env for ansible
+echo export ANSIBLE_HOST_KEY_CHECKING=False | sudo tee -a /etc/profile.d/deploy_server.sh
+echo export ANSIBLE_COLLECTIONS_PATHS=$${ansible_collections} | sudo tee -a /etc/profile.d/deploy_server.sh
+
+# Set env for MSI
+echo export ARM_USE_MSI=true | sudo tee -a /etc/profile.d/deploy_server.sh
+echo "export ARM_MSI_ENDPOINT='http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01'" | sudo tee -a /etc/profile.d/deploy_server.sh
+echo export ARM_CLIENT_ID=$${client_id} | sudo tee -a /etc/profile.d/deploy_server.sh
+echo export ARM_SUBSCRIPTION_ID=$${subscription_id} | sudo tee -a /etc/profile.d/deploy_server.sh
+echo export ARM_TENANT_ID=$${tenant_id} | sudo tee -a /etc/profile.d/deploy_server.sh
+echo export DEPLOYMENT_REPO_PATH=$HOME/Azure_SAP_Automated_Deployment/sap-hana | sudo tee -a /etc/profile.d/deploy_server.sh
+
+# Ensure that the user's account is logged in to Azure with specified creds
+echo az login --identity --output none | sudo tee -a /etc/profile.d/deploy_server.sh
+echo 'echo $${USER} account ready for use with Azure SAP Automated Deployment' | sudo tee -a /etc/profile.d/deploy_server.sh


### PR DESCRIPTION
Update the sap_deployer module to generate a configure_deployer.sh
script under /tmp on the deployer node which is then run using a
remote-exec operation.

The new configure_deployer.sh script is derived from the previous
remote-exec inline scripting, with changes to leverage a Python
virtualenv to host Ansible and other Python tools and depenencies,
rather than pip installing them into the system Python environment
which risks both breaking the system package management, and being
broken by any subsequent Python related package installs.

The generated /etc/profile.d/deployer_setup.sh script should also
correctly add the new Terraform and Ansible bin directories to the
session PATH, rather than replacing the session PATH with a fixed
list of paths that pertained when the terraform remote-exec was
triggered. Note that this script is only included in interactive
sessions, such as a user login via SSH, but not from non-interactive
sessions such as using SSH to run a specific command on a system.

The deploy/ansible/*test_menu.sh scripts have been updated to set
their PATH and ANSIBLE_COLLECTIONS_PATHS environment variables
appropriately to ensure that they can access the required tools 
even when run from a non-interactive session.

Similarly update the deploy/scripts shell scripts to ensure that
they also include the relevant paths in their PATH settings to
ensure that they can find the relevant tools when running under
non-interactive sessions. Note that this change may need to be
re-visited if it is expected that non-deployer environmemnts that
may run these scripts will have the relevant path entries setup
in an incompatible fashion.