### PR TITLE
Update cloudinit growpart config management

### DIFF
--- a/deploy/terraform/run/sap_system/module.tf
+++ b/deploy/terraform/run/sap_system/module.tf
@@ -78,7 +78,7 @@ module "hdb_node" {
   db_asg_id                  = module.common_infrastructure.db_asg_id
   terraform_template_version = var.terraform_template_version
   deployment                 = var.deployment
-  cloudinit_disable_growpart = module.common_infrastructure.cloudinit_disable_growpart
+  cloudinit_growpart_config  = module.common_infrastructure.cloudinit_growpart_config
 
 }
 
@@ -111,7 +111,7 @@ module "app_tier" {
   landscape_tfstate          = data.terraform_remote_state.landscape.outputs
   terraform_template_version = var.terraform_template_version
   deployment                 = var.deployment
-  cloudinit_disable_growpart = module.common_infrastructure.cloudinit_disable_growpart
+  cloudinit_growpart_config  = module.common_infrastructure.cloudinit_growpart_config
 
 }
 
@@ -142,7 +142,7 @@ module "anydb_node" {
   db_asg_id                  = module.common_infrastructure.db_asg_id
   terraform_template_version = var.terraform_template_version
   deployment                 = var.deployment
-  cloudinit_disable_growpart = module.common_infrastructure.cloudinit_disable_growpart
+  cloudinit_growpart_config  = module.common_infrastructure.cloudinit_growpart_config
 
 }
 

--- a/deploy/terraform/terraform-units/modules/sap_landscape/iscsi.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/iscsi.tf
@@ -86,7 +86,7 @@ resource "azurerm_linux_virtual_machine" "iscsi" {
   admin_password                  = local.iscsi_auth_password
   disable_password_authentication = local.enable_iscsi_auth_key
 
-  custom_data = try(data.template_cloudinit_config.disable_growpart.rendered, "Cg==")
+  custom_data = try(data.template_cloudinit_config.config_growpart.rendered, "Cg==")
 
   os_disk {
     name                 = format("%s%s%s%s", local.prefix, var.naming.separator, local.virtualmachine_names[count.index], local.resource_suffixes.osdisk)
@@ -124,13 +124,13 @@ resource "azurerm_linux_virtual_machine" "iscsi" {
 
 // Define a cloud-init config that disables the automatic expansion
 // of the root partition.
-data "template_cloudinit_config" "disable_growpart" {
+data "template_cloudinit_config" "config_growpart" {
   gzip          = true
   base64_encode = true
 
   # Main cloud-config configuration file.
   part {
     content_type = "text/cloud-config"
-    content      = "growpart: {'mode': 'off'}"
+    content      = "growpart: {'mode': 'auto'}"
   }
 }

--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/variables_local.tf
@@ -67,8 +67,8 @@ variable "terraform_template_version" {
   description = "The version of Terraform templates that were identified in the state file"
 }
 
-variable "cloudinit_disable_growpart" {
-  description = "A cloud-init config that disables automatic growpart expansion of root partition"
+variable "cloudinit_growpart_config" {
+  description = "A cloud-init config that configures automatic growpart expansion of root partition"
 }
 
 

--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/vm-anydb.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/vm-anydb.tf
@@ -81,7 +81,7 @@ resource "azurerm_linux_virtual_machine" "dbserver" {
     }
   }
 
-  custom_data = var.cloudinit_disable_growpart
+  custom_data = var.cloudinit_growpart_config
 
   dynamic "os_disk" {
     iterator = disk

--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/vm-observer.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/vm-observer.tf
@@ -62,7 +62,7 @@ resource "azurerm_linux_virtual_machine" "observer" {
   ]
   size = local.observer_size
 
-  custom_data = var.cloudinit_disable_growpart
+  custom_data = var.cloudinit_growpart_config
 
   os_disk {
     name                   = format("%s%s%s%s", local.prefix, var.naming.separator, local.observer_virtualmachine_names[count.index], local.resource_suffixes.osdisk)

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/variables_local.tf
@@ -80,8 +80,8 @@ variable "terraform_template_version" {
   description = "The version of Terraform templates that were identified in the state file"
 }
 
-variable "cloudinit_disable_growpart" {
-  description = "A cloud-init config that disables automatic growpart expansion of root partition"
+variable "cloudinit_growpart_config" {
+  description = "A cloud-init config that configures automatic growpart expansion of root partition"
 }
 
 

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-app.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-app.tf
@@ -96,7 +96,7 @@ resource "azurerm_linux_virtual_machine" "app" {
     }
   }
 
-  custom_data = var.cloudinit_disable_growpart
+  custom_data = var.cloudinit_growpart_config
 
   dynamic "os_disk" {
     iterator = disk

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-scs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-scs.tf
@@ -104,7 +104,7 @@ resource "azurerm_linux_virtual_machine" "scs" {
     }
   }
 
-  custom_data = var.cloudinit_disable_growpart
+  custom_data = var.cloudinit_growpart_config
 
   dynamic "os_disk" {
     iterator = disk

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-webdisp.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-webdisp.tf
@@ -90,7 +90,7 @@ resource "azurerm_linux_virtual_machine" "web" {
     }
   }
 
-  custom_data = var.cloudinit_disable_growpart
+  custom_data = var.cloudinit_growpart_config
 
   dynamic "os_disk" {
     iterator = disk

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/infrastructure.tf
@@ -134,14 +134,14 @@ resource "azurerm_application_security_group" "db" {
 
 // Define a cloud-init config that disables the automatic expansion
 // of the root partition.
-data "template_cloudinit_config" "disable_growpart" {
+data "template_cloudinit_config" "config_growpart" {
   gzip          = true
   base64_encode = true
 
   # Main cloud-config configuration file.
   part {
     content_type = "text/cloud-config"
-    content      = "growpart: {'mode': 'off'}"
+    content      = "growpart: {'mode': 'auto'}"
   }
 }
 

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/outputs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/outputs.tf
@@ -92,6 +92,6 @@ output "use_local_credentials" {
   value = local.use_local_credentials
 }
 
-output "cloudinit_disable_growpart" {
-  value = local.cloudinit_disable_growpart
+output "cloudinit_growpart_config" {
+  value = local.cloudinit_growpart_config
 }

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/variables_local.tf
@@ -385,5 +385,5 @@ locals {
 
 locals {
   // 'Cg==` is empty string, base64 encoded.
-  cloudinit_disable_growpart = try(data.template_cloudinit_config.disable_growpart.rendered, "Cg==")
+  cloudinit_growpart_config = try(data.template_cloudinit_config.config_growpart.rendered, "Cg==")
 }

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/vm-anchor.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/vm-anchor.tf
@@ -47,7 +47,7 @@ resource "azurerm_linux_virtual_machine" "anchor" {
     }
   }
 
-  custom_data = local.cloudinit_disable_growpart
+  custom_data = local.cloudinit_growpart_config
 
   os_disk {
     name                   = format("%s%s%s%s", local.prefix, var.naming.separator, local.anchor_virtualmachine_names[count.index], local.resource_suffixes.osdisk)

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/variables_local.tf
@@ -74,8 +74,8 @@ variable "terraform_template_version" {
   description = "The version of Terraform templates that were identified in the state file"
 }
 
-variable "cloudinit_disable_growpart" {
-  description = "A cloud-init config that disables automatic growpart expansion of root partition"
+variable "cloudinit_growpart_config" {
+  description = "A cloud-init config that configures automatic growpart expansion of root partition"
 }
 
 

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/vm-hdb.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/vm-hdb.tf
@@ -138,7 +138,7 @@ resource "azurerm_linux_virtual_machine" "vm_dbnode" {
 
   size = local.hdb_vms[count.index].size
 
-  custom_data = var.cloudinit_disable_growpart
+  custom_data = var.cloudinit_growpart_config
 
   dynamic "os_disk" {
     iterator = disk


### PR DESCRIPTION
Change the existing "disablement" to an "enablement" and rename the
terraform entities to better reflect that it is configuring how the
growpart mechanism is used.

Since we haven't yet completed the partition resize support, better
to let customers make use of the automatic expansion of the OS disk
rather than leaving them with a minimal footprint partition layout
even if they have increased the size of the disk.

Whenever we want to disable growpart expansion we can just switch
the `auto` back to `off` again.