### PR TITLE
Register the workload vnet with Private DNS

### DIFF
--- a/deploy/terraform/run/sap_landscape/module.tf
+++ b/deploy/terraform/run/sap_landscape/module.tf
@@ -4,8 +4,8 @@
 */
 
 module "sap_landscape" {
-   providers = {
-    azurerm.main = azurerm.main
+  providers = {
+    azurerm.main     = azurerm.main
     azurerm.deployer = azurerm.deployer
   }
   source                      = "../../terraform-units/modules/sap_landscape"
@@ -15,11 +15,15 @@ module "sap_landscape" {
   naming                      = module.sap_namegenerator.naming
   service_principal           = local.service_principal
   key_vault                   = var.key_vault
-  deployer_tfstate            = try(data.terraform_remote_state.deployer[0].outputs,[])
+  deployer_tfstate            = try(data.terraform_remote_state.deployer[0].outputs, [])
   diagnostics_storage_account = var.diagnostics_storage_account
   witness_storage_account     = var.witness_storage_account
 
-  use_deployer                = length(var.deployer_tfstate_key) > 0
+  use_deployer = length(var.deployer_tfstate_key) > 0
+
+  dns_label               = var.dns_label
+  dns_resource_group_name = length(var.private_dns_resource_group) > 0 ? var.private_dns_resource_group : local.saplib_resource_group_name
+
 }
 
 module "sap_namegenerator" {

--- a/deploy/terraform/run/sap_landscape/output.tf
+++ b/deploy/terraform/run/sap_landscape/output.tf
@@ -100,3 +100,7 @@ output "db_nsg_id" {
 output "web_nsg_id" {
   value = module.sap_landscape.admin_nsg_id
 }
+
+output "dns_label" {
+  value = var.dns_label
+}

--- a/deploy/terraform/run/sap_landscape/variables_global.tf
+++ b/deploy/terraform/run/sap_landscape/variables_global.tf
@@ -117,3 +117,13 @@ variable "terraform_template_version" {
   description = "The version of Terraform templates that were identified in the state file"
   default = ""
 }
+
+variable "dns_label" {
+  description = "DNS label"
+  default = ""
+}
+
+variable "dns_resource_group_name" {
+  description = "DNS resource group name"
+  default = ""
+}

--- a/deploy/terraform/terraform-units/modules/sap_landscape/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/infrastructure.tf
@@ -119,3 +119,13 @@ data "azurerm_storage_account" "witness_storage" {
   name                = split("/", var.witness_storage_account.arm_id)[8]
   resource_group_name = split("/", var.witness_storage_account.arm_id)[4]
 }
+
+resource "azurerm_private_dns_zone_virtual_network_link" "vnet_sap" {
+  provider              = azurerm.deployer
+  count                 = length(var.dns_label) > 0 ? 1 : 0
+  name                  = format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.dns_link)
+  resource_group_name   = var.dns_resource_group_name
+  private_dns_zone_name = var.dns_label
+  virtual_network_id    = local.vnet_sap_exists ? data.azurerm_virtual_network.vnet_sap[0].id : azurerm_virtual_network.vnet_sap[0].id
+  registration_enabled  = true
+}

--- a/deploy/terraform/terraform-units/modules/sap_landscape/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/variables_local.tf
@@ -19,6 +19,16 @@ variable "use_deployer" {
   description = "Use the deployer"
 }
 
+variable "dns_label" {
+  description = "DNS label"
+  default = ""
+}
+
+variable "dns_resource_group_name" {
+  description = "DNS resource group name"
+  default = ""
+}
+
 locals {
   // Resources naming
   storageaccount_name         = var.naming.storageaccount_names.VNET.landscape_storageaccount_name


### PR DESCRIPTION
## Problem
Provide DNS registration for the workload vnet

## Solution
Register the workload DNS if the dns label is provided as a parameter. 

The solution takes two parameters dns_label and dns_resource_group_name, if provided the workload vnet will be registered

## Tests
<Please provide steps to test the PR>

## Notes
<Additional comments for the PR>