### PR TITLE
Ability to set licensing and patching on the VMs

### DIFF
--- a/deploy/terraform/run/sap_system/module.tf
+++ b/deploy/terraform/run/sap_system/module.tf
@@ -47,6 +47,7 @@ module "common_infrastructure" {
   authentication             = var.authentication
   terraform_template_version = var.terraform_template_version
   deployment                 = var.deployment
+  license_type               = var.license_type
 
 }
 
@@ -79,6 +80,7 @@ module "hdb_node" {
   terraform_template_version = var.terraform_template_version
   deployment                 = var.deployment
   cloudinit_growpart_config  = module.common_infrastructure.cloudinit_growpart_config
+  license_type               = var.license_type
 
 }
 
@@ -112,6 +114,7 @@ module "app_tier" {
   terraform_template_version = var.terraform_template_version
   deployment                 = var.deployment
   cloudinit_growpart_config  = module.common_infrastructure.cloudinit_growpart_config
+  license_type               = var.license_type
 
 }
 
@@ -143,6 +146,7 @@ module "anydb_node" {
   terraform_template_version = var.terraform_template_version
   deployment                 = var.deployment
   cloudinit_growpart_config  = module.common_infrastructure.cloudinit_growpart_config
+  license_type               = var.license_type
 
 }
 

--- a/deploy/terraform/run/sap_system/variables_local.tf
+++ b/deploy/terraform/run/sap_system/variables_local.tf
@@ -61,6 +61,12 @@ variable "terraform_template_version" {
   default     = ""
 }
 
+variable "license_type" {
+  description = "Specifies the license type for the OS"
+  default = ""
+
+}
+
 locals {
 
   version_label = trimspace(file("${path.module}/../../../configs/version.txt"))

--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/variables_local.tf
@@ -71,6 +71,12 @@ variable "cloudinit_growpart_config" {
   description = "A cloud-init config that configures automatic growpart expansion of root partition"
 }
 
+variable "license_type" {
+  description = "Specifies the license type for the OS"
+  default = ""
+
+}
+
 
 locals {
   // Imports database sizing information

--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/vm-anydb.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/vm-anydb.tf
@@ -137,6 +137,9 @@ resource "azurerm_linux_virtual_machine" "dbserver" {
     storage_account_uri = var.storage_bootdiag_endpoint
   }
 
+  patch_mode = "Manual"
+  license_type = length(var.license_type) > 0 ? var.license_type : null
+  
   tags = local.tags
 }
 
@@ -206,7 +209,10 @@ resource "azurerm_windows_virtual_machine" "dbserver" {
   boot_diagnostics {
     storage_account_uri = var.storage_bootdiag_endpoint
   }
-
+  
+  patch_mode = "Manual"
+  license_type = length(var.license_type) > 0 ? var.license_type : null 
+  
   tags = local.tags
 }
 

--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/vm-observer.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/vm-observer.tf
@@ -87,6 +87,8 @@ resource "azurerm_linux_virtual_machine" "observer" {
     storage_account_uri = var.storage_bootdiag_endpoint
   }
 
+  license_type = length(var.license_type) > 0 ? var.license_type : null
+  
   tags = local.tags
 }
 
@@ -141,5 +143,7 @@ resource "azurerm_windows_virtual_machine" "observer" {
     storage_account_uri = var.storage_bootdiag_endpoint
   }
 
+  patch_mode = "Manual"
+  license_type = length(var.license_type) > 0 ? var.license_type : null
   tags = local.tags
 }

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/variables_local.tf
@@ -84,6 +84,11 @@ variable "cloudinit_growpart_config" {
   description = "A cloud-init config that configures automatic growpart expansion of root partition"
 }
 
+variable "license_type" {
+  description = "Specifies the license type for the OS"
+  default = ""
+
+}
 
 locals {
   // Imports Disk sizing sizing information

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-app.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-app.tf
@@ -141,6 +141,8 @@ resource "azurerm_linux_virtual_machine" "app" {
     storage_account_uri = var.storage_bootdiag_endpoint
   }
 
+  license_type = length(var.license_type) > 0 ? var.license_type : null
+  
   tags = local.app_tags
 
 }
@@ -218,6 +220,9 @@ resource "azurerm_windows_virtual_machine" "app" {
     storage_account_uri = var.storage_bootdiag_endpoint
   }
 
+  patch_mode = "Manual"
+  license_type = length(var.license_type) > 0 ? var.license_type : null
+  
   tags = local.app_tags
 
 }

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-scs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-scs.tf
@@ -149,6 +149,8 @@ resource "azurerm_linux_virtual_machine" "scs" {
     storage_account_uri = var.storage_bootdiag_endpoint
   }
 
+  license_type = length(var.license_type) > 0 ? var.license_type : null
+
   tags = local.scs_tags
 }
 
@@ -225,6 +227,9 @@ resource "azurerm_windows_virtual_machine" "scs" {
   boot_diagnostics {
     storage_account_uri = var.storage_bootdiag_endpoint
   }
+
+  patch_mode = "Manual"
+  license_type = length(var.license_type) > 0 ? var.license_type : null
 
   tags = local.scs_tags
 }

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-webdisp.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-webdisp.tf
@@ -135,6 +135,7 @@ resource "azurerm_linux_virtual_machine" "web" {
     storage_account_uri = var.storage_bootdiag_endpoint
   }
 
+  license_type = length(var.license_type) > 0 ? var.license_type : null
   tags = local.web_tags
 }
 
@@ -211,6 +212,10 @@ resource "azurerm_windows_virtual_machine" "web" {
   boot_diagnostics {
     storage_account_uri = var.storage_bootdiag_endpoint
   }
+
+
+  patch_mode = "Manual"
+  license_type = length(var.license_type) > 0 ? var.license_type : null
 
   tags = local.web_tags
 }

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/variables_local.tf
@@ -45,6 +45,11 @@ variable "terraform_template_version" {
   description = "The version of Terraform templates that were identified in the state file"
 }
 
+variable "license_type" {
+  description = "Specifies the license type for the OS"
+  default = ""
+
+}
 
 locals {
   // Resources naming

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/vm-anchor.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/vm-anchor.tf
@@ -75,6 +75,8 @@ resource "azurerm_linux_virtual_machine" "anchor" {
     ultra_ssd_enabled = local.enable_anchor_ultra[count.index]
   }
 
+
+  license_type = length(var.license_type) > 0 ? var.license_type : null
 }
 
 # Create the Windows Application VM(s)
@@ -121,5 +123,7 @@ resource "azurerm_windows_virtual_machine" "anchor" {
   additional_capabilities {
     ultra_ssd_enabled = local.enable_anchor_ultra[count.index]
   }
-
+  
+  patch_mode = "Manual"
+  license_type = length(var.license_type) > 0 ? var.license_type : null
 }

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/variables_local.tf
@@ -78,6 +78,11 @@ variable "cloudinit_growpart_config" {
   description = "A cloud-init config that configures automatic growpart expansion of root partition"
 }
 
+variable "license_type" {
+  description = "Specifies the license type for the OS"
+  default = ""
+
+}
 
 locals {
   // Resources naming

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/vm-hdb.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/vm-hdb.tf
@@ -174,6 +174,8 @@ resource "azurerm_linux_virtual_machine" "vm_dbnode" {
     storage_account_uri = var.storage_bootdiag_endpoint
   }
 
+  license_type = length(var.license_type) > 0 ? var.license_type : null
+
   tags = local.tags
 }
 


### PR DESCRIPTION
## Problem
Provide a way to specify the patching schedule to manual for Windows VMs
Provide a way to specify the licensing model
## Solution
Add a parameter licensing_type to sap-system

## Tests
add the licensing_type variable to the input json

## Notes
https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/windows_virtual_machine#patch_mode

This requires registration

Use
az feature register -n InGuestAutoPatchVMPreview --namespace Microsoft.Compute

https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/windows_virtual_machine#license_type
https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_virtual_machine#license_type