### PR TITLE
Support providing the database SID

### DIFF
--- a/deploy/terraform/run/sap_system/module.tf
+++ b/deploy/terraform/run/sap_system/module.tf
@@ -167,7 +167,8 @@ module "output_files" {
   nics_dbnodes_admin    = module.hdb_node.nics_dbnodes_admin
   nics_dbnodes_db       = module.hdb_node.nics_dbnodes_db
   loadbalancers         = module.hdb_node.loadbalancers
-  hdb_sid               = module.hdb_node.hdb_sid
+  sap_sid               = local.sap_sid
+  db_sid                = local.db_sid
   hana_database_info    = module.hdb_node.hana_database_info
   nics_scs              = module.app_tier.nics_scs
   nics_app              = module.app_tier.nics_app

--- a/deploy/terraform/run/sap_system/sapsystem_full.json
+++ b/deploy/terraform/run/sap_system/sapsystem_full.json
@@ -108,6 +108,8 @@
       },
       "platform"                           : "HANA",
       "size"                               : "Default",
+      "sid"                                : "HDB",
+      "instance_number"                    : "01",
       "use_DHCP"                           : false,
       "zones"                              : ["1"]
     }

--- a/deploy/terraform/run/sap_system/sapsystem_full.tfvars
+++ b/deploy/terraform/run/sap_system/sapsystem_full.tfvars
@@ -85,6 +85,8 @@ database_vm_image = {
 
 #database_platform="HANA"
 #database_size="Default"
+#database_sid="HDB"
+#database_instance_number="01"
 
 #database_no_avset=false
 #database_no_ppg=false

--- a/deploy/terraform/run/sap_system/tfvar_variables.tf
+++ b/deploy/terraform/run/sap_system/tfvar_variables.tf
@@ -263,6 +263,15 @@ variable "database_size" {
   default = ""
 }
 
+variable "database_sid" {
+  default = ""
+}
+
+variable "database_instance_number" {
+  default = "01"
+}
+
+
 variable "database_vm_zones" {
   default = []
 }

--- a/deploy/terraform/run/sap_system/transform.tf
+++ b/deploy/terraform/run/sap_system/transform.tf
@@ -96,6 +96,13 @@ locals {
   }
   db_os_specified = (length(local.db_os.source_image_id) + length(local.db_os.publisher)) > 0
 
+  db_sid_specified = length(var.database_sid) + length (try(var.databases[0].sid, ""))) > 0
+
+  instance = {
+    sid     = try(coalesce(var.database_sid,try(var.databases[0].sid, "")), upper(var.databases[0].platform) == "HANA" ? "hdb" : lower(substr(var.databases[0].platform,0,3)))
+    instance_number = upper(var.databases[0].platform) == "HANA" ? coalesce(var.database_instance_number,try(var.databases[0].instance_number, "01")) : ""
+  }
+
   app_authentication = {
     type     = try(coalesce(var.app_tier_authentication_type, try(var.application.authentication.type, "")), "")
     username = try(coalesce(var.automation_username, try(var.application.authentication.username, "")), "")
@@ -312,7 +319,8 @@ locals {
     local.db_avset_arm_ids_defined ? { avset_arm_ids = local.avset_arm_ids } : null), (
     length(local.dbnodes) > 0 ? { dbnodes = local.dbnodes } : null), (
     length(local.db_zones_temp) > 0 ? { zones = local.db_zones_temp } : null), (
-    length(local.frontend_ip) > 0 ? { loadbalancer = { frontend_ip = local.frontend_ip } } : { loadbalancer = {} })
+    length(local.frontend_ip) > 0 ? { loadbalancer = { frontend_ip = local.frontend_ip } } : { loadbalancer = {} }), (
+    local.db_sid_specified ? {instance = local.instance}: null)
     )
   ]
 

--- a/deploy/terraform/terraform-units/modules/sap_system/output_files/inventory.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/output_files/inventory.tf
@@ -144,7 +144,7 @@ resource "local_file" "ansible_inventory_new_yml" {
     ips_pas = length(local.ips_app) > 0 ? slice(local.ips_app, 0, 1) : [],
     ips_app = length(local.ips_app) > 1 ? slice(local.ips_app, 1, length(local.ips_app)) : []
     ips_web = length(local.ips_web) > 0 ? local.ips_web : [],
-    sid     = var.hdb_sid,
+    sid     = var.sap_sid,
     passervers = length(local.ips_app) > 0 ? (
       slice(var.naming.virtualmachine_names.APP_VMNAME, 0, 1)) : (
       []
@@ -184,14 +184,15 @@ resource "local_file" "ansible_inventory_new_yml" {
     ansible_user      = var.ansible_user
     }
   )
-  filename             = format("%s/%s_hosts.yaml", path.cwd, var.hdb_sid)
+  filename             = format("%s/%s_hosts.yaml", path.cwd, var.sap_sid)
   file_permission      = "0660"
   directory_permission = "0770"
 }
 
 resource "local_file" "sap-parameters_yml" {
   content = templatefile(format("%s/sap-parameters.yml.tmpl", path.module), {
-    sid           = var.hdb_sid,
+    sid           = var.sap_sid,
+    db_sid = var.db_sid
     kv_uri        = local.kv_name,
     secret_prefix = local.secret_prefix,
     disks         = var.disks
@@ -213,7 +214,7 @@ resource "local_file" "sap-parameters_yml" {
 
 resource "azurerm_storage_blob" "hosts_yaml" {
   provider               = azurerm.deployer
-  name                   = format("%s_hosts.yaml", length(trimspace(var.naming.prefix.SDU)) > 0 ? trimspace(var.naming.prefix.SDU) : var.hdb_sid)
+  name                   = format("%s_hosts.yaml", length(trimspace(var.naming.prefix.SDU)) > 0 ? trimspace(var.naming.prefix.SDU) : var.sap_sid)
   storage_account_name   = local.tfstate_storage_account_name
   storage_container_name = local.ansible_container_name
   type                   = "Block"
@@ -225,7 +226,7 @@ resource "azurerm_storage_blob" "sap_parameters_yaml" {
     local_file.sap-parameters_yml
   ]
   provider               = azurerm.deployer
-  name                   = format("%s_sap-parameters.yaml", length(trimspace(var.naming.prefix.SDU)) > 0 ? trimspace(var.naming.prefix.SDU) : var.hdb_sid)
+  name                   = format("%s_sap-parameters.yaml", length(trimspace(var.naming.prefix.SDU)) > 0 ? trimspace(var.naming.prefix.SDU) : var.sap_sid)
   storage_account_name   = local.tfstate_storage_account_name
   storage_container_name = local.ansible_container_name
   type                   = "Block"

--- a/deploy/terraform/terraform-units/modules/sap_system/output_files/sap-parameters.yml.tmpl
+++ b/deploy/terraform/terraform-units/modules/sap_system/output_files/sap-parameters.yml.tmpl
@@ -7,6 +7,7 @@ sap_fqdn:                      ${dns}
 
 # TERRAFORM CREATED
 sap_sid:                       ${sid}
+db_sid:                        ${db_sid}
 kv_uri:                        ${kv_uri}
 secret_prefix:                 ${secret_prefix}
 scs_high_availability:         ${scs_ha}

--- a/deploy/terraform/terraform-units/modules/sap_system/output_files/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/output_files/variables_local.tf
@@ -15,8 +15,12 @@ variable "loadbalancers" {
   description = "List of LoadBalancers created for HANA Databases"
 }
 
-variable "hdb_sid" {
-  description = "List of SIDs used when generating Load Balancers"
+variable "sap_sid" {
+  description = "SAP SID"
+}
+
+variable "db_sid" {
+  description = "Database SID"
 }
 
 variable "hana_database_info" {


### PR DESCRIPTION
## Problem
Currently there is no way to specify the database SID to be persisten in the sap-parameters.yaml file

## Solution
Add the database SID in the sap-parameters.yaml file

## Tests
Add the database_sid and database_instance_number variables to the tfvars file or   "sid"                                : "HDB",
      "instance_number"                    : "01",
into the database block

## Notes
<Additional comments for the PR>