### PR TITLE
Provide a way to control the deployment of load balancers for non-HA deployments

### DIFF
--- a/deploy/samples/WORKSPACES/SYSTEM/DEV-WEEU-SAP01-X00/DEV-WEEU-SAP01-X00.json
+++ b/deploy/samples/WORKSPACES/SYSTEM/DEV-WEEU-SAP01-X00/DEV-WEEU-SAP01-X00.json
@@ -43,5 +43,6 @@
   },
   "options": {
     "resource_offset"               : 1
-  }
+  },
+  "use_loadbalancers_for_standalone_deployments" : true
 }

--- a/deploy/samples/WORKSPACES/SYSTEM/DEV-WEEU-SAP01-X00/DEV-WEEU-SAP01-X00.tfvars
+++ b/deploy/samples/WORKSPACES/SYSTEM/DEV-WEEU-SAP01-X00/DEV-WEEU-SAP01-X00.tfvars
@@ -260,3 +260,5 @@ webdispatcher_server_count=0
 #resource_offset=1
 #vm_disk_encryption_set_id=""
 #nsg_asg_with_vnet=false
+
+#use_loadbalancers_for_standalone_deployments=false

--- a/deploy/terraform/run/sap_system/module.tf
+++ b/deploy/terraform/run/sap_system/module.tf
@@ -59,30 +59,31 @@ module "hdb_node" {
   providers = {
     azurerm.main     = azurerm
     azurerm.deployer = azurerm.deployer
-  }
-  databases                  = local.databases
-  infrastructure             = local.infrastructure
-  options                    = local.options
-  resource_group             = module.common_infrastructure.resource_group
-  vnet_sap                   = module.common_infrastructure.vnet_sap
-  storage_bootdiag_endpoint  = module.common_infrastructure.storage_bootdiag_endpoint
-  ppg                        = module.common_infrastructure.ppg
-  sid_kv_user_id             = module.common_infrastructure.sid_kv_user_id
-  naming                     = module.sap_namegenerator.naming
-  custom_disk_sizes_filename = var.db_disk_sizes_filename
-  admin_subnet               = module.common_infrastructure.admin_subnet
-  db_subnet                  = module.common_infrastructure.db_subnet
-  storage_subnet             = module.common_infrastructure.storage_subnet
-  anchor_vm                  = module.common_infrastructure.anchor_vm // Workaround to create dependency from anchor to db to app
-  sid_password               = module.common_infrastructure.sid_password
-  sid_username               = module.common_infrastructure.sid_username
-  sdu_public_key             = module.common_infrastructure.sdu_public_key
-  sap_sid                    = local.sap_sid
-  db_asg_id                  = module.common_infrastructure.db_asg_id
-  terraform_template_version = var.terraform_template_version
-  deployment                 = var.deployment
-  cloudinit_growpart_config  = null # This needs more consideration module.common_infrastructure.cloudinit_growpart_config
-  license_type               = var.license_type
+  }                  
+  databases                                    = local.databases
+  infrastructure                               = local.infrastructure
+  options                                      = local.options
+  resource_group                               = module.common_infrastructure.resource_group
+  vnet_sap                                     = module.common_infrastructure.vnet_sap
+  storage_bootdiag_endpoint                    = module.common_infrastructure.storage_bootdiag_endpoint
+  ppg                                          = module.common_infrastructure.ppg
+  sid_kv_user_id                               = module.common_infrastructure.sid_kv_user_id
+  naming                                       = module.sap_namegenerator.naming
+  custom_disk_sizes_filename                   = var.db_disk_sizes_filename
+  admin_subnet                                 = module.common_infrastructure.admin_subnet
+  db_subnet                                    = module.common_infrastructure.db_subnet
+  storage_subnet                               = module.common_infrastructure.storage_subnet
+  anchor_vm                                    = module.common_infrastructure.anchor_vm // Workaround to create dependency from anchor to db to app
+  sid_password                                 = module.common_infrastructure.sid_password
+  sid_username                                 = module.common_infrastructure.sid_username
+  sdu_public_key                               = module.common_infrastructure.sdu_public_key
+  sap_sid                                      = local.sap_sid
+  db_asg_id                                    = module.common_infrastructure.db_asg_id
+  terraform_template_version                   = var.terraform_template_version
+  deployment                                   = var.deployment
+  cloudinit_growpart_config                    = null # This needs more consideration module.common_infrastructure.cloudinit_growpart_config
+  license_type                                 = var.license_type
+  use_loadbalancers_for_standalone_deployments = var.use_loadbalancers_for_standalone_deployments
 
 }
 
@@ -92,31 +93,32 @@ module "app_tier" {
   providers = {
     azurerm.main     = azurerm
     azurerm.deployer = azurerm.deployer
-  }
-  application                = local.application
-  infrastructure             = local.infrastructure
-  options                    = local.options
-  resource_group             = module.common_infrastructure.resource_group
-  vnet_sap                   = module.common_infrastructure.vnet_sap
-  storage_bootdiag_endpoint  = module.common_infrastructure.storage_bootdiag_endpoint
-  ppg                        = module.common_infrastructure.ppg
-  sid_kv_user_id             = module.common_infrastructure.sid_kv_user_id
-  naming                     = module.sap_namegenerator.naming
-  admin_subnet               = module.common_infrastructure.admin_subnet
-  custom_disk_sizes_filename = var.app_disk_sizes_filename
-  anydb_vm_ids               = module.anydb_node.anydb_vms // Workaround to create dependency from anchor to db to app
-  hdb_vm_ids                 = module.hdb_node.hdb_vms
-  sid_password               = module.common_infrastructure.sid_password
-  sid_username               = module.common_infrastructure.sid_username
-  sdu_public_key             = module.common_infrastructure.sdu_public_key
-  route_table_id             = module.common_infrastructure.route_table_id
-  firewall_id                = module.common_infrastructure.firewall_id
-  sap_sid                    = local.sap_sid
-  landscape_tfstate          = data.terraform_remote_state.landscape.outputs
-  terraform_template_version = var.terraform_template_version
-  deployment                 = var.deployment
-  cloudinit_growpart_config  = null # This needs more consideration module.common_infrastructure.cloudinit_growpart_config
-  license_type               = var.license_type
+  }                  
+  application                                  = local.application
+  infrastructure                               = local.infrastructure
+  options                                      = local.options
+  resource_group                               = module.common_infrastructure.resource_group
+  vnet_sap                                     = module.common_infrastructure.vnet_sap
+  storage_bootdiag_endpoint                    = module.common_infrastructure.storage_bootdiag_endpoint
+  ppg                                          = module.common_infrastructure.ppg
+  sid_kv_user_id                               = module.common_infrastructure.sid_kv_user_id
+  naming                                       = module.sap_namegenerator.naming
+  admin_subnet                                 = module.common_infrastructure.admin_subnet
+  custom_disk_sizes_filename                   = var.app_disk_sizes_filename
+  anydb_vm_ids                                 = module.anydb_node.anydb_vms // Workaround to create dependency from anchor to db to app
+  hdb_vm_ids                                   = module.hdb_node.hdb_vms
+  sid_password                                 = module.common_infrastructure.sid_password
+  sid_username                                 = module.common_infrastructure.sid_username
+  sdu_public_key                               = module.common_infrastructure.sdu_public_key
+  route_table_id                               = module.common_infrastructure.route_table_id
+  firewall_id                                  = module.common_infrastructure.firewall_id
+  sap_sid                                      = local.sap_sid
+  landscape_tfstate                            = data.terraform_remote_state.landscape.outputs
+  terraform_template_version                   = var.terraform_template_version
+  deployment                                   = var.deployment
+  cloudinit_growpart_config                    = null # This needs more consideration module.common_infrastructure.cloudinit_growpart_config
+  license_type                                 = var.license_type
+  use_loadbalancers_for_standalone_deployments = var.use_loadbalancers_for_standalone_deployments
 
 }
 
@@ -126,29 +128,30 @@ module "anydb_node" {
   providers = {
     azurerm.main     = azurerm
     azurerm.deployer = azurerm.deployer
-  }
-  databases                  = local.databases
-  infrastructure             = local.infrastructure
-  options                    = local.options
-  resource_group             = module.common_infrastructure.resource_group
-  vnet_sap                   = module.common_infrastructure.vnet_sap
-  storage_bootdiag_endpoint  = module.common_infrastructure.storage_bootdiag_endpoint
-  ppg                        = module.common_infrastructure.ppg
-  sid_kv_user_id             = module.common_infrastructure.sid_kv_user_id
-  naming                     = module.sap_namegenerator.naming
-  custom_disk_sizes_filename = var.db_disk_sizes_filename
-  admin_subnet               = module.common_infrastructure.admin_subnet
-  db_subnet                  = module.common_infrastructure.db_subnet
-  anchor_vm                  = module.common_infrastructure.anchor_vm // Workaround to create dependency from anchor to db to app
-  sid_password               = module.common_infrastructure.sid_password
-  sid_username               = module.common_infrastructure.sid_username
-  sdu_public_key             = module.common_infrastructure.sdu_public_key
-  sap_sid                    = local.sap_sid
-  db_asg_id                  = module.common_infrastructure.db_asg_id
-  terraform_template_version = var.terraform_template_version
-  deployment                 = var.deployment
-  cloudinit_growpart_config  = null # This needs more consideration module.common_infrastructure.cloudinit_growpart_config
-  license_type               = var.license_type
+  }                  
+  databases                                    = local.databases
+  infrastructure                               = local.infrastructure
+  options                                      = local.options
+  resource_group                               = module.common_infrastructure.resource_group
+  vnet_sap                                     = module.common_infrastructure.vnet_sap
+  storage_bootdiag_endpoint                    = module.common_infrastructure.storage_bootdiag_endpoint
+  ppg                                          = module.common_infrastructure.ppg
+  sid_kv_user_id                               = module.common_infrastructure.sid_kv_user_id
+  naming                                       = module.sap_namegenerator.naming
+  custom_disk_sizes_filename                   = var.db_disk_sizes_filename
+  admin_subnet                                 = module.common_infrastructure.admin_subnet
+  db_subnet                                    = module.common_infrastructure.db_subnet
+  anchor_vm                                    = module.common_infrastructure.anchor_vm // Workaround to create dependency from anchor to db to app
+  sid_password                                 = module.common_infrastructure.sid_password
+  sid_username                                 = module.common_infrastructure.sid_username
+  sdu_public_key                               = module.common_infrastructure.sdu_public_key
+  sap_sid                                      = local.sap_sid
+  db_asg_id                                    = module.common_infrastructure.db_asg_id
+  terraform_template_version                   = var.terraform_template_version
+  deployment                                   = var.deployment
+  cloudinit_growpart_config                    = null # This needs more consideration module.common_infrastructure.cloudinit_growpart_config
+  license_type                                 = var.license_type
+  use_loadbalancers_for_standalone_deployments = var.use_loadbalancers_for_standalone_deployments
 
 }
 

--- a/deploy/terraform/run/sap_system/tfvar_variables.tf
+++ b/deploy/terraform/run/sap_system/tfvar_variables.tf
@@ -501,3 +501,8 @@ variable "legacy_nic_order" {
 variable "enable_purge_control_for_keyvaults" {
   default = true
 }
+
+variable "use_loadbalancers_for_standalone_deployments" {
+  default = true
+}
+

--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/infrastructure.tf
@@ -5,9 +5,8 @@ Load balancer front IP address range: .4 - .9
 resource "azurerm_lb" "anydb" {
   provider            = azurerm.main
   count               = local.enable_deployment && ( var.use_loadbalancers_for_standalone_deployments || local.anydb_ha ) ? 1 : 0
-
-  name  = format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.db_alb)
-  sku   = "Standard"
+  name                = format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.db_alb)
+  sku                 = "Standard"
 
   resource_group_name = var.resource_group[0].name
   location            = var.resource_group[0].location
@@ -27,14 +26,14 @@ resource "azurerm_lb" "anydb" {
 }
 
 resource "azurerm_lb_backend_address_pool" "anydb" {
-  count           = local.enable_deployment ? 1 : 0
+  count           = local.enable_deployment && ( var.use_loadbalancers_for_standalone_deployments || local.anydb_ha ) ? 1 : 0
   name            = format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.db_alb_bepool)
   loadbalancer_id = azurerm_lb.anydb[count.index].id
 }
 
 resource "azurerm_lb_probe" "anydb" {
-  provider                  = azurerm.main
-  count               = local.enable_deployment ? 1 : 0
+  provider            = azurerm.main
+  count               = local.enable_deployment && ( var.use_loadbalancers_for_standalone_deployments || local.anydb_ha ) ? 1 : 0
   name                = format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.db_alb_hp)
   resource_group_name = var.resource_group[0].name
   loadbalancer_id     = azurerm_lb.anydb[count.index].id
@@ -46,8 +45,8 @@ resource "azurerm_lb_probe" "anydb" {
 
 # Create the Load Balancer Rules
 resource "azurerm_lb_rule" "anydb" {
-  provider                  = azurerm.main
-  count                          = local.enable_deployment && local.db_server_count > 0 ? 1 : 0
+  provider                       = azurerm.main
+  count                          = local.enable_deployment && ( var.use_loadbalancers_for_standalone_deployments || local.anydb_ha ) ? 1 : 0
   resource_group_name            = var.resource_group[0].name
   loadbalancer_id                = azurerm_lb.anydb[0].id
   name                           = format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.db_alb_rule)
@@ -62,8 +61,8 @@ resource "azurerm_lb_rule" "anydb" {
 
 
 resource "azurerm_network_interface_backend_address_pool_association" "anydb" {
-  provider                  = azurerm.main
-  count                   = local.enable_deployment ? local.db_server_count : 0
+  provider                = azurerm.main
+  count                   = local.enable_deployment && ( var.use_loadbalancers_for_standalone_deployments || local.anydb_ha ) ? 1 : 0
   network_interface_id    = azurerm_network_interface.anydb_db[count.index].id
   ip_configuration_name   = azurerm_network_interface.anydb_db[count.index].ip_configuration[0].name
   backend_address_pool_id = azurerm_lb_backend_address_pool.anydb[0].id
@@ -83,7 +82,7 @@ resource "azurerm_availability_set" "anydb" {
 }
 
 data "azurerm_availability_set" "anydb" {
-  provider                  = azurerm.main
+  provider            = azurerm.main
   count               = local.enable_deployment && local.use_avset && local.availabilitysets_exist ? max(length(local.zones), 1) : 0
   name                = split("/", local.availabilityset_arm_ids[count.index])[8]
   resource_group_name = split("/", local.availabilityset_arm_ids[count.index])[4]

--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/infrastructure.tf
@@ -4,7 +4,7 @@ Load balancer front IP address range: .4 - .9
 
 resource "azurerm_lb" "anydb" {
   provider            = azurerm.main
-  count               = local.enable_deployment && ( var.use_loadbalancers_for_standalone_deployments || local.anydb_ha ) ? 1 : 0
+  count               = local.enable_db_lb_deployment ? 1 : 0
   name                = format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.db_alb)
   sku                 = "Standard"
 
@@ -13,7 +13,7 @@ resource "azurerm_lb" "anydb" {
 
   frontend_ip_configuration {
     name      = format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.db_alb_feip)
-    subnet_id = var.db_subnet
+    subnet_id = var.db_subnet.id
 
     private_ip_address = local.use_DHCP ? (
       null) : (
@@ -26,14 +26,14 @@ resource "azurerm_lb" "anydb" {
 }
 
 resource "azurerm_lb_backend_address_pool" "anydb" {
-  count           = local.enable_deployment && ( var.use_loadbalancers_for_standalone_deployments || local.anydb_ha ) ? 1 : 0
+  count           = local.enable_db_lb_deployment ? 1 : 0
   name            = format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.db_alb_bepool)
   loadbalancer_id = azurerm_lb.anydb[count.index].id
 }
 
 resource "azurerm_lb_probe" "anydb" {
   provider            = azurerm.main
-  count               = local.enable_deployment && ( var.use_loadbalancers_for_standalone_deployments || local.anydb_ha ) ? 1 : 0
+  count               = local.enable_db_lb_deployment ? 1 : 0
   name                = format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.db_alb_hp)
   resource_group_name = var.resource_group[0].name
   loadbalancer_id     = azurerm_lb.anydb[count.index].id
@@ -46,7 +46,7 @@ resource "azurerm_lb_probe" "anydb" {
 # Create the Load Balancer Rules
 resource "azurerm_lb_rule" "anydb" {
   provider                       = azurerm.main
-  count                          = local.enable_deployment && ( var.use_loadbalancers_for_standalone_deployments || local.anydb_ha ) ? 1 : 0
+  count                          = local.enable_db_lb_deployment ? 1 : 0
   resource_group_name            = var.resource_group[0].name
   loadbalancer_id                = azurerm_lb.anydb[0].id
   name                           = format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.db_alb_rule)
@@ -62,7 +62,7 @@ resource "azurerm_lb_rule" "anydb" {
 
 resource "azurerm_network_interface_backend_address_pool_association" "anydb" {
   provider                = azurerm.main
-  count                   = local.enable_deployment && ( var.use_loadbalancers_for_standalone_deployments || local.anydb_ha ) ? 1 : 0
+  count                   = local.enable_db_lb_deployment ? local.db_server_count : 0
   network_interface_id    = azurerm_network_interface.anydb_db[count.index].id
   ip_configuration_name   = azurerm_network_interface.anydb_db[count.index].ip_configuration[0].name
   backend_address_pool_id = azurerm_lb_backend_address_pool.anydb[0].id

--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/infrastructure.tf
@@ -3,8 +3,9 @@ Load balancer front IP address range: .4 - .9
 +--------------------------------------4--------------------------------------*/
 
 resource "azurerm_lb" "anydb" {
-  provider                  = azurerm.main
-  count = local.enable_deployment ? 1 : 0
+  provider            = azurerm.main
+  count               = local.enable_deployment && ( var.use_loadbalancers_for_standalone_deployments || local.anydb_ha ) ? 1 : 0
+
   name  = format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.db_alb)
   sku   = "Standard"
 

--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/outputs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/outputs.tf
@@ -22,7 +22,7 @@ output "anydb_db_ip" {
 }
 
 output "db_lb_ip" {
-  value = local.enable_deployment ? azurerm_lb.anydb[0].frontend_ip_configuration[0].private_ip_address : ""
+  value = local.enable_deployment && ( var.use_loadbalancers_for_standalone_deployments || local.anydb_ha ) ? try(azurerm_lb.anydb[0].frontend_ip_configuration[0].private_ip_address, "") : ""
 }
 
 output "any_database_info" {
@@ -30,7 +30,7 @@ output "any_database_info" {
 }
 
 output "anydb_loadbalancers" {
-  value = azurerm_lb.anydb
+  value = local.enable_deployment && ( var.use_loadbalancers_for_standalone_deployments || local.anydb_ha ) ? azurerm_lb.anydb : null
 }
 
 // Output for DNS
@@ -51,9 +51,8 @@ output "dns_info_vms" {
   ) : null
 
 }
-
 output "dns_info_loadbalancers" {
-  value = local.enable_deployment ? (
+  value = local.enable_deployment && ( var.use_loadbalancers_for_standalone_deployments || local.anydb_ha ) ? (
     zipmap([format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.db_alb)], [azurerm_lb.anydb[0].private_ip_addresses[0]])) : (
     null
   )

--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/outputs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/outputs.tf
@@ -30,7 +30,7 @@ output "any_database_info" {
 }
 
 output "anydb_loadbalancers" {
-  value = local.enable_deployment && ( var.use_loadbalancers_for_standalone_deployments || local.anydb_ha ) ? azurerm_lb.anydb : null
+  value = local.enable_db_lb_deployment ? azurerm_lb.anydb : null
 }
 
 // Output for DNS
@@ -52,7 +52,7 @@ output "dns_info_vms" {
 
 }
 output "dns_info_loadbalancers" {
-  value = local.enable_deployment && ( var.use_loadbalancers_for_standalone_deployments || local.anydb_ha ) ? (
+  value = local.enable_db_lb_deployment ? (
     zipmap([format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.db_alb)], [azurerm_lb.anydb[0].private_ip_addresses[0]])) : (
     null
   )

--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/variables_local.tf
@@ -77,6 +77,10 @@ variable "license_type" {
 
 }
 
+variable "use_loadbalancers_for_standalone_deployments" {
+  description = "Defines if load balancers are used even for standalone deployments"
+  default     = true
+}
 
 locals {
   // Imports database sizing information

--- a/deploy/terraform/terraform-units/modules/sap_system/anydb_node/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/anydb_node/variables_local.tf
@@ -170,8 +170,9 @@ locals {
   db_sid       = lower(substr(local.anydb_platform, 0, 3))
   loadbalancer = try(local.anydb.loadbalancer, {})
 
-  node_count      = try(length(var.databases[0].dbnodes), 1)
+  node_count      = local.enable_deployment ? try(length(var.databases[0].dbnodes), 1) : 0
   db_server_count = local.anydb_ha ? local.node_count * 2 : local.node_count
+  enable_db_lb_deployment = local.db_server_count > 0 && (var.use_loadbalancers_for_standalone_deployments || local.db_server_count >  1)
 
   anydb_cred = try(local.anydb.credentials, {})
 

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/infrastructure.tf
@@ -58,8 +58,10 @@ data "azurerm_subnet" "subnet_sap_web" {
 
 # Create the SCS Load Balancer
 resource "azurerm_lb" "scs" {
+  
   provider            = azurerm.main
-  count               = local.enable_deployment && local.scs_server_count > 0 ? 1 : 0
+  
+  count               = local.enable_deployment && ( var.use_loadbalancers_for_standalone_deployments || local.scs_high_availability ) ? 1 : 0
   name                = format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.scs_alb)
   resource_group_name = var.resource_group[0].name
   location            = var.resource_group[0].location
@@ -222,7 +224,7 @@ resource "azurerm_availability_set" "app" {
 # Create the Web dispatcher Load Balancer
 resource "azurerm_lb" "web" {
   provider            = azurerm.main
-  count               = local.enable_deployment && local.webdispatcher_count > 0 ? 1 : 0
+  count               = local.enable_deployment && ( var.use_loadbalancers_for_standalone_deployments || local.webdispatcher_count > 1 ) ? 1 : 0
   name                = format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.web_alb)
   resource_group_name = var.resource_group[0].name
   location            = var.resource_group[0].location

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/infrastructure.tf
@@ -59,7 +59,7 @@ data "azurerm_subnet" "subnet_sap_web" {
 # Create the SCS Load Balancer
 resource "azurerm_lb" "scs" {
   provider            = azurerm.main
-  count               = local.enable_deployment && ( var.use_loadbalancers_for_standalone_deployments || local.scs_high_availability ) ? 1 : 0
+  count               = local.enable_scs_lb_deployment ? 1 : 0
   name                = format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.scs_alb)
   resource_group_name = var.resource_group[0].name
   location            = var.resource_group[0].location
@@ -80,7 +80,7 @@ resource "azurerm_lb" "scs" {
 
 resource "azurerm_lb_backend_address_pool" "scs" {
   provider        = azurerm.main
-  count           = local.enable_deployment && ( var.use_loadbalancers_for_standalone_deployments || local.scs_high_availability ) ? 1 : 0
+  count           = local.enable_scs_lb_deployment ? 1 : 0
   name            = format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.scs_alb_bepool)
   loadbalancer_id = azurerm_lb.scs[0].id
 
@@ -88,7 +88,7 @@ resource "azurerm_lb_backend_address_pool" "scs" {
 
 resource "azurerm_lb_probe" "scs" {
   provider            = azurerm.main
-  count               = local.enable_deployment && ( var.use_loadbalancers_for_standalone_deployments || local.scs_high_availability ) ? (local.scs_high_availability ? 2 : 1) : 0
+  count               = local.enable_scs_lb_deployment ? (local.scs_high_availability ? 2 : 1) : 0
   resource_group_name = var.resource_group[0].name
   loadbalancer_id     = azurerm_lb.scs[0].id
   name                = format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes[count.index == 0 ? "scs_alb_hp" : "scs_ers_hp"])
@@ -100,7 +100,7 @@ resource "azurerm_lb_probe" "scs" {
 
 resource "azurerm_lb_probe" "clst" {
   provider            = azurerm.main
-  count               = local.enable_deployment && (local.scs_high_availability && upper(local.scs_ostype) == "WINDOWS") ? 1 : 0
+  count               = local.enable_scs_lb_deployment && (local.scs_high_availability && upper(local.scs_ostype) == "WINDOWS") ? 1 : 0
   resource_group_name = var.resource_group[0].name
   loadbalancer_id     = azurerm_lb.scs[0].id
   name                = format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.scs_clst_hp)
@@ -112,7 +112,7 @@ resource "azurerm_lb_probe" "clst" {
 
 resource "azurerm_lb_probe" "fs" {
   provider            = azurerm.main
-  count               = local.enable_deployment && (local.scs_high_availability && upper(local.scs_ostype) == "WINDOWS") ? 1 : 0
+  count               = local.enable_scs_lb_deployment && (local.scs_high_availability && upper(local.scs_ostype) == "WINDOWS") ? 1 : 0
   resource_group_name = var.resource_group[0].name
   loadbalancer_id     = azurerm_lb.scs[0].id
   name                = format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.scs_fs_hp)
@@ -126,7 +126,7 @@ resource "azurerm_lb_probe" "fs" {
 # Create the SCS Load Balancer Rules
 resource "azurerm_lb_rule" "scs" {
   provider                       = azurerm.main
-  count                          = local.enable_deployment && ( var.use_loadbalancers_for_standalone_deployments || local.scs_high_availability ) ? 1 : 0
+  count                          = local.enable_scs_lb_deployment ? 1 : 0
   resource_group_name            = var.resource_group[0].name
   loadbalancer_id                = azurerm_lb.scs[0].id
   name                           = format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.scs_scs_rule)
@@ -142,7 +142,7 @@ resource "azurerm_lb_rule" "scs" {
 # Create the ERS Load balancer rules only in High Availability configurations
 resource "azurerm_lb_rule" "ers" {
   provider                       = azurerm.main
-  count                          = local.enable_deployment && local.scs_high_availability ? 1 : 0
+  count                          = local.enable_scs_lb_deployment && local.scs_high_availability ? 1 : 0
   resource_group_name            = var.resource_group[0].name
   loadbalancer_id                = azurerm_lb.scs[0].id
   name                           = format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.scs_ers_rule)
@@ -157,7 +157,7 @@ resource "azurerm_lb_rule" "ers" {
 
 resource "azurerm_lb_rule" "clst" {
   provider                       = azurerm.main
-  count                          = local.enable_deployment && local.win_ha_scs  ? 1 : 0
+  count                          = local.enable_scs_lb_deployment && local.win_ha_scs  ? 1 : 0
   resource_group_name            = var.resource_group[0].name
   loadbalancer_id                = azurerm_lb.scs[0].id
   name                           = format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.scs_clst_rule)
@@ -172,7 +172,7 @@ resource "azurerm_lb_rule" "clst" {
 
 resource "azurerm_lb_rule" "fs" {
   provider                       = azurerm.main
-  count                          = local.enable_deployment && local.win_ha_scs  ? 1 : 0
+  count                          = local.enable_scs_lb_deployment && local.win_ha_scs  ? 1 : 0
   resource_group_name            = var.resource_group[0].name
   loadbalancer_id                = azurerm_lb.scs[0].id
   name                           = format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.scs_fs_rule)
@@ -222,7 +222,7 @@ resource "azurerm_availability_set" "app" {
 # Create the Web dispatcher Load Balancer
 resource "azurerm_lb" "web" {
   provider            = azurerm.main
-  count               = local.enable_deployment && ( var.use_loadbalancers_for_standalone_deployments || local.webdispatcher_count > 1 ) ? 1 : 0
+  count               = local.enable_web_lb_deployment ? 1 : 0
   name                = format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.web_alb)
   resource_group_name = var.resource_group[0].name
   location            = var.resource_group[0].location
@@ -241,7 +241,7 @@ resource "azurerm_lb" "web" {
 
 resource "azurerm_lb_backend_address_pool" "web" {
   provider            = azurerm.main
-  count               = local.enable_deployment && ( var.use_loadbalancers_for_standalone_deployments || local.webdispatcher_count > 1 ) ? 1 : 0
+  count               = local.enable_web_lb_deployment ? 1 : 0
   name                = format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.web_alb_bepool)
   loadbalancer_id     = azurerm_lb.web[0].id
 }
@@ -251,7 +251,7 @@ resource "azurerm_lb_backend_address_pool" "web" {
 # Create the Web dispatcher Load Balancer Rules
 resource "azurerm_lb_rule" "web" {
   provider                       = azurerm.main
-  count                          = local.enable_deployment && ( var.use_loadbalancers_for_standalone_deployments || local.webdispatcher_count > 1 ) ? 1 : 0
+  count                          = local.enable_web_lb_deployment ? 1 : 0
   resource_group_name            = var.resource_group[0].name
   loadbalancer_id                = azurerm_lb.web[0].id
   name                           = format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.web_alb_inrule)
@@ -266,7 +266,8 @@ resource "azurerm_lb_rule" "web" {
 # Associate Web dispatcher VM NICs with the Load Balancer Backend Address Pool
 resource "azurerm_network_interface_backend_address_pool_association" "web" {
   provider                = azurerm.main
-  count                   = local.enable_deployment && ( var.use_loadbalancers_for_standalone_deployments || local.webdispatcher_count > 1 ) ? 1 : 0
+  depends_on = [azurerm_lb_backend_address_pool.web]
+  count                   = local.enable_web_lb_deployment ? 1 : 0
   network_interface_id    = azurerm_network_interface.web[count.index].id
   ip_configuration_name   = azurerm_network_interface.web[count.index].ip_configuration[0].name
   backend_address_pool_id = azurerm_lb_backend_address_pool.web[0].id

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/infrastructure.tf
@@ -58,9 +58,7 @@ data "azurerm_subnet" "subnet_sap_web" {
 
 # Create the SCS Load Balancer
 resource "azurerm_lb" "scs" {
-  
   provider            = azurerm.main
-  
   count               = local.enable_deployment && ( var.use_loadbalancers_for_standalone_deployments || local.scs_high_availability ) ? 1 : 0
   name                = format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.scs_alb)
   resource_group_name = var.resource_group[0].name
@@ -82,7 +80,7 @@ resource "azurerm_lb" "scs" {
 
 resource "azurerm_lb_backend_address_pool" "scs" {
   provider        = azurerm.main
-  count           = local.enable_deployment && local.scs_server_count > 0 ? 1 : 0
+  count           = local.enable_deployment && ( var.use_loadbalancers_for_standalone_deployments || local.scs_high_availability ) ? 1 : 0
   name            = format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.scs_alb_bepool)
   loadbalancer_id = azurerm_lb.scs[0].id
 
@@ -90,7 +88,7 @@ resource "azurerm_lb_backend_address_pool" "scs" {
 
 resource "azurerm_lb_probe" "scs" {
   provider            = azurerm.main
-  count               = local.enable_deployment && local.scs_server_count > 0 ? (local.scs_high_availability ? 2 : 1) : 0
+  count               = local.enable_deployment && ( var.use_loadbalancers_for_standalone_deployments || local.scs_high_availability ) ? (local.scs_high_availability ? 2 : 1) : 0
   resource_group_name = var.resource_group[0].name
   loadbalancer_id     = azurerm_lb.scs[0].id
   name                = format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes[count.index == 0 ? "scs_alb_hp" : "scs_ers_hp"])
@@ -128,7 +126,7 @@ resource "azurerm_lb_probe" "fs" {
 # Create the SCS Load Balancer Rules
 resource "azurerm_lb_rule" "scs" {
   provider                       = azurerm.main
-  count                          = local.enable_deployment && local.scs_server_count > 0 ? 1 : 0
+  count                          = local.enable_deployment && ( var.use_loadbalancers_for_standalone_deployments || local.scs_high_availability ) ? 1 : 0
   resource_group_name            = var.resource_group[0].name
   loadbalancer_id                = azurerm_lb.scs[0].id
   name                           = format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.scs_scs_rule)
@@ -144,7 +142,7 @@ resource "azurerm_lb_rule" "scs" {
 # Create the ERS Load balancer rules only in High Availability configurations
 resource "azurerm_lb_rule" "ers" {
   provider                       = azurerm.main
-  count                          = local.enable_deployment && local.scs_server_count > 0 ? (local.scs_high_availability ? 1 : 0) : 0
+  count                          = local.enable_deployment && local.scs_high_availability ? 1 : 0
   resource_group_name            = var.resource_group[0].name
   loadbalancer_id                = azurerm_lb.scs[0].id
   name                           = format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.scs_ers_rule)
@@ -243,7 +241,7 @@ resource "azurerm_lb" "web" {
 
 resource "azurerm_lb_backend_address_pool" "web" {
   provider            = azurerm.main
-  count               = local.enable_deployment && local.webdispatcher_count > 0 ? 1 : 0
+  count               = local.enable_deployment && ( var.use_loadbalancers_for_standalone_deployments || local.webdispatcher_count > 1 ) ? 1 : 0
   name                = format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.web_alb_bepool)
   loadbalancer_id     = azurerm_lb.web[0].id
 }
@@ -253,7 +251,7 @@ resource "azurerm_lb_backend_address_pool" "web" {
 # Create the Web dispatcher Load Balancer Rules
 resource "azurerm_lb_rule" "web" {
   provider                       = azurerm.main
-  count                          = local.enable_deployment && local.webdispatcher_count > 0 ? 1 : 0
+  count                          = local.enable_deployment && ( var.use_loadbalancers_for_standalone_deployments || local.webdispatcher_count > 1 ) ? 1 : 0
   resource_group_name            = var.resource_group[0].name
   loadbalancer_id                = azurerm_lb.web[0].id
   name                           = format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.web_alb_inrule)
@@ -268,7 +266,7 @@ resource "azurerm_lb_rule" "web" {
 # Associate Web dispatcher VM NICs with the Load Balancer Backend Address Pool
 resource "azurerm_network_interface_backend_address_pool_association" "web" {
   provider                = azurerm.main
-  count                   = local.enable_deployment && local.webdispatcher_count > 0 ? local.webdispatcher_count : 0
+  count                   = local.enable_deployment && ( var.use_loadbalancers_for_standalone_deployments || local.webdispatcher_count > 1 ) ? 1 : 0
   network_interface_id    = azurerm_network_interface.web[count.index].id
   ip_configuration_name   = azurerm_network_interface.web[count.index].ip_configuration[0].name
   backend_address_pool_id = azurerm_lb_backend_address_pool.web[0].id

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/outputs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/outputs.tf
@@ -47,23 +47,23 @@ output "web_admin_ip" {
 }
 
 output "web_lb_ip" {
-  value = local.enable_deployment && ( var.use_loadbalancers_for_standalone_deployments || local.webdispatcher_count > 0 ) ? try(azurerm_lb.web[0].frontend_ip_configuration[0].private_ip_address, "") : ""
+  value = local.enable_web_lb_deployment ? try(azurerm_lb.web[0].frontend_ip_configuration[0].private_ip_address, "") : ""
 }
 
 output "scs_lb_ip" {
-  value = local.enable_deployment && ( var.use_loadbalancers_for_standalone_deployments || local.scs_server_count > 0 ) ? try(azurerm_lb.scs[0].frontend_ip_configuration[0].private_ip_address, "") : ""
+  value = local.enable_scs_lb_deployment ? try(azurerm_lb.scs[0].frontend_ip_configuration[0].private_ip_address, "") : ""
 }
 
 output "ers_lb_ip" {
-  value = local.enable_deployment && local.scs_high_availability ? try(azurerm_lb.scs[0].frontend_ip_configuration[1].private_ip_address, "") : ""
+  value = local.enable_scs_lb_deployment && local.scs_high_availability ? try(azurerm_lb.scs[0].frontend_ip_configuration[1].private_ip_address, "") : ""
 }
 
 output "cluster_lb_ip" {
-  value = local.enable_deployment && ( var.use_loadbalancers_for_standalone_deployments || local.scs_server_count > 0) && (local.scs_high_availability && upper(local.scs_ostype) == "WINDOWS") ? try(azurerm_lb.scs[0].frontend_ip_configuration[2].private_ip_address, "") : ""
+  value = local.enable_scs_lb_deployment && (local.scs_high_availability && upper(local.scs_ostype) == "WINDOWS") ? try(azurerm_lb.scs[0].frontend_ip_configuration[2].private_ip_address, "") : ""
 }
 
 output "fileshare_lb_ip" {
-  value = local.enable_deployment && ( var.use_loadbalancers_for_standalone_deployments || local.scs_server_count > 0) && (local.scs_high_availability && upper(local.scs_ostype) == "WINDOWS") ? try(azurerm_lb.scs[0].frontend_ip_configuration[3].private_ip_address, "") : ""
+  value = local.enable_scs_lb_deployment && (local.scs_high_availability && upper(local.scs_ostype) == "WINDOWS") ? try(azurerm_lb.scs[0].frontend_ip_configuration[3].private_ip_address, "") : ""
 }
 
 // Output for DNS
@@ -107,39 +107,39 @@ output "dns_info_loadbalancers" {
   value = !(local.enable_deployment && ( var.use_loadbalancers_for_standalone_deployments || local.scs_high_availability )) ? null : (
     zipmap(
       compact([
-        local.scs_server_count > 0 ? format("%s%s%s", local.prefix, var.naming.separator, "scs") : "",
-        local.scs_server_count > 0 ? format("%s%s%s", local.prefix, var.naming.separator, "ers") : "",
-        local.scs_server_count > 0 ? (
+        local.enable_scs_lb_deployment ? format("%s%s%s", local.prefix, var.naming.separator, "scs") : "",
+        local.enable_scs_lb_deployment ? format("%s%s%s", local.prefix, var.naming.separator, "ers") : "",
+        local.enable_scs_lb_deployment ? (
           local.win_ha_scs && length(azurerm_lb.scs[0].private_ip_addresses) == 4 ? (
             format("%s%s%s", local.prefix, var.naming.separator, "clst")) : (
             ""
           )) : (
           ""
         ),
-        local.scs_server_count > 0 ? (
+        local.enable_scs_lb_deployment ? (
           local.win_ha_scs && length(azurerm_lb.scs[0].private_ip_addresses) == 4 ? (
             format("%s%s%s", local.prefix, var.naming.separator, "fs")) : (
             ""
           )) : (
           ""
         ),
-        local.webdispatcher_count > 0 ? format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.web_alb) : ""
+        local.enable_web_lb_deployment ? format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.web_alb) : ""
       ]),
       compact([
-        local.scs_server_count > 0 ? try(azurerm_lb.scs[0].private_ip_addresses[0], "") : "",
-        local.scs_server_count > 0 ? try(azurerm_lb.scs[0].private_ip_addresses[1], "") : "",
-        local.scs_server_count > 0 ? (
+        local.enable_scs_lb_deployment ? try(azurerm_lb.scs[0].private_ip_addresses[0], "") : "",
+        local.enable_scs_lb_deployment ? try(azurerm_lb.scs[0].private_ip_addresses[1], "") : "",
+        local.enable_scs_lb_deployment ? (
           local.win_ha_scs && length(azurerm_lb.scs[0].private_ip_addresses) == 4 ? (
             azurerm_lb.scs[0].private_ip_addresses[2]) : (
             ""
           )) : (
           ""
         ),
-        local.scs_server_count > 0 ? (
+        local.enable_scs_lb_deployment ? (
           local.win_ha_scs && length(azurerm_lb.scs[0].private_ip_addresses) == 4 ? azurerm_lb.scs[0].private_ip_addresses[3] : "") : (
           ""
         ),
-        local.webdispatcher_count > 0 ? try(azurerm_lb.web[0].private_ip_address, "") : ""
+        local.enable_web_lb_deployment ? try(azurerm_lb.web[0].private_ip_address, "") : ""
       ])
     )
   )

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/outputs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/outputs.tf
@@ -47,23 +47,23 @@ output "web_admin_ip" {
 }
 
 output "web_lb_ip" {
-  value = local.enable_deployment && local.webdispatcher_count > 0 ? azurerm_lb.web[0].frontend_ip_configuration[0].private_ip_address : ""
+  value = local.enable_deployment && ( var.use_loadbalancers_for_standalone_deployments || local.webdispatcher_count > 0 ) ? try(azurerm_lb.web[0].frontend_ip_configuration[0].private_ip_address, "") : ""
 }
 
 output "scs_lb_ip" {
-  value = local.enable_deployment && local.scs_server_count > 0 ? azurerm_lb.scs[0].frontend_ip_configuration[0].private_ip_address : ""
+  value = local.enable_deployment && ( var.use_loadbalancers_for_standalone_deployments || local.scs_server_count > 0 ) ? try(azurerm_lb.scs[0].frontend_ip_configuration[0].private_ip_address, "") : ""
 }
 
 output "ers_lb_ip" {
-  value = local.enable_deployment && local.scs_server_count > 0 ? azurerm_lb.scs[0].frontend_ip_configuration[1].private_ip_address : ""
+  value = local.enable_deployment && local.scs_high_availability ? try(azurerm_lb.scs[0].frontend_ip_configuration[1].private_ip_address, "") : ""
 }
 
 output "cluster_lb_ip" {
-  value = local.enable_deployment && local.scs_server_count > 0 && (local.scs_high_availability && upper(local.scs_ostype) == "WINDOWS") ? azurerm_lb.scs[0].frontend_ip_configuration[2].private_ip_address : ""
+  value = local.enable_deployment && ( var.use_loadbalancers_for_standalone_deployments || local.scs_server_count > 0) && (local.scs_high_availability && upper(local.scs_ostype) == "WINDOWS") ? try(azurerm_lb.scs[0].frontend_ip_configuration[2].private_ip_address, "") : ""
 }
 
 output "fileshare_lb_ip" {
-  value = local.enable_deployment && local.scs_server_count > 0 && (local.scs_high_availability && upper(local.scs_ostype) == "WINDOWS") ? azurerm_lb.scs[0].frontend_ip_configuration[3].private_ip_address : ""
+  value = local.enable_deployment && ( var.use_loadbalancers_for_standalone_deployments || local.scs_server_count > 0) && (local.scs_high_availability && upper(local.scs_ostype) == "WINDOWS") ? try(azurerm_lb.scs[0].frontend_ip_configuration[3].private_ip_address, "") : ""
 }
 
 // Output for DNS
@@ -104,7 +104,7 @@ output "dns_info_vms" {
 }
 
 output "dns_info_loadbalancers" {
-  value = !local.enable_deployment ? null : (
+  value = !(local.enable_deployment && ( var.use_loadbalancers_for_standalone_deployments || local.scs_high_availability )) ? null : (
     zipmap(
       compact([
         local.scs_server_count > 0 ? format("%s%s%s", local.prefix, var.naming.separator, "scs") : "",
@@ -126,8 +126,8 @@ output "dns_info_loadbalancers" {
         local.webdispatcher_count > 0 ? format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.web_alb) : ""
       ]),
       compact([
-        local.scs_server_count > 0 ? azurerm_lb.scs[0].private_ip_addresses[0] : "",
-        local.scs_server_count > 0 ? azurerm_lb.scs[0].private_ip_addresses[1] : "",
+        local.scs_server_count > 0 ? try(azurerm_lb.scs[0].private_ip_addresses[0], "") : "",
+        local.scs_server_count > 0 ? try(azurerm_lb.scs[0].private_ip_addresses[1], "") : "",
         local.scs_server_count > 0 ? (
           local.win_ha_scs && length(azurerm_lb.scs[0].private_ip_addresses) == 4 ? (
             azurerm_lb.scs[0].private_ip_addresses[2]) : (
@@ -139,7 +139,7 @@ output "dns_info_loadbalancers" {
           local.win_ha_scs && length(azurerm_lb.scs[0].private_ip_addresses) == 4 ? azurerm_lb.scs[0].private_ip_addresses[3] : "") : (
           ""
         ),
-        local.webdispatcher_count > 0 ? azurerm_lb.web[0].private_ip_address : ""
+        local.webdispatcher_count > 0 ? try(azurerm_lb.web[0].private_ip_address, "") : ""
       ])
     )
   )

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/variables_local.tf
@@ -233,7 +233,10 @@ locals {
   scs_high_availability    = var.application.scs_high_availability
   application_server_count = var.application.application_server_count
   scs_server_count         = var.application.scs_server_count * (local.scs_high_availability ? 2 : 1)
+  enable_scs_lb_deployment = local.scs_server_count > 0 && (var.use_loadbalancers_for_standalone_deployments || local.scs_server_count > 1)
+  
   webdispatcher_count      = var.application.webdispatcher_count
+  enable_web_lb_deployment = local.webdispatcher_count > 0 && (var.use_loadbalancers_for_standalone_deployments || local.webdispatcher_count > 1)
 
   app_nic_ips       = try(var.application.app_nic_ips, [])
   app_admin_nic_ips = try(var.application.app_admin_nic_ips, [])

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/variables_local.tf
@@ -90,6 +90,11 @@ variable "license_type" {
 
 }
 
+variable "use_loadbalancers_for_standalone_deployments" {
+  description = "Defines if load balancers are used even for standalone deployments"
+  default     = true
+}
+
 locals {
   // Imports Disk sizing sizing information
 

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-scs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-scs.tf
@@ -59,7 +59,7 @@ resource "azurerm_network_interface" "scs_admin" {
 # Associate SCS VM NICs with the Load Balancer Backend Address Pool
 resource "azurerm_network_interface_backend_address_pool_association" "scs" {
   provider                = azurerm.main
-  count                   = local.enable_deployment ? local.scs_server_count : 0
+  count                   = local.enable_deployment && ( var.use_loadbalancers_for_standalone_deployments || local.scs_high_availability ) ? local.scs_server_count : 0
   network_interface_id    = azurerm_network_interface.scs[count.index].id
   ip_configuration_name   = azurerm_network_interface.scs[count.index].ip_configuration[0].name
   backend_address_pool_id = azurerm_lb_backend_address_pool.scs[0].id

--- a/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-scs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/app_tier/vm-scs.tf
@@ -59,7 +59,7 @@ resource "azurerm_network_interface" "scs_admin" {
 # Associate SCS VM NICs with the Load Balancer Backend Address Pool
 resource "azurerm_network_interface_backend_address_pool_association" "scs" {
   provider                = azurerm.main
-  count                   = local.enable_deployment && ( var.use_loadbalancers_for_standalone_deployments || local.scs_high_availability ) ? local.scs_server_count : 0
+  count                   = local.enable_scs_lb_deployment ? local.scs_server_count : 0
   network_interface_id    = azurerm_network_interface.scs[count.index].id
   ip_configuration_name   = azurerm_network_interface.scs[count.index].ip_configuration[0].name
   backend_address_pool_id = azurerm_lb_backend_address_pool.scs[0].id

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/infrastructure.tf
@@ -24,7 +24,7 @@ Load balancer front IP address range: .4 - .9
 
 resource "azurerm_lb" "hdb" {
   provider            = azurerm.main
-  count               = local.enable_deployment && ( var.use_loadbalancers_for_standalone_deployments || local.hdb_ha ) ? 1 : 0
+  count               = local.enable_db_lb_deployment ? 1 : 0
   name                = format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.db_alb)
   resource_group_name = var.resource_group[0].name
   location            = var.resource_group[0].location
@@ -41,7 +41,7 @@ resource "azurerm_lb" "hdb" {
 
 resource "azurerm_lb_backend_address_pool" "hdb" {
   provider        = azurerm.main
-  count           = local.enable_deployment && ( var.use_loadbalancers_for_standalone_deployments || local.hdb_ha ) ? 1 : 0
+  count           = local.enable_db_lb_deployment ? 1 : 0
   name            = format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.db_alb_bepool)
   loadbalancer_id = azurerm_lb.hdb[count.index].id
 
@@ -49,7 +49,7 @@ resource "azurerm_lb_backend_address_pool" "hdb" {
 
 resource "azurerm_lb_probe" "hdb" {
   provider            = azurerm.main
-  count               = local.enable_deployment && ( var.use_loadbalancers_for_standalone_deployments || local.hdb_ha ) ? 1 : 0
+  count               = local.enable_db_lb_deployment ? 1 : 0
   resource_group_name = var.resource_group[0].name
   loadbalancer_id     = azurerm_lb.hdb[count.index].id
   name                = format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.db_alb_hp)
@@ -64,7 +64,7 @@ resource "azurerm_lb_probe" "hdb" {
 # In a scale-out scenario, we need to rewrite this code according to the scale-out + HA reference architecture.
 resource "azurerm_network_interface_backend_address_pool_association" "hdb" {
   depends_on              = [azurerm_network_interface.nics_dbnodes_db]
-  count                   = local.enable_deployment && ( var.use_loadbalancers_for_standalone_deployments || local.hdb_ha ) ? length(local.hdb_vms) : 0
+  count                   = local.enable_db_lb_deployment ? length(local.hdb_vms) : 0
   network_interface_id    = azurerm_network_interface.nics_dbnodes_db[count.index].id
   ip_configuration_name   = azurerm_network_interface.nics_dbnodes_db[count.index].ip_configuration[0].name
   backend_address_pool_id = azurerm_lb_backend_address_pool.hdb[0].id
@@ -72,7 +72,7 @@ resource "azurerm_network_interface_backend_address_pool_association" "hdb" {
 
 resource "azurerm_lb_rule" "hdb" {
   provider                       = azurerm.main
-  count                          = local.enable_deployment && ( var.use_loadbalancers_for_standalone_deployments || local.hdb_ha ) ? 1 : 0
+  count                          = local.enable_db_lb_deployment ? 1 : 0
   resource_group_name            = var.resource_group[0].name
   loadbalancer_id                = azurerm_lb.hdb[0].id
   name                           = format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.db_alb_rule)

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/infrastructure.tf
@@ -41,7 +41,7 @@ resource "azurerm_lb" "hdb" {
 
 resource "azurerm_lb_backend_address_pool" "hdb" {
   provider        = azurerm.main
-  count           = local.enable_deployment ? 1 : 0
+  count           = local.enable_deployment && ( var.use_loadbalancers_for_standalone_deployments || local.hdb_ha ) ? 1 : 0
   name            = format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.db_alb_bepool)
   loadbalancer_id = azurerm_lb.hdb[count.index].id
 
@@ -49,7 +49,7 @@ resource "azurerm_lb_backend_address_pool" "hdb" {
 
 resource "azurerm_lb_probe" "hdb" {
   provider            = azurerm.main
-  count               = local.enable_deployment ? 1 : 0
+  count               = local.enable_deployment && ( var.use_loadbalancers_for_standalone_deployments || local.hdb_ha ) ? 1 : 0
   resource_group_name = var.resource_group[0].name
   loadbalancer_id     = azurerm_lb.hdb[count.index].id
   name                = format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.db_alb_hp)
@@ -64,7 +64,7 @@ resource "azurerm_lb_probe" "hdb" {
 # In a scale-out scenario, we need to rewrite this code according to the scale-out + HA reference architecture.
 resource "azurerm_network_interface_backend_address_pool_association" "hdb" {
   depends_on              = [azurerm_network_interface.nics_dbnodes_db]
-  count                   = local.enable_deployment ? length(local.hdb_vms) : 0
+  count                   = local.enable_deployment && ( var.use_loadbalancers_for_standalone_deployments || local.hdb_ha ) ? length(local.hdb_vms) : 0
   network_interface_id    = azurerm_network_interface.nics_dbnodes_db[count.index].id
   ip_configuration_name   = azurerm_network_interface.nics_dbnodes_db[count.index].ip_configuration[0].name
   backend_address_pool_id = azurerm_lb_backend_address_pool.hdb[0].id
@@ -72,7 +72,7 @@ resource "azurerm_network_interface_backend_address_pool_association" "hdb" {
 
 resource "azurerm_lb_rule" "hdb" {
   provider                       = azurerm.main
-  count                          = local.enable_deployment ? 1 : 0
+  count                          = local.enable_deployment && ( var.use_loadbalancers_for_standalone_deployments || local.hdb_ha ) ? 1 : 0
   resource_group_name            = var.resource_group[0].name
   loadbalancer_id                = azurerm_lb.hdb[0].id
   name                           = format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.db_alb_rule)

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/infrastructure.tf
@@ -24,7 +24,7 @@ Load balancer front IP address range: .4 - .9
 
 resource "azurerm_lb" "hdb" {
   provider            = azurerm.main
-  count               = local.enable_deployment ? 1 : 0
+  count               = local.enable_deployment && ( var.use_loadbalancers_for_standalone_deployments || local.hdb_ha ) ? 1 : 0
   name                = format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.db_alb)
   resource_group_name = var.resource_group[0].name
   location            = var.resource_group[0].location

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/outputs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/outputs.tf
@@ -12,7 +12,7 @@ output "nics_dbnodes_db" {
 }
 
 output "loadbalancers" {
-  value = azurerm_lb.hdb
+  value = local.enable_deployment && ( var.use_loadbalancers_for_standalone_deployments || local.hdb_ha ) ? azurerm_lb.hdb : null
 }
 
 output "hdb_sid" {
@@ -42,7 +42,7 @@ output "dns_info_vms" {
 }
 
 output "dns_info_loadbalancers" {
-  value = local.enable_deployment ? (
+  value = local.enable_deployment && ( var.use_loadbalancers_for_standalone_deployments || local.hdb_ha ) ? (
     zipmap([format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.db_alb)], [azurerm_lb.hdb[0].private_ip_addresses[0]])) : (
     null
   )
@@ -62,5 +62,5 @@ output "db_ha" {
 }
 
 output "db_lb_ip" {
-  value = local.enable_deployment ? azurerm_lb.hdb[0].frontend_ip_configuration[0].private_ip_address : ""
+  value = local.enable_deployment && ( var.use_loadbalancers_for_standalone_deployments || local.hdb_ha ) ? try(azurerm_lb.hdb[0].frontend_ip_configuration[0].private_ip_address, "") : ""
 }

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/outputs.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/outputs.tf
@@ -42,7 +42,7 @@ output "dns_info_vms" {
 }
 
 output "dns_info_loadbalancers" {
-  value = local.enable_deployment && ( var.use_loadbalancers_for_standalone_deployments || local.hdb_ha ) ? (
+  value = local.enable_db_lb_deployment ? (
     zipmap([format("%s%s%s", local.prefix, var.naming.separator, local.resource_suffixes.db_alb)], [azurerm_lb.hdb[0].private_ip_addresses[0]])) : (
     null
   )
@@ -62,5 +62,5 @@ output "db_ha" {
 }
 
 output "db_lb_ip" {
-  value = local.enable_deployment && ( var.use_loadbalancers_for_standalone_deployments || local.hdb_ha ) ? try(azurerm_lb.hdb[0].frontend_ip_configuration[0].private_ip_address, "") : ""
+  value = local.enable_db_lb_deployment ? try(azurerm_lb.hdb[0].frontend_ip_configuration[0].private_ip_address, "") : ""
 }

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/variables_local.tf
@@ -81,8 +81,13 @@ variable "cloudinit_growpart_config" {
 variable "license_type" {
   description = "Specifies the license type for the OS"
   default     = ""
-
 }
+
+variable "use_loadbalancers_for_standalone_deployments" {
+  description = "Defines if load balancers are used even for standalone deployments"
+  default     = true
+}
+
 
 locals {
   // Resources naming

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/variables_local.tf
@@ -184,8 +184,11 @@ locals {
     "password" = var.sid_password
   }
 
-  node_count      = try(length(local.hdb.dbnodes), 1)
+  node_count      = local.enable_deployment ? try(length(local.hdb.dbnodes), 1) : 0
   db_server_count = local.hdb_ha ? local.node_count * 2 : local.node_count
+
+  enable_db_lb_deployment = local.db_server_count > 0 && (var.use_loadbalancers_for_standalone_deployments || local.db_server_count >  1)
+
 
   hdb_ins = try(local.hdb.instance, {})
   hdb_sid = try(local.hdb_ins.sid, local.sid) // HANA database sid from the Databases array for use as reference to LB/AS


### PR DESCRIPTION
## Problem
Currently we always deploy load balancers in from to db, scs and web. This adds unneccesary cost for cases where HA is not required

## Solution
Provide a switch that controls if load balancers are created for non HA deployments

## Tests
Add the following variable to your tfvars parameter file: **use_loadbalancers_for_standalone_deployments=false** 

If using json add: 
  **"use_loadbalancers_for_standalone_deployments" : true**

## Notes
<Additional comments for the PR>