### PR TITLE
Workaround Azure CLI installer script prompt for input

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_deployer/templates/configure_deployer.sh.tmpl
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/templates/configure_deployer.sh.tmpl
@@ -276,7 +276,7 @@ sudo ln -vfs ../$(dirname $${tf_dir})/terraform $${tf_bin}/terraform
 #
 # Install az cli using provided scripting
 #
-curl -sL https://aka.ms/InstallAzureCLI | sudo bash
+curl -sL https://aka.ms/InstallAzureCLI | sudo bash </dev/null
 
 #
 # Install latest Ansible revision of specified version for all users.


### PR DESCRIPTION
The Azure CLI installer script is prompting for input to confirm the
target install path; we are happy with the default path suggested in
the prompt message, and can ensure that the default is accepted by
redirecting the stdin for the shell action to /dev/null, effectively
making it a non-interactive session, causing the default to be used.