### PR TITLE
Get SAP Library information from keyvault

### DIFF
--- a/deploy/ansible/playbook_03_bom_processing.yaml
+++ b/deploy/ansible/playbook_03_bom_processing.yaml
@@ -5,6 +5,27 @@
 # +------------------------------------4--------------------------------------*/
 ---
 
+- hosts: localhost
+  name: Get Storage account details from KeyVault
+  remote_user:    "{{ orchestration_ansible_user }}"
+  become:         no
+  become_user:    root
+  gather_facts:   yes
+  vars_files:
+    - vars/ansible-input-api.yaml                               # API Input template with defaults
+  tasks:
+  - ansible.builtin.set_fact:
+      tier:  sa
+
+  - block:
+    - include_role:
+        name:     roles-misc/0.3.sap-installation-media-storage-details
+        public:   yes      
+    tags:
+      - 0.3.sap-installation-media-storage-details
+
+
+
 # Steps:
 #   01) NFS: Make Local Shares available via NFS Exports
 #   02) Process BOM (Download and Extract)
@@ -60,6 +81,9 @@
   - block:
     - include_role:
         name:     roles-sap/3.3-bom-processing
+    vars:
+      sapbits_location_base_path: "{{ hostvars.localhost.sapbits-location-base-path }}"
+      sapbits_sas_token:          "{{ hostvars.localhost.sapbits_sas_token }}"
     tags:
       - 3.3-bom-processing
 

--- a/deploy/ansible/playbook_bom_downloader.yaml
+++ b/deploy/ansible/playbook_bom_downloader.yaml
@@ -9,6 +9,7 @@
 #   01) Process BOM (Validate and Extract)
 #
 
+
 - hosts:          localhost
 
   name:           BOM Validator
@@ -28,12 +29,25 @@
 #
 # -------------------------------------+---------------------------------------8
 
+  - block:
+    - include_role:
+        name:     roles-misc/0.3.sap-installation-media-storage-details
+        public:   yes      
+    tags:
+      - 0.3.sap-installation-media-storage-details
+
   - ansible.builtin.set_fact:
       tier:     preparation
 
-  - include_role:
-      name:     roles-sap/0.1-bom-validator
-
+  - block:
+    - include_role:
+        name:     roles-sap/0.1-bom-validator
+    vars:
+      sapbits_location_base_path: "{{ hostvars.localhost.sapbits-location-base-path }}"
+      sapbits_sas_token:          "{{ hostvars.localhost.sapbits_sas_token }}"
+    tags:
+      - 0.1-bom-validator
+  
 
 ...
 # /*---------------------------------------------------------------------------8

--- a/deploy/ansible/playbook_bom_uploader.yaml
+++ b/deploy/ansible/playbook_bom_uploader.yaml
@@ -28,11 +28,25 @@
 #
 # -------------------------------------+---------------------------------------8
 
+  - block:
+    - include_role:
+        name:     roles-misc/0.3.sap-installation-media-storage-details
+        public:   yes      
+    tags:
+      - 0.3.sap-installation-media-storage-details
+
+
   - ansible.builtin.set_fact:
       tier:     "uploader"
 
-  - include_role:
-      name:     roles-sap/0.1-bom-validator
+  - block:
+    - include_role:
+        name:     roles-sap/0.1-bom-validator
+    vars:
+      sapbits_location_base_path: "{{ hostvars.localhost.sapbits-location-base-path }}"
+      sapbits_sas_token:          "{{ hostvars.localhost.sapbits_sas_token }}"
+    tags:
+      - 0.1-bom-validator
 
 
 ...

--- a/deploy/ansible/roles-misc/0.3.sap-installation-media-storage-details/tasks/main.yaml
+++ b/deploy/ansible/roles-misc/0.3.sap-installation-media-storage-details/tasks/main.yaml
@@ -1,0 +1,48 @@
+
+- name: "Get Deployer Keyvault name from keyvault"
+  command: >-
+    az keyvault secret show
+      --vault-name {{ kv_uri }}
+      --name  {{ deployer-kv-name }}
+  changed_when: false
+  register: deployer-kv-name
+  no_log: false
+
+- name: "Extract SAP Binaries Storage Account information"
+  command: >-
+    az keyvault secret show
+      --vault-name {{ deployer-kv-name }}
+      --name {{ sapbits-location-secret }}
+  changed_when: false
+  register: sapbits-location-base-path-secret
+  no_log: false
+
+  ansible.builtin.set_fact:
+    sapbits-location-base-path: >-
+      {{ (sapbits-location-base-path-secret.stdout | from_json).value }}
+  no_log: false
+
+- name: "Debug, storage account"
+  ansible.builtin.debug: 
+    var: sapbits-location-base-path
+    
+
+- name: "Extract SAP Binaries Storage Account SAS"
+  command: >-
+    az keyvault secret show
+      --vault-name {{ deployer-kv-name }}
+      --name {{ sapbits-sas-token-secret }}
+  changed_when: false
+  register: sapbits_sas_token-secret
+  no_log: false
+
+  ansible.builtin.set_fact:
+    sapbits_sas_token: >-
+      {{ (sapbits_sas_token-secret.stdout | from_json).value }}
+  no_log: false
+
+- name: "Debug, SAS Token"
+  ansible.builtin.debug: 
+    var: sapbits_sas_token
+    
+

--- a/deploy/ansible/vars/ansible-input-api.yaml
+++ b/deploy/ansible/vars/ansible-input-api.yaml
@@ -62,6 +62,10 @@ password_db_xsa_admin:        ""
 download_templates:           false
 prometheus:                   false                                                      # Install Prometheus Monitoring Agent
 
+# Keyvault 
+deployer-kv-name:             "deployer-kv-name"                                         # Name of secret containing the deployer keyvault name in the workload zone keyvault
+sapbits-location-secret:      "sapbits_location_base_path"                               # Name of secret containing the SAP Binaries storage account container URL
+sapbits-sas-token-secret:     "sapbits-sas-token"                                        # Name of secret containing the SAP Binaries storage account SAS token
 
 sap_swap:
   - { tier: 'scs',  swap_size_mb: '4096' }


### PR DESCRIPTION
## Problem
Currently the sap-bits key etc are manual inputs, this is both time consuming and error prone

## Solution
Persist the SAP Library details in deplyer keyvault so that Ansible is able to retrieve the details

## Tests
Re-deploy the SAP Library, the SAP Workload Zone to get the secrets stored

## Notes
<Additional comments for the PR>