### PR TITLE
Add support for resource group tags

### DIFF
--- a/deploy/terraform/bootstrap/sap_deployer/tfvar_variables.tf
+++ b/deploy/terraform/bootstrap/sap_deployer/tfvar_variables.tf
@@ -28,6 +28,11 @@ variable "resourcegroup_arm_id" {
   default = ""
 }
 
+
+variable "resourcegroup_tags" {
+  default = {}
+}
+
 /*
 
 This block describes the variables for the VNet block in the json file

--- a/deploy/terraform/bootstrap/sap_deployer/transform.tf
+++ b/deploy/terraform/bootstrap/sap_deployer/transform.tf
@@ -8,6 +8,8 @@ locals {
       name   = try(coalesce(var.resourcegroup_name, try(var.infrastructure.resource_group.name, "")), "")
       arm_id = try(coalesce(var.resourcegroup_arm_id, try(var.infrastructure.resource_group.arm_id, "")), "")
     }
+    tags = try(coalesce(var.resourcegroup_tags, try(var.infrastructure.tags, {})), {})
+
     vnets = {
       management = {
         name          = try(coalesce(var.management_network_name, try(var.infrastructure.vnets.management.name, "")), "")

--- a/deploy/terraform/bootstrap/sap_library/tfvar_variables.tf
+++ b/deploy/terraform/bootstrap/sap_library/tfvar_variables.tf
@@ -29,6 +29,10 @@ variable "resourcegroup_arm_id" {
   default = ""
 }
 
+variable "resourcegroup_tags" {
+  default = {}
+}
+
 /*
 
 /*

--- a/deploy/terraform/bootstrap/sap_library/transform.tf
+++ b/deploy/terraform/bootstrap/sap_library/transform.tf
@@ -8,6 +8,7 @@ locals {
       name   = try(coalesce(var.resourcegroup_name, try(var.infrastructure.resource_group.name, "")), "")
       arm_id = try(coalesce(var.resourcegroup_arm_id, try(var.infrastructure.resource_group.arm_id, "")), "")
     }
+    tags = try(coalesce(var.resourcegroup_tags, try(var.infrastructure.tags, {})), {})
   }
   deployer = {
     environment = coalesce(var.deployer_environment, try(var.deployer.environment, ""))

--- a/deploy/terraform/run/sap_deployer/output.tf
+++ b/deploy/terraform/run/sap_deployer/output.tf
@@ -92,3 +92,7 @@ output "firewall_id" {
 output "automation_version" {
   value = local.version_label
 }
+
+output "tags" {
+  value = local.infrastructure.tags
+}

--- a/deploy/terraform/run/sap_deployer/tfvar_variables.tf
+++ b/deploy/terraform/run/sap_deployer/tfvar_variables.tf
@@ -28,6 +28,10 @@ variable "resourcegroup_arm_id" {
   default = ""
 }
 
+variable "resourcegroup_tags" {
+  default = {}
+}
+
 /*
 
 This block describes the variables for the VNet block in the json file

--- a/deploy/terraform/run/sap_deployer/transform.tf
+++ b/deploy/terraform/run/sap_deployer/transform.tf
@@ -8,6 +8,7 @@ locals {
       name   = try(coalesce(var.resourcegroup_name, try(var.infrastructure.resource_group.name, "")), "")
       arm_id = try(coalesce(var.resourcegroup_arm_id, try(var.infrastructure.resource_group.arm_id, "")), "")
     }
+    tags = try(merge(var.resourcegroup_tags, try(var.infrastructure.tags, {})), {})
     vnets = {
       management = {
         name          = try(coalesce(var.management_network_name, try(var.infrastructure.vnets.management.name, "")), "")

--- a/deploy/terraform/run/sap_landscape/tfvar_variables.tf
+++ b/deploy/terraform/run/sap_landscape/tfvar_variables.tf
@@ -28,6 +28,10 @@ variable "resourcegroup_arm_id" {
   default = ""
 }
 
+variable "resourcegroup_tags" {
+  default = {}
+}
+
 /*
 
 This block describes the variables for the VNet block in the json file

--- a/deploy/terraform/run/sap_landscape/transform.tf
+++ b/deploy/terraform/run/sap_landscape/transform.tf
@@ -36,6 +36,7 @@ locals {
     environment = coalesce(var.environment, try(var.infrastructure.environment, ""))
     region      = coalesce(var.location, try(var.infrastructure.region, ""))
     codename    = try(var.codename, try(var.infrastructure.codename, ""))
+    tags        = try(merge(var.resourcegroup_tags, try(var.infrastructure.tags, {})), {})
   }
 
   authentication = {

--- a/deploy/terraform/run/sap_library/tfvar_variables.tf
+++ b/deploy/terraform/run/sap_library/tfvar_variables.tf
@@ -29,6 +29,10 @@ variable "resourcegroup_arm_id" {
   default = ""
 }
 
+variable "resourcegroup_tags" {
+  default = {}
+}
+
 /*
 
 /*

--- a/deploy/terraform/run/sap_library/transform.tf
+++ b/deploy/terraform/run/sap_library/transform.tf
@@ -8,6 +8,7 @@ locals {
       name   = try(coalesce(var.resourcegroup_name, try(var.infrastructure.resource_group.name, "")), "")
       arm_id = try(coalesce(var.resourcegroup_arm_id, try(var.infrastructure.resource_group.arm_id, "")), "")
     }
+    tags = try(merge(var.resourcegroup_tags, try(var.infrastructure.tags, {})), {})
   }
   deployer = {
     environment = coalesce(var.deployer_environment, try(var.deployer.environment, ""))

--- a/deploy/terraform/run/sap_system/tfvar_variables.tf
+++ b/deploy/terraform/run/sap_system/tfvar_variables.tf
@@ -28,6 +28,10 @@ variable "resourcegroup_arm_id" {
   default = ""
 }
 
+variable "resourcegroup_tags" {
+  default = {}
+}
+
 variable "proximityplacementgroup_names" {
   default = []
 }

--- a/deploy/terraform/run/sap_system/transform.tf
+++ b/deploy/terraform/run/sap_system/transform.tf
@@ -5,6 +5,7 @@ locals {
     environment = coalesce(var.environment, try(var.infrastructure.environment, ""))
     region      = coalesce(var.location, try(var.infrastructure.region, ""))
     codename    = try(var.codename, try(var.infrastructure.codename, ""))
+    tags        = try(merge(var.resourcegroup_tags, try(var.infrastructure.tags, {})), {})
   }
 
 

--- a/deploy/terraform/terraform-units/modules/sap_deployer/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_deployer/infrastructure.tf
@@ -76,12 +76,8 @@ resource "azurerm_resource_group" "deployer" {
   count    = local.enable_deployers && !local.rg_exists ? 1 : 0
   name     = local.rg_name
   location = local.region
+  tags     = var.infrastructure.tags
 
-  lifecycle {
-    ignore_changes = [
-      tags
-    ]
-  }
 }
 
 data "azurerm_resource_group" "deployer" {

--- a/deploy/terraform/terraform-units/modules/sap_landscape/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/infrastructure.tf
@@ -9,12 +9,7 @@ resource "azurerm_resource_group" "resource_group" {
   count    = local.rg_exists ? 0 : 1
   name     = local.rg_name
   location = local.region
-
-  lifecycle {
-    ignore_changes = [
-      tags
-    ]
-  }
+  tags     = var.infrastructure.tags
 
 }
 

--- a/deploy/terraform/terraform-units/modules/sap_library/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_library/infrastructure.tf
@@ -8,12 +8,8 @@ resource "azurerm_resource_group" "library" {
   count    = local.rg_exists ? 0 : 1
   name     = local.rg_name
   location = local.region
+  tags     = var.infrastructure.tags
 
-  lifecycle {
-    ignore_changes = [
-      tags
-    ]
-  }
 }
 
 // Imports data of existing resource group

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/infrastructure.tf
@@ -4,12 +4,8 @@ resource "azurerm_resource_group" "resource_group" {
   count    = local.rg_exists ? 0 : 1
   name     = local.rg_name
   location = local.region
+  tags     = var.infrastructure.tags
 
-  lifecycle {
-    ignore_changes = [
-      tags
-    ]
-  }
 }
 
 // Imports data of existing resource group


### PR DESCRIPTION
## Problem
Add the ability to provide tags on the resource groups

## Solution
Add the tags attribute to the resourcegroup resource blocks

## Tests
Provide either
resourcegroup_tags = {
    "foo" = "bar"
}

or

  "tags": {
      "Foo": "Bar"
    }

in the infrastructure section

## Notes
<Additional comments for the PR>