### PR TITLE
Add protection for deletion of resource groups still containing items

### DIFF
--- a/deploy/terraform/run/sap_landscape/providers.tf
+++ b/deploy/terraform/run/sap_landscape/providers.tf
@@ -13,7 +13,10 @@
 */
 
 provider "azurerm" {
-  features {}
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = true
+    }
   subscription_id = local.spn.subscription_id
   client_id       = local.use_spn ? local.spn.client_id : null
   client_secret   = local.use_spn ? local.spn.client_secret : null

--- a/deploy/terraform/run/sap_system/providers.tf
+++ b/deploy/terraform/run/sap_system/providers.tf
@@ -13,7 +13,11 @@
 */
 
 provider "azurerm" {
-  features {}
+  features { 
+    resource_group {
+      prevent_deletion_if_contains_resources = true
+  }
+}
   subscription_id = local.spn.subscription_id
   client_id       = local.spn.client_id
   client_secret   = local.spn.client_secret

--- a/deploy/terraform/terraform-units/modules/sap_landscape/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/infrastructure.tf
@@ -11,6 +11,15 @@ resource "azurerm_resource_group" "resource_group" {
   location = local.region
   tags     = var.infrastructure.tags
 
+  prevent_deletion_if_contains_resources = true
+
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
+
+
 }
 
 // Imports data of existing resource group

--- a/deploy/terraform/terraform-units/modules/sap_landscape/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_landscape/infrastructure.tf
@@ -11,8 +11,6 @@ resource "azurerm_resource_group" "resource_group" {
   location = local.region
   tags     = var.infrastructure.tags
 
-  prevent_deletion_if_contains_resources = true
-
   lifecycle {
     ignore_changes = [
       tags

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/infrastructure.tf
@@ -6,6 +6,14 @@ resource "azurerm_resource_group" "resource_group" {
   location = local.region
   tags     = var.infrastructure.tags
 
+  prevent_deletion_if_contains_resources = true
+
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
+
 }
 
 // Imports data of existing resource group

--- a/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/infrastructure.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/common_infrastructure/infrastructure.tf
@@ -6,7 +6,6 @@ resource "azurerm_resource_group" "resource_group" {
   location = local.region
   tags     = var.infrastructure.tags
 
-  prevent_deletion_if_contains_resources = true
 
   lifecycle {
     ignore_changes = [


### PR DESCRIPTION
## Problem
Currently a terraform destroy deletes the resource group it created. If there are items created outside of Terraform these would be deleted as well.

## Solution
Add the feature flag blocking terraform destroying resource groups with content

## Tests
Deploy a SAP Deployment and add a VM to the resource group. Try to run terrafrom detroys
## Notes
This will be the default behaviour in Terraform Azure providers v.3 and onwards