### PR TITLE
Just warn instead of error some ansible lint rules

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -11,12 +11,19 @@ exclude_paths:
   - PoC/
   - .github/
 
-skip_list:
+warn_list:
   # FIXME: rename roles to use _ instead of -
   - role-name
 
+  # FIXME: this should be done in separate PR
+  - command-instead-of-shell
+
+  # FIXME: Experimental violations should be fixed in separate PR
+  - experimental
+
+skip_list:
   # Ignored because there is no easier way to do
-  - empty-string-compare 
+  - empty-string-compare
 
   # Following are ignored because of readability:
   - line-length

--- a/.github/workflows/github-actions-ansible-lint.yml
+++ b/.github/workflows/github-actions-ansible-lint.yml
@@ -8,7 +8,7 @@ jobs:
     - uses: BSFishy/pip-action@v1
       with:
         packages: |
-          ansible==2.9
+          ansible==2.10
           ansible-lint
     - run: "ansible-lint -v --force-color"
       working-directory: ${{ github.workspace }}

--- a/deploy/ansible/roles-db/4.0.0-hdb-install/tasks/main.yaml
+++ b/deploy/ansible/roles-db/4.0.0-hdb-install/tasks/main.yaml
@@ -90,6 +90,7 @@
 
 - name:                               "SAP HANA: Execute hdblcm"
   ansible.builtin.shell: |
+                                      set -o pipefail
                                       set -o errexit
                                       pwd=$(<{{ dir_params }}/hdbserver_{{ ansible_hostname }}_{{ sap_sid }}_passwords.xml)
                                       echo $pwd | \

--- a/deploy/ansible/roles-os/1.17-generic-pacemaker/tasks/1.17.2.0-cluster-RedHat.yml
+++ b/deploy/ansible/roles-os/1.17-generic-pacemaker/tasks/1.17.2.0-cluster-RedHat.yml
@@ -69,6 +69,7 @@
 
 - name: Ensure the expected quorum votes is set for the cluster
   ansible.builtin.shell: "pcs quorum expected-votes {{ cluster_quorum.expected_votes }}"
+  changed_when: false
 
 - name: Configure the cluster STONITH device on the primary node
   block:

--- a/deploy/ansible/roles-os/1.17-generic-pacemaker/tasks/1.17.3-post_provision_report.yml
+++ b/deploy/ansible/roles-os/1.17-generic-pacemaker/tasks/1.17.3-post_provision_report.yml
@@ -15,7 +15,7 @@
     msg: "{{ cluster_status_report.stdout }}"
 
 - name: Check the SBD devices status
-  ansible.builtin.shell: crm_mon -1 | grep sbd
+  ansible.builtin.shell: set -o pipefail && crm_mon -1 | grep sbd
   register: sbd_status_report
   changed_when: false
   failed_when: false

--- a/deploy/ansible/roles-sap-os/2.10-sap-notes/tasks/2.10.0.yaml
+++ b/deploy/ansible/roles-sap-os/2.10-sap-notes/tasks/2.10.0.yaml
@@ -5,6 +5,7 @@
 # TODO: when tier = HANA; put in a block; move to sap specific
 - name:     Task Disable Transparent Hugepages & Configure Processor C-States 1
   ansible.builtin.command:    "echo never > /sys/kernel/mm/transparent_hugepage/enabled"
+  changed_when: false
 
 - name:     Task Disable Transparent Hugepages & Configure Processor C-States 2
   ansible.builtin.lineinfile:
@@ -14,6 +15,7 @@
 
 - name:     Task Disable Transparent Hugepages & Configure Processor C-States 3
   ansible.builtin.command:    grub2-mkconfig -o /boot/grub2/grub.cfg
+  changed_when: false
 
 ...
 # /*----------------------------------------------------------------------------8

--- a/deploy/ansible/roles-sap/5.1-dbload/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/5.1-dbload/tasks/main.yaml
@@ -43,7 +43,7 @@
     sap_ciVirtualHostname:
     sap_appVirtualHostname:
   tags:
-  - skip_ansible_lint
+    - skip_ansible_lint
 
 # *====================================4=======================================8
 #   SAP DBLOAD: Install
@@ -83,7 +83,7 @@
     chdir:                             /usr/sap/install/SWPM
     creates:                           /etc/sap_deployment_automation/sap_deployment_dbload.txt
   tags:
-  - skip_ansible_lint
+    - skip_ansible_lint
 
 ...
 # /*---------------------------------------------------------------------------8

--- a/deploy/ansible/roles-sap/5.2-pas-install/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/5.2-pas-install/tasks/main.yaml
@@ -48,7 +48,7 @@
     sap_ciVirtualHostname:        "{{ query('inventory_hostnames', '{{ sap_sid|upper }}_PAS') | first }}"
     sap_appVirtualHostname:
   tags:
-  - skip_ansible_lint
+    - skip_ansible_lint
 
 # *====================================4=======================================8
 #   SAP PAS: Install
@@ -90,7 +90,7 @@
     chdir:            /usr/sap/install/SWPM
     creates:          /etc/sap_deployment_automation/sap_deployment_pas.txt
   tags:
-  - skip_ansible_lint
+    - skip_ansible_lint
   # Skip when TRUE (test mode)
   # when: not test_new_bom
 # *====================================4=======================================8

--- a/deploy/ansible/roles-sap/5.3-app-install/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/5.3-app-install/tasks/main.yaml
@@ -48,7 +48,7 @@
     sap_ciVirtualHostname:        "{{ query('inventory_hostnames', '{{ sap_sid|upper }}_PAS') | first }}"
     sap_appVirtualHostname:       "{{ inventory_hostname }}"
   tags:
-  - skip_ansible_lint
+    - skip_ansible_lint
 
 # *====================================4=======================================8
 #   SAP APP: Install
@@ -90,7 +90,7 @@
     chdir:            /usr/sap/install/SWPM
     creates:          /etc/sap_deployment_automation/sap_deployment_app.txt
   tags:
-  - skip_ansible_lint
+    - skip_ansible_lint
   # Skip when TRUE (test mode)
   # when: not test_new_bom
 # *====================================4=======================================8

--- a/deploy/ansible/roles-sap/5.4-web-install/tasks/main.yaml
+++ b/deploy/ansible/roles-sap/5.4-web-install/tasks/main.yaml
@@ -39,7 +39,7 @@
     sap_db_hostname:              "{{ query('inventory_hostnames', '{{ sap_sid|upper }}_DB')  | first }}"
     sap_webVirtualHostname:       "{{ inventory_hostname }}"
   tags:
-  - skip_ansible_lint
+    - skip_ansible_lint
 
 # *====================================4=======================================8
 #   SAP Web Dispatcher: Install
@@ -59,7 +59,7 @@
     chdir:            /usr/sap/install/SWPM
     creates:          /etc/sap_deployment_automation/sap_deployment_web.txt
   tags:
-  - skip_ansible_lint
+    - skip_ansible_lint
   # Skip when TRUE (test mode)
   # when: not test_new_bom
 # *====================================4=======================================8

--- a/deploy/ansible/roles-sap/5.5-hanadb-pacemaker/tasks/5.5.5-post_provision_report.yml
+++ b/deploy/ansible/roles-sap/5.5-hanadb-pacemaker/tasks/5.5.5-post_provision_report.yml
@@ -15,7 +15,7 @@
     msg:                    "{{ cluster_status_report.stdout }}"
 
 - name:                     Check the SBD devices status
-  ansible.builtin.shell:    crm_mon -1 | grep sbd
+  ansible.builtin.shell:    set -o pipefail && crm_mon -1 | grep sbd
   register:                 sbd_status_report
   changed_when:             false
   failed_when:              false


### PR DESCRIPTION
## Problem
<Please describe what problem this PR is trying to resolve>
Make the `ansible-lint` job green, by just print the errors, but not making the job fail in case of rules: `command-instead-of-shell` and `experimental`. 

## Solution
<Please elaborate the solution for the problem>

## Tests
<Please provide steps to test the PR>

## Notes
<Additional comments for the PR>