### PR TITLE
Disk changes, logical volumes will be conditionally created based on …

### DIFF
--- a/deploy/ansible/roles-os/1.5-disk-setup/tasks/main.yml
+++ b/deploy/ansible/roles-os/1.5-disk-setup/tasks/main.yml
@@ -63,61 +63,125 @@
 
 # Get all the unique disk types from sap-parameters
 
-# -------------------------------------+---------------------------------------8
-#
-- name:                                Load the disk configuration settings
-  ansible.builtin.include_vars:        disks_config.yml
-
-- name:                                "Print unique disks"
-  ansible.builtin.debug:
-    var:                               
-    - disktypes
-    - volume_groups
-    verbosity:                         2
 
 # -------------------------------------+---------------------------------------8
 #
-- name:                                "Volume Group creation"
-  ansible.builtin.lvg:
-    vg:                                "{{ item.vg }}"
-    pvs:                               "{{ item.pvs }}"
-    pesize:                            4M
-    state:                             present
-  loop:                                "{{ volume_groups }}"
+- name:                      Load the disk configuration settings
+  include_vars:              disks_config.yml
+
+- name:                          "print unique disks"
+  debug:
+    var:                         disktypes
+    verbosity:                   2
+
+- name:                          "Print volume group details"
+  debug:
+    var:                         volume_groups
+    #verbosity:                   2
+
+
+#CREATE VOLUME GROUPS BASED ON sap-parameters.yaml
+# -------------------------------------+---------------------------------------8
+#
+- name:                           "Volume Group creation"
+  lvg:
+    vg:                           "{{ item.vg }}"
+    pvs:                          "{{ item.pvs }}"
+    pesize:                       4M
+    state:                        present
+  loop:                           "{{ volume_groups }}"
   when:
     - tier == "sapos"
+  register: vgscreated  
+
+- name: "Filter the vg name from vgscreated results"
+  set_fact:
+    vgcreatedlist: "{{ vgscreated | json_query('results[*].item.vg') }}"
+
+#Debug for testing
+- name:                          "Print vgcreated details"
+  debug:
+    var:                        vgcreatedlist
+
+- name:                         "Print logical group details"
+  debug:
+    var:                         logical_volumes
+
+- name:                          "created logical group details"
+  debug:
+    var:                         vgscreated.results
+    #verbosity:                   2
+
+#Debug testing end of line 
 
 
+#CREATE LOGICAL VOLUMES BASED ON VGCREATEDLIST
 # -------------------------------------+---------------------------------------8
 #
-- name:                                "Logical Volume creation"
-  ansible.builtin.lvol:
-    lv:                                "{{ item.lv }}"
-    vg:                                "{{ item.vg }}"
-    size:                              "{{ item.size }}"
-    opts:                              "{{ lvol_opts_from_lv_item }}"
-    active:                            true
-    state:                             present
-    shrink:                            false
-    resizefs:                          false
-  loop:                                "{{ logical_volumes }}"
-  when:
-    - item.tier in ["all", tier]
-    - item.node_tier in ["all", node_tier]
-
-
-# -------------------------------------+---------------------------------------8
-#
-- name:                                "Filesystem creation"
-  ansible.builtin.filesystem:
-    dev:                               "{{ dev_path_from_lv_item }}"
-    fstype:                            "{{ item.fstype }}"
-    opts:                              "{{ item.fsopts | default('') }}"
+- name:                           "Logical Volume creation"
+  lvol:
+    lv:                           "{{ item.lv }}"
+    vg:                           "{{ item.vg }}"
+    size:                         "{{ item.size }}"
+    opts:                         "{{ lvol_opts_from_lv_item }}"
+    active:                       yes
+    state:                        present
+    shrink:                       no
+    resizefs:                     no
   loop: "{{ logical_volumes }}"
   when:
-    - item.tier in ["all", tier]
+    - tier == "sapos"
     - item.node_tier in ["all", node_tier]
-    - item.fstype is defined
+    - item.vg in vgcreatedlist 
+  register: lvscreated 
+
+  
+#Debug for testing
+- name:                           "Print vgcreated details"
+  debug:
+    var:                         lvscreated
+
+
+- name: "Filter the logical volumes created results"
+  set_fact:
+    lvcreatedlist_tmp: "{{ lvscreated.results | rejectattr('skipped', 'defined') | list }}"
+
+    
+#Debug for testing
+- name:                           "Print vgcreated filtered details"
+  debug:
+    var:                         lvcreatedlist_tmp
+
+#- fail: msg="here"
+
+- name: "Filter the logical volumes created results1"
+  set_fact:
+    lvcreatedlist: "{{ lvcreatedlist_tmp | map(attribute='item.lv') | list }}"
+    
+
+#Debug for testing
+- name:                           "Print vgcreated details"
+  debug:
+    var:                         lvcreatedlist
+
+
+- name:                       "Filesystem creation"
+  filesystem:
+    dev:                       "{{ dev_path_from_lv_item }}"
+    fstype:                    "{{ item.fstype }}"
+    opts:                      "{{ item.fsopts | default('') }}"
+  loop: "{{ logical_volumes }}"
+  when:
+        - item.tier in ["all", tier ]
+        - item.node_tier in ["all", node_tier]
+        - item.fstype is defined
+        - item.lv in lvcreatedlist     
+  register : filesystemscreated    
+  
+#Debug for testing
+- name:                           "Print values to be passed for filesystem creation"
+  debug:
+    var:                         filesystemscreated
 
 ...
 # /*---------------------------------------------------------------------------8


### PR DESCRIPTION
…the volumes groups. Files systems will be created based on the logical volumes created.

## Problem
Currently the logical volumes and file systems are not created based on the vg availability. Due to this issue, intermittently  the blkid is not generated. 
Ansible "file system" module is not idempotent. It checks for file systems using blkid. Due to the above problem, it cannot find an entry of the previously created file systems. 
When the sap-os configuration playbook  is rerun , it will attempt to create and format the file systems but fails due to missing entries.

## Solution
We track  the logical volumes created and create the logical volumes based on volumes groups created in previous step.
We then track the logical volumes created and create the file systems based on the logical volumes created in previous step and then track the file systems created and pass it to mkfs.xfs to make an entry into blkid.

## Tests
${DEPLOYMENT_REPO_PATH}/deploy/ansible/test_menu.sh --> Select option2. 
Rerun the above command multiple time to test idempotency of ansible file system module.

## Notes
Ansible "file system" module is not idempotent when it there is not entry of the previously created file system in blkid.