### PR TITLE
sapmnt nfs mount is missing on PAS

### DIFF
--- a/deploy/ansible/playbook_05_02_sap_pas_install.yaml
+++ b/deploy/ansible/playbook_05_02_sap_pas_install.yaml
@@ -58,6 +58,21 @@
         - always
 
 # -------------------------------------+---------------------------------------8
+# Role: 2.6-SAP Mounts
+#
+# Description:
+#
+# -------------------------------------+---------------------------------------8
+
+    - block:
+        - name:                        Include 2.6-sap-mounts
+          ansible.builtin.include_role:
+            name:     roles-sap-os/2.6-sap-mounts
+      tags:
+        - 2.6-sap-mounts
+
+
+# -------------------------------------+---------------------------------------8
 # Role: 5.2-PAS Installation
 #
 # Description:

--- a/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/main.yaml
+++ b/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/main.yaml
@@ -57,7 +57,7 @@
   loop:
     - { type: 'nfs4',  src: '{{ nfs_server }}:/sapmnt/{{ sap_sid|upper }}',  path: '/sapmnt/{{ sap_sid|upper }}' }
   when:
-    - tier == 'dbload' or tier == 'app'
+    - tier == 'dbload' or tier == 'app' or tier == 'pas' 
     - node_tier == 'pas' or node_tier =='app'
     - sap_mnt | default ('none') | trim | length == 4
 


### PR DESCRIPTION
## Problem
sapmnt nfs mount is missing on PAS

## Solution
Add tier==pas condition in sap-mounts. 
Call the sap-mounts block in pas install playbook.

## Tests
Install PAS.

## Notes
<Additional comments for the PR>