### PR TITLE
Fix doc and samples reference examples to match recent changes

### DIFF
--- a/deploy/samples/WORKSPACES/DEPLOYER/MGMT-WEEU-DEP00-INFRASTRUCTURE/MGMT-WEEU-DEP00-INFRASTRUCTURE.tfvars
+++ b/deploy/samples/WORKSPACES/DEPLOYER/MGMT-WEEU-DEP00-INFRASTRUCTURE/MGMT-WEEU-DEP00-INFRASTRUCTURE.tfvars
@@ -120,7 +120,7 @@ This block describes the variables for the authentication section block in the j
 This block describes the variables for the options section block in the json file
 */
 
-#enable_deployer_public_ip=false
+#deployer_enable_public_ip=false
 # firewall_deployment is a boolean flag controlling if an Azure firewall is to be deployed in the deployer VNet
 firewall_deployment=true
 

--- a/documentation/SAP_Automation_on_Azure/Process_Documentation/WORKSPACES/DEPLOYER/MGMT-EUS2-DEP01-INFRASTRUCTURE/MGMT-EUS2-DEP01-INFRASTRUCTURE.json
+++ b/documentation/SAP_Automation_on_Azure/Process_Documentation/WORKSPACES/DEPLOYER/MGMT-EUS2-DEP01-INFRASTRUCTURE/MGMT-EUS2-DEP01-INFRASTRUCTURE.json
@@ -15,7 +15,7 @@
     }
   },
   "options": {
-    "enable_deployer_public_ip" : true
+    "deployer_enable_public_ip" : true
   },
   "firewall_deployment"         : true
 }

--- a/documentation/SAP_Automation_on_Azure/Process_Documentation/WORKSPACES/DEPLOYER/MGMT-WEEU-DEP00-INFRASTRUCTURE/MGMT-WEEU-DEP00-INFRASTRUCTURE.json
+++ b/documentation/SAP_Automation_on_Azure/Process_Documentation/WORKSPACES/DEPLOYER/MGMT-WEEU-DEP00-INFRASTRUCTURE/MGMT-WEEU-DEP00-INFRASTRUCTURE.json
@@ -15,7 +15,7 @@
     }
   },
   "options": {
-    "enable_deployer_public_ip" : true
+    "deployer_enable_public_ip" : true
   },
   "firewall_deployment"         : true
 }

--- a/documentation/SAP_Automation_on_Azure/Process_Documentation/WORKSPACES/DEPLOYER/MGMT-WEEU-DEP00-INFRASTRUCTURE/MGMT-WEEU-DEP00-INFRASTRUCTURE.tfvars
+++ b/documentation/SAP_Automation_on_Azure/Process_Documentation/WORKSPACES/DEPLOYER/MGMT-WEEU-DEP00-INFRASTRUCTURE/MGMT-WEEU-DEP00-INFRASTRUCTURE.tfvars
@@ -77,7 +77,7 @@ This block describes the variables for the key_vault section block in the json f
 This block describes the variables for the options section block in the json file
 */
 
-#enable_deployer_public_ip=false
+#deployer_enable_public_ip=false
 
 firewall_deployment=true
 #firewall_rule_subnets=[]

--- a/documentation/SAP_Automation_on_Azure/Software_Documentation/configuration-deployer.md
+++ b/documentation/SAP_Automation_on_Azure/Software_Documentation/configuration-deployer.md
@@ -60,7 +60,7 @@ The configuration of the deployement infrastructure is achieved using a json for
   },
 
   "options": {
-    "enable_deployer_public_ip"       : false                                     <-- Optional, Default: false
+    "deployer_enable_public_ip"       : false                                     <-- Optional, Default: false
   },
   "firewall_deployment"               : true                                      <-- Optional, Default: false
 }                                                                                 <-- JSON Closing tag
@@ -100,7 +100,7 @@ The complete set of configuratiuon options is listed in the table below.
 | authentication                                        | `path_to_public_key`          | optional      | -        | - Not required in a standard deployment.<br/> <!-- TODO: Yunzi --> |
 | authentication                                           | `path_to_private_key`         | optional      | -        | - Not required in a standard deployment.<br/> <!-- TODO: Yunzi --> |
 ||<p>| 
-| options                                           | `enable_deployer_public_ip`   | optional      | false    | Controls whether the deployer VM will have a public IP address or not.- Not required in a standard deployment.|
+| options                                           | `deployer_enable_public_ip`   | optional      | false    | Controls whether the deployer VM will have a public IP address or not.- Not required in a standard deployment.|
 |<p>| 
 | firewall_deployment                                           | `true/false`   | optional      | false    | Controls whether the deployment will include an Azure Firewall|
 
@@ -162,7 +162,7 @@ The complete set of configuratiuon options is listed in the table below.
       "path_to_private_key"             : "sshkey"
     },
   "options": {
-      "enable_deployer_public_ip"       : false
+      "deployer_enable_public_ip"       : false
     },
   "firewall_deployment"                 : true
   }

--- a/documentation/SAP_Automation_on_Azure/Software_Documentation/workshops/accelerated/02-prepare-environment.md
+++ b/documentation/SAP_Automation_on_Azure/Software_Documentation/workshops/accelerated/02-prepare-environment.md
@@ -130,7 +130,7 @@
         }
       },
       "options": {
-        "enable_deployer_public_ip"           : true
+        "deployer_enable_public_ip"           : true
       },
       "firewall_deployment"                   : true,
       "enable_purge_control_for_keyvaults"    : false
@@ -163,7 +163,7 @@
         }
       },
       "options": {
-        "enable_deployer_public_ip"           : true
+        "deployer_enable_public_ip"           : true
       },
       "firewall_deployment"                   : true,
       "enable_purge_control_for_keyvaults"    : false

--- a/documentation/SAP_Automation_on_Azure/Software_Documentation/workshops/accelerated/templates/NP-EUS2-DEP00-INFRASTRUCTURE.json
+++ b/documentation/SAP_Automation_on_Azure/Software_Documentation/workshops/accelerated/templates/NP-EUS2-DEP00-INFRASTRUCTURE.json
@@ -16,7 +16,7 @@
     }
   },
   "options": {
-    "enable_deployer_public_ip"           : true
+    "deployer_enable_public_ip"           : true
   },
   "firewall_deployment"                   : true
 }

--- a/documentation/SAP_Automation_on_Azure/Software_Documentation/workshops/manual-infrastructure-deployment/01-bootstrap-deployer.md
+++ b/documentation/SAP_Automation_on_Azure/Software_Documentation/workshops/manual-infrastructure-deployment/01-bootstrap-deployer.md
@@ -132,7 +132,7 @@
         }
       },
       "options": {
-        "enable_deployer_public_ip"           : true
+        "deployer_enable_public_ip"           : true
       },
       "firewall_deployment"                   : true
     }

--- a/documentation/SAP_Automation_on_Azure/Software_Documentation/workshops/manual-infrastructure-deployment/templates/DEMO-EUS2-DEP00-INFRASTRUCTURE.json
+++ b/documentation/SAP_Automation_on_Azure/Software_Documentation/workshops/manual-infrastructure-deployment/templates/DEMO-EUS2-DEP00-INFRASTRUCTURE.json
@@ -16,7 +16,7 @@
     }
   },
   "options": {
-    "enable_deployer_public_ip"           : true
+    "deployer_enable_public_ip"           : true
   },
   "firewall_deployment"                   : true
 }


### PR DESCRIPTION
Recently the enable_deployer_public_ip config setting was renamerd to
deployer_enable_public_ip but some of the existing references in the
documentation and deploy/samples WORKSPACE reference examples were not
updated to match, as well as some of the embedded example configs in
the docs.