### PR TITLE
Add the ability to deploy HANA with just a single NIC

### DIFF
--- a/deploy/terraform/run/sap_system/module.tf
+++ b/deploy/terraform/run/sap_system/module.tf
@@ -88,6 +88,7 @@ module "hdb_node" {
   cloudinit_growpart_config                    = null # This needs more consideration module.common_infrastructure.cloudinit_growpart_config
   license_type                                 = var.license_type
   use_loadbalancers_for_standalone_deployments = var.use_loadbalancers_for_standalone_deployments
+  hana_dual_nics                               = var.hana_dual_nics
 
 }
 

--- a/deploy/terraform/run/sap_system/tfvar_variables.tf
+++ b/deploy/terraform/run/sap_system/tfvar_variables.tf
@@ -537,3 +537,8 @@ variable "use_loadbalancers_for_standalone_deployments" {
   default = true
 }
 
+variable "hana_dual_nics" {
+  default = true
+}
+
+

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/variables_local.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/variables_local.tf
@@ -88,6 +88,11 @@ variable "use_loadbalancers_for_standalone_deployments" {
   default     = true
 }
 
+variable "hana_dual_nics" {
+  description = "Defines if the HANA DB uses dual network interfaces"
+  default = true
+}
+
 
 locals {
   // Resources naming


### PR DESCRIPTION
## Problem
Currently the HANA deployment has two network interfaces, not all customers want that.

The AnyDB and the App tiers already have that capability

## Solution
Provide an ability to use just a single network interface for HANA

## Tests
Provide 
hana_dual_nics=false in tfvars or json file

## Notes
<Additional comments for the PR>