### PR TITLE
Don't fallback on 'none' string

### DIFF
--- a/deploy/ansible/roles-sap-os/2.4-hosts-file/tasks/pre_checks.yaml
+++ b/deploy/ansible/roles-sap-os/2.4-hosts-file/tasks/pre_checks.yaml
@@ -8,7 +8,7 @@
   ansible.builtin.assert:
     that:
       - "sap_fqdn is defined"                                 # Has the variable been defined
-      - "sap_fqdn | default('none') | trim | length > 4"      #   and given a value
+      - "sap_fqdn | trim | length != 0"                       #   and given a value
 
 # -------------------------------------+---------------------------------------8
 

--- a/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/main.yaml
+++ b/deploy/ansible/roles-sap-os/2.6-sap-mounts/tasks/main.yaml
@@ -44,7 +44,7 @@
   when:
     - tier == 'sapos'
     - node_tier == 'pas' or node_tier =='app'
-    - sap_mnt | default ('none') | trim | length == 4
+    - sap_mnt is undefined
 
 # Mount Filesystems
 - name:                                Mount Filesystems when not using ANF (app & pas)
@@ -59,7 +59,7 @@
   when:
     - tier == 'dbload' or tier == 'app'
     - node_tier == 'pas' or node_tier =='app'
-    - sap_mnt | default ('none') | trim | length == 4
+    - sap_mnt is undefined
 
 
 # Mount Filesystems
@@ -74,7 +74,7 @@
     - { type: 'nfs4',  src: '{{ nfs_server }}:/usr/sap/install',             path: '/usr/sap/install'  }
   when:
     - tier == 'sapos'
-    - sap_mnt | default ('none') | trim | length == 4
+    - sap_mnt is undefined
     - node_tier == 'hana'
 
 # Mount Filesystems
@@ -89,7 +89,7 @@
     - { type: 'xfs',  src: '/dev/vg_sap/lv_sapmnt',  path: '/sapmnt/{{ sap_sid|upper }}' }
   when:
     - tier == 'sapos'
-    - sap_mnt | default ('none') | trim | length == 4
+    - sap_mnt is undefined
     - node_tier == 'scs'
 
 # Import this task only if the sap_mnt is defined, i.e. ANF is used
@@ -103,7 +103,7 @@
   ansible.builtin.import_tasks:        2.6.1-anf-mounts.yaml
   when:
     - sap_mnt is defined or sap_trans is defined
-    - sap_mnt | default ('none') | trim | length > 4
+    - sap_mnt | trim | length != 0
     - tier == 'sapos'
 
 ...

--- a/deploy/ansible/roles-sap/3.3-bom-processing/tasks/pre_checks.yaml
+++ b/deploy/ansible/roles-sap/3.3-bom-processing/tasks/pre_checks.yaml
@@ -16,7 +16,7 @@
       - "sapbits_bom_files | trim | length != 0"                                #   and given a value
 
       - "bom_base_name is defined"                                              # Has the variable been defined
-      - "bom_base_name | default ('none') | trim | length > 4"                  #   and given a value
+      - "bom_base_name | trim | length != 0"                                    #   and given a value
 
       - "target_media_location is defined"                                      # Has the variable been defined
       - "target_media_location | trim | length != 0"                            #   and given a value


### PR DESCRIPTION
## Problem
<Please describe what problem this PR is trying to resolve>
This patch removes checks that rely on fallback to 'none' string and
rather check that the variable is undefined or defined.