### PR TITLE
Env and region needed before env config path generated

### DIFF
--- a/deploy/scripts/set_secrets.sh
+++ b/deploy/scripts/set_secrets.sh
@@ -102,6 +102,14 @@ while :; do
     esac
 done
 
+while [ -z "${environment}" ]; then
+    read -r -p "Environment name: " environment
+fi
+
+while [ -z "${region}" ]; then
+    read -r -p "Region name: " region
+fi
+
 automation_config_directory=~/.sap_deployment_automation
 environment_config_information="${automation_config_directory}"/"${environment}""${region}"
 
@@ -110,10 +118,6 @@ if [ ! -d "${automation_config_directory}" ]; then
     mkdir "${automation_config_directory}"
 else
     touch "${environment_config_information}"
-fi
-
-if [ -z "${environment}" ]; then
-    read -r -p "Environment name:" environment
 fi
 
 if [ -z "$subscription" ]; then


### PR DESCRIPTION
We need to ensure we have the env and region values assigned, either
via CLI options, or via prompted data entry, before we assign the path
to the environment specific file under ~/.sap_deployment_automation.