### PR TITLE
Fix some issues in load_config_vars

### DIFF
--- a/deploy/scripts/deploy_utils.sh
+++ b/deploy/scripts/deploy_utils.sh
@@ -27,16 +27,23 @@ function save_config_vars() {
 }
 
 function load_config_vars() {
-    local var_file="${1}"
-    local var_name="${2}"
-    local var_value
+    local var_file="${1}" var_name var_value
 
-    for var_name; do
-        if [ -f "${var_file}" ]; then
-            var_value="$(grep -m1 "^${var_name}=" "${var_file}" | cut -d'=' -f2 | tr -d '"')"
-        fi
+    shift # shift params 1 place to remove var_file value from front of list
 
-        [[ -z "${var_value}" ]] && continue #switch to compound command `[[` instead of `[`
+    # We don't assign values to variables if they aren't found in the var_file
+    # so there is nothing to do if the specified var_file doesn't exist
+    if [[ ! -f "${var_file}" ]]; then
+        return
+    fi
+
+    for var_name; do # iterate over function params
+        # NOTE: Should we care if we fail to retrieve a value from the file?
+        var_value="$(grep -m1 "^${var_name}=" "${var_file}" | cut -d'=' -f2 | tr -d '"')"
+
+        # NOTE: this continue means we skip setting an empty value for a variable
+        # whose value is empty in the var_file...
+        [[ -z "${var_value}" ]] && continue # switch to compound command `[[` instead of `[`
 
         typeset -g "${var_name}" # declare the specified variable as global
 


### PR DESCRIPTION
In load_config_vars(), after saving the first argument as var_file, we
need to shift the parameters list by one to avoid trying to lookup the
var_file's path as a variable name in the var_file file.

Also since we don't want to set/update variable values if they are not
found in the var_file, just return immediately when var_file doesn't
exist, rather than repeatedly checking for it's existence, once per
specified variable.