### PR TITLE
root_dirname used before it is assigned

### DIFF
--- a/deploy/scripts/remove_region.sh
+++ b/deploy/scripts/remove_region.sh
@@ -155,8 +155,8 @@ if [ "${ext}" == json ]; then
     region=$(jq --raw-output .infrastructure.region "${deployer_parameter_file}")
 else
 
-    load_config_vars "${root_dirname}"/"${deployer_parameter_file}" "environment"
-    load_config_vars "${root_dirname}"/"${deployer_parameter_file}" "location"
+    load_config_vars "${deployer_parameter_file}" "environment"
+    load_config_vars "${deployer_parameter_file}" "location"
     region=$(echo ${location} | xargs)
 fi
 


### PR DESCRIPTION
Remove the unnecessary use of the root_dirname prefix on the deployer
parameter tfvars file path when checking for environment and location
values.