### PR TITLE
Confirm environment and region non-empty in set_secrets.sh

### DIFF
--- a/deploy/scripts/set_secrets.sh
+++ b/deploy/scripts/set_secrets.sh
@@ -110,6 +110,23 @@ while [ -z "${region}" ]; do
     read -r -p "Region name: " region
 done
 
+# NOTE: If we want to be more specific on the permitted number of
+# letters in the environment name, e.g. between 3 and 6 letters,
+# replate the '\+' in the next line with '\{3,6\}'.
+if [[ ! "${environment}" =~ ^[[:upper:]]\+$ ]]; then
+    echo "The 'environment' must be specified as an non-empty uppercase string!"
+    showhelp
+    exit 65	#/* data format error */
+fi
+
+# NOTE: If we have the list of possible regions in a file somewhere
+# we can validate it is one of the entries in that list.
+if [[ ! "${region}" =~ ^[[:lower:]]\+$ ]]; then
+    echo "The 'region' must be specified as an non-empty lower string!"
+    showhelp
+    exit 65	#/* data format error */
+fi
+
 automation_config_directory=~/.sap_deployment_automation
 environment_config_information="${automation_config_directory}"/"${environment}""${region}"
 
@@ -145,10 +162,8 @@ fi
 
 if [ ! -n "$client_secret" ]; then
     #do not output the secret to screen
-    stty -echo
-    read -ers -p "        -> Kindly provide SPN Password: " client_secret
+    read -rs -p "        -> Kindly provide SPN Password: " client_secret
     echo "********"
-    stty echo
 fi
 
 if [ -z "${tenant_id}" ]; then


### PR DESCRIPTION
In order to safely construct the path to the relevant config file
we need to ensure that the environment and region values that are
provider via CLI option, or via prompted user input, are non-empty
values that conform to the expected validation pattern.

Also when prompting for the user to enter a password field we don't
need to explicitly manage terminal echoing if we are specifying the
-s option to the read command since it will both handle disablement
of terminal echo correctly, and more importantly, will restore the
terminal echo mode if the user Ctrl-C's the script run.

Additionally the -e option enables readline processing which makes
no sense when enterring a password, as we don't necessarily want
or need readline editing features when entering a password value.