### PR TITLE
Enhance region and environment regexp checks

### DIFF
--- a/deploy/scripts/deploy_utils.sh
+++ b/deploy/scripts/deploy_utils.sh
@@ -363,6 +363,25 @@ function print_script_name_and_function() {
     echo -e "\t[$(basename "")]: $(basename "$0") $1"
 }
 
+#
+# Input validation routines
+#
+
+# An environment value must be a string that is at most 5 characters
+# long, made up of uppercase letters and numbers, and must start with
+# an uppercase letter.
+function valid_environment() {
+    [[ "${environment}" =~ ^[[:upper:]][[:upper:][:digit:]]{1,4}$ ]]
+}
+
+# A region name must be a valid Azure lowercase region name, made
+# up of lowercase latters optionally followed by numbers.
+# NOTE: If we have the list of possible regions in a file somewhere
+# we can validate it is one of the entries in that list.
+function valid_region_name() {
+    [[ "${region}" =~ ^[[:lower:]]+[[:digit:]]?$ ]]
+}
+
 #print the function name being executed
 #printf maybe instead of echo
 #printf "%s\n" "${FUNCNAME[@]}"

--- a/deploy/scripts/set_secrets.sh
+++ b/deploy/scripts/set_secrets.sh
@@ -110,19 +110,14 @@ while [ -z "${region}" ]; do
     read -r -p "Region name: " region
 done
 
-# NOTE: If we want to be more specific on the permitted number of
-# letters in the environment name, e.g. between 3 and 6 letters,
-# replate the '\+' in the next line with '\{3,6\}'.
-if [[ ! "${environment}" =~ ^[[:upper:]]\+$ ]]; then
-    echo "The 'environment' must be specified as an non-empty uppercase string!"
+if ! valid_environment "${environment}"; then
+    echo "The 'environment' must be at most 5 characters long, composed of uppercase letters and numbers!"
     showhelp
     exit 65	#/* data format error */
 fi
 
-# NOTE: If we have the list of possible regions in a file somewhere
-# we can validate it is one of the entries in that list.
-if [[ ! "${region}" =~ ^[[:lower:]]\+$ ]]; then
-    echo "The 'region' must be specified as an non-empty lower string!"
+if ! valid_region_name "${region}"; then
+    echo "The 'region' must be a non-empty string composed of lowercase letters followed by numbers!"
     showhelp
     exit 65	#/* data format error */
 fi


### PR DESCRIPTION
Define valid_environment and valid_region_name helper functions in
deploy_utils.sh that can be used to validate that environment and 
region name strings conform to the expected formats.
 
As a starting point we are requiring the following:
    
  * environments are specified as a string of at most 5 characters,
    and at least 2 characters, starting with an uppercase letter,
    followed by one or more letters or numbers.
    
  * region names are specified as a string of lowercase letters
    optionally followed by numbers.
    
Update set_secrets.sh to leverage these new helper functions when
checking that provided environment and region values are specified
correctly.
