### PR TITLE
Report adding the subscription secret in set_secrets.sh

### DIFF
--- a/deploy/scripts/set_secrets.sh
+++ b/deploy/scripts/set_secrets.sh
@@ -221,6 +221,7 @@ if [ -n "${result}" ]; then
     az keyvault set-policy -n "${keyvault}" --secret-permissions get list recover restore set --upn "${upn}"
 fi
 
+echo -e "\t $cyan Setting secret ${secretname} in keyvault ${keyvault} $resetformatting \n"
 az keyvault secret set --name "${secretname}" --vault-name "${keyvault}" --value "${subscription}" >stdout.az 2>&1
 
 result=$(grep "ERROR: The user, group or application" stdout.az)


### PR DESCRIPTION
To avoid any misunderstandings, ensure that we report setting the
subscription id in the same way that we report the setting of the
SPN client id, secret and tenant id.