### PR TITLE
Need to cd to deployer dir before running install_deployer.sh

### DIFF
--- a/deploy/scripts/prepare_region.sh
+++ b/deploy/scripts/prepare_region.sh
@@ -367,6 +367,8 @@ if [ 0 == $step ]; then
     
     allParams=$(printf " -p %s %s" "${deployer_file_parametername}" "${approveparam}")
     
+    cd "${deployer_dirname}" || exit
+    
     "${DEPLOYMENT_REPO_PATH}"/deploy/scripts/install_deployer.sh $allParams
     if (($? > 0)); then
         exit $?
@@ -386,8 +388,6 @@ if [ 0 == $step ]; then
     if [ ! -z "$tenant_id" ]; then
         save_config_var "tenant_id" "${deployer_config_information}"
     fi
-    
-    cd "${deployer_dirname}" || exit
     
     if [ $force == 1 ]; then
         rm -Rf .terraform terraform.tfstate*


### PR DESCRIPTION
The running of the install_deployer.sh was moved to earlier in the
prepare_region.sh script but the cd into the deployer dir was not
moved so install_deployer.sh failed because it couldn't find the
specified parameter in the current directory.