### PR TITLE
Patch hostname length

### DIFF
--- a/deploy/terraform/terraform-units/modules/sap_namegenerator/vm.tf
+++ b/deploy/terraform/terraform-units/modules/sap_namegenerator/vm.tf
@@ -54,11 +54,11 @@ locals {
   ]
 
   hana_computer_names = [for idx in range(var.db_server_count) :
-    format("%sd%s%02dl%d%s", lower(var.sap_sid), lower(var.db_sid), idx + var.resource_offset, 0, local.random_id_vm_verified)
+    format("%sd%s%02dl%d%s", lower(var.sap_sid), lower(var.db_sid), idx + var.resource_offset, 0, substr(local.random_id_vm_verified, 0, 2))
   ]
 
   hana_computer_names_ha = [for idx in range(var.db_server_count) :
-    format("%sd%s%02dl%d%s", lower(var.sap_sid), lower(var.db_sid), idx + var.resource_offset, 1, local.random_id_vm_verified)
+    format("%sd%s%02dl%d%s", lower(var.sap_sid), lower(var.db_sid), idx + var.resource_offset, 1, substr(local.random_id_vm_verified, 0, 2))
   ]
 
   hana_server_vm_names = [for idx in range(var.db_server_count) :

--- a/deploy/terraform/terraform-units/modules/sap_system/hdb_node/vm-hdb.tf
+++ b/deploy/terraform/terraform-units/modules/sap_system/hdb_node/vm-hdb.tf
@@ -197,6 +197,12 @@ resource "azurerm_linux_virtual_machine" "vm_dbnode" {
   license_type = length(var.license_type) > 0 ? var.license_type : null
 
   tags = local.tags
+  lifecycle  {
+    ignore_changes = [
+        // Ignore changes to computername
+        computer_name
+    ]
+  }
 }
 
 # Creates managed data disk


### PR DESCRIPTION
## Problem
Currently HANA database hostname is 14 characters in length. While the automation does not cater to the scenario of running a dbload from the database VM, a manual run could be initiated from the database VM that can cause the dbload to fail.

## Solution
Reduce the length of the randomized results to 2 chars. This is the simplest route to take as the other parts that make up the VM name do not change.

## Tests
pull the new code and deploy a new system.

## Notes
